### PR TITLE
 exec refactor

### DIFF
--- a/src/nifty.py
+++ b/src/nifty.py
@@ -774,8 +774,12 @@ def _exec(command, print_to_screen = False, outfnm = None, logfnm = None, stdin 
     persist = Continue execution even if the command gives a nonzero return code.
     """
     cmd_options={'shell':(type(command) is str), 'stdout':PIPE,'stdin':None, 'stderr':PIPE}
-    if logfnm: cmd_options['stdout'] = open(logfnm,'a+')
-    elif outfnm: cmd_options['stdout'] = open(outfnm,'w+')
+    if logfnm:
+        cmd_options['stdout'] = open(logfnm,'a+')
+        offset = os.path.getsize(logfnm)
+    elif outfnm:
+        cmd_options['stdout'] = open(outfnm,'w+')
+        offset = 0
     if stdin: cmd_options['stdin'] = PIPE
 
     if print_command:
@@ -809,7 +813,7 @@ def _exec(command, print_to_screen = False, outfnm = None, logfnm = None, stdin 
         p = subprocess.Popen(command, **cmd_options)
         Output, Error = p.communicate(stdin)
         if type(cmd_options['stdout']) is file:
-            cmd_options['stdout'].seek(0)
+            cmd_options['stdout'].seek(offset)
             Output = cmd_options['stdout'].read()
 
     # if logfnm != None or outfnm != None:


### PR DESCRIPTION
1) Eliminated some unnecessary loops
2) Switched file open from 'a'/'w' to 'a+'/'w+' (update modes) to avoid having to reopen it for reading
3) fixed bug in print_command routine due to buffering by 'print' where the command run was not written to the output file until after the command was run.
4) when appending to file, _exec would still read entire contents of file and return that as process output. This could include previous output in addition to output for the most recently run process. Not sure if this is what was intended? Added offset in file operation so that only output for the most recently run process (and the most recent append operation) is returned
