### PR TITLE
Mix xml txt

### DIFF
--- a/src/forcefield.py
+++ b/src/forcefield.py
@@ -1026,9 +1026,12 @@ class FF(forcebalance.BaseClass):
         for f in self.fnms:
             if self.Readers[f].pdict == "XML_Override":
                 for i, pName in enumerate(self.map):
-                    pfield = self.pfields[i]
-                    pid,fnm,ln,fld,mult,cmd = pfield
-                    if fnm == f:
+                    for p in self.pfields:
+                        if p[0] == pName:
+                            fnm = p[1]
+                            break
+                    ffnameScript = f.split('.')[0]+'Script.txt'
+                    if fnm == f or fnm == ffnameScript:
                         ttstr = '/'.join([pName.split('/')[0],pName.split('/')[1]])
                         if ttstr not in termtypelist:
                             termtypelist.append(ttstr)

--- a/src/forcefield.py
+++ b/src/forcefield.py
@@ -1276,7 +1276,6 @@ class FF(forcebalance.BaseClass):
                 for i in range(self.np):
                     qct = 0
                     qidx = []
-                    pfnm = self.pfields[i][1]
                     for imol, iatoms in self.patoms[i]:
                         for iatom in iatoms:
                             if imol == molname and iatom in molatoms:


### PR DESCRIPTION
The previous forcefield.py would crash if we mixed XML and text parameter files in a single optimization if both files contained free parameters. This PR fixes the issue.