### PR TITLE
Avoid installing networkx v2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ def buildKeywordDictionary(args):
     setupKeywords["ext_modules"]       = [CMBAR, DCD, PERMUTE, CONTACT]
     setupKeywords["platforms"]         = ["Linux"]
     setupKeywords["description"]       = "Automated force field optimization."
-    setupKeywords["install_requires"]  = ['networkx>=1.9', 'decorator>=3.4.0']
+    setupKeywords["install_requires"]  = ['networkx>=1.9,<2.0', 'decorator>=3.4.0']
     setupKeywords["long_description"]  = """
 
     ForceBalance (https://simtk.org/home/forcebalance) is a library


### PR DESCRIPTION
Networkx v2 has recently been published, and as a result, the fresh installations of ForceBalance attempt to grab the latest version of networkx which leads to this error:

```
G.nodes[n][name] = values
TypeError: unhashable type: 'dict'
```