### PR TITLE
Molecule builtins

### DIFF
--- a/src/molecule.py
+++ b/src/molecule.py
@@ -19,11 +19,12 @@ from numpy import sin, cos, arccos
 from pkg_resources import parse_version
 
 # For Python 3 compatibility
+from builtins import input
 try:
     from itertools import zip_longest as zip_longest
 except ImportError:
     from itertools import izip_longest as zip_longest
-
+    
 # ======================================================================#
 # |                                                                    |#
 # |              Chemical file format conversion module                |#


### PR DESCRIPTION
For some reason, the line `from builtins import input` was missing at the top, leading to errors when users were asked to enter strings in Python 2.7. This should fix the issue.