### PR TITLE
More intuitive error message when lxml module is missing

### DIFF
--- a/src/forcefield.py
+++ b/src/forcefield.py
@@ -110,7 +110,8 @@ from forcebalance.nifty import *
 from copy import deepcopy
 try:
     from lxml import etree
-except: pass
+except:
+    print("Failed to import lxml module, needed by OpenMM engine")
 import traceback
 import itertools
 from collections import OrderedDict, defaultdict

--- a/src/forcefield.py
+++ b/src/forcefield.py
@@ -108,15 +108,16 @@ from forcebalance.finite_difference import in_fd
 from forcebalance.nifty import *
 # from string import count
 from copy import deepcopy
-try:
-    from lxml import etree
-except:
-    print("Failed to import lxml module, needed by OpenMM engine")
 import traceback
 import itertools
 from collections import OrderedDict, defaultdict
 from forcebalance.output import getLogger
 logger = getLogger(__name__)
+
+try:
+    from lxml import etree
+except:
+    logger.warning("Failed to import lxml module, needed by OpenMM engine")
 
 FF_Extensions = {"itp" : "gmx",
                  "top" : "gmx",
@@ -460,7 +461,11 @@ class FF(forcebalance.BaseClass):
         self.Readers[ffname] = Reader(ffname)
         if fftype == "openmm":
             ## Read in an XML force field file as an _ElementTree object
-            self.ffdata[ffname] = etree.parse(absff)
+            try:
+                self.ffdata[ffname] = etree.parse(absff)
+            except NameError:
+                logger.error("If etree not defined, please check if lxml module has been installed")
+                raise
             self.ffdata_isxml[ffname] = True
             # Process the file
             self.addff_xml(ffname)

--- a/src/liquid.py
+++ b/src/liquid.py
@@ -242,7 +242,7 @@ class Liquid(Target):
         # Don't read indicate.log when calling meta_indicate()
         self.read_indicate = False
         self.write_indicate = False
-        
+
     def prepare_temp_directory(self):
         """ Prepare the temporary directory by copying in important files. """
         abstempdir = os.path.join(self.root,self.tempdir)
@@ -314,7 +314,7 @@ class Liquid(Target):
                 raise RuntimeError
         # Check the reference data table for validity.
         default_denoms = defaultdict(int)
-        PhasePoints = None
+        PhasePoints = set()
         RefData_copy = copy.deepcopy(self.RefData)
         for head in self.RefData:
             if head not in known_vars+[i+"_wt" for i in known_vars]:
@@ -336,11 +336,12 @@ class Liquid(Target):
                     # If there is only one data point, then the denominator is just the single
                     # data point itself.
                     default_denoms[head+"_denom"] = np.sqrt(np.abs(dat[0]))
-            self.PhasePoints = list(self.RefData[head].keys())
+            PhasePoints |= set(self.RefData[head].keys())
             # This prints out all of the reference data.
             # printcool_dictionary(self.RefData[head],head)
         self.RefData = RefData_copy
         # Create labels for the directories.
+        self.PhasePoints = sorted(list(PhasePoints))
         self.Labels = ["%.2fK-%.1f%s" % i for i in self.PhasePoints]
         logger.debug("global_opts:\n%s\n" % str(global_opts))
         logger.debug("default_denoms:\n%s\n" % str(default_denoms))

--- a/src/molecule.py
+++ b/src/molecule.py
@@ -1089,7 +1089,7 @@ class Molecule(object):
                 # explicitly defined copy() methods.
                 New.Data[key] = []
                 for i in range(len(self.Data[key])):
-                    New.Data[key].append(self.Data[key][i].copy())
+                    New.Data[key].append(copy.copy(self.Data[key][i]))
             elif key in ['topology']:
                 # These are NetworkX graph objects or other variables with explicitly defined copy() methods.
                 New.Data[key] = self.Data[key].copy()


### PR DESCRIPTION
Original error "etree not defined" does not indicate the reason, that lxml module is not found. New warning and error messages added to suggest installing the lxml module to solve the problem.