### PR TITLE
Changes for networkx v2.2

### DIFF
--- a/src/amberio.py
+++ b/src/amberio.py
@@ -1276,7 +1276,9 @@ class AMBER(Engine):
                     G.add_edge(b[0], b[1])
                 for b in prmtop.getBondsWithH():
                     G.add_edge(b[0], b[1])
-                gs = list(nx.connected_component_subgraphs(G))
+                gs = [G.subgraph(c).copy() for c in nx.connected_components(G)]
+                # Deprecated in networkx 2.2
+                # gs = list(nx.connected_component_subgraphs(G))
                 self.AtomLists['MoleculeNumber'] = [None for i in range(na)]
                 for ig, g in enumerate(gs):
                     for i in g.nodes():

--- a/src/molecule.py
+++ b/src/molecule.py
@@ -2027,7 +2027,9 @@ class Molecule(object):
         # The Topology is simply the NetworkX graph object.
         self.topology = G
         # LPW: Molecule.molecules is a funny misnomer... it should be fragments or substructures or something
-        self.molecules = list(nx.connected_component_subgraphs(G))
+        self.molecules = [G.subgraph(c).copy() for c in nx.connected_components(G)]
+        # Deprecated in networkx 2.2
+        # self.molecules = list(nx.connected_component_subgraphs(G))
 
     def distance_matrix(self, pbc=True):
         ''' Obtain distance matrix between all pairs of atoms. '''

--- a/src/tinkerio.py
+++ b/src/tinkerio.py
@@ -540,7 +540,9 @@ class TINKER(Engine):
         # Use networkx to figure out a list of molecule numbers.
         if len(list(G.nodes())) > 0:
             # The following code only works in TINKER 6.2
-            gs = list(nx.connected_component_subgraphs(G))
+            gs = [G.subgraph(c).copy() for c in nx.connected_components(G)]
+            # Deprecated in networkx 2.2
+            # gs = list(nx.connected_component_subgraphs(G))
             tmols = [gs[i] for i in np.argsort(np.array([min(list(g.nodes())) for g in gs]))]
             mnodes = [list(m.nodes()) for m in tmols]
             self.AtomLists['MoleculeNumber'] = [[i+1 in m for m in mnodes].index(1) for i in range(self.mol.na)]


### PR DESCRIPTION
NetworkX v2.2 is going to deprecate the `connected_component_subgraphs()` function for some reason, I just got the warning today. No idea why they're doing this, but I guess I should update things on this end.