### PR TITLE
Remove calls to np.matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ install:
     # Omnia packages
   - conda install -c omnia pymbar openmm
 
-    # Gromacs (from Bioconda)
+    # Gromacs
   - wget ftp://ftp.gromacs.org/pub/gromacs/gromacs-4.6.7.tar.gz
   - echo "Extracting Gromacs - log suppressed.."
   - tar xvzf gromacs-4.6.7.tar.gz &> untar.log
@@ -79,6 +79,7 @@ install:
   - cmake .. -DCMAKE_INSTALL_PREFIX=/home/travis/opt/gromacs/4.6.7 -DGMX_DOUBLE=ON -DGMX_GPU=OFF -DGMX_BUILD_OWN_FFTW=ON &> config.log
   - make -j 2 &> make.log
   - make install &> install.log
+  - tail -500 install.log
   - cd ..
   - mkdir build_s
   - cd build_s
@@ -87,8 +88,11 @@ install:
   - cmake .. -DCMAKE_INSTALL_PREFIX=/home/travis/opt/gromacs/4.6.7 -DGMX_DOUBLE=OFF -DGMX_GPU=OFF -DGMX_BUILD_OWN_FFTW=ON &> config.log
   - make -j 2 &> make.log
   - make install &> install.log
+  - tail -500 install.log
   - cd ../..
   - . /home/travis/opt/gromacs/4.6.7/bin/GMXRC.bash
+  - which mdrun
+  - which mdrun_d
   
     # Tinker binaries
   - wget https://dasher.wustl.edu/tinker/downloads/bin-linux64-8.2.1.tar.gz -O tinker.tar.gz
@@ -122,10 +126,11 @@ before_script:
   # - pip install -e .
 
 script:
+  - cd studies/001_water_tutorial
+  - tar xvjf targets.tar.bz2
+  - ForceBalance very_simple.in
+  - cd ..
   - python test
-  # - cd studies/001_water_tutorial
-  # - tar xvjf targets.tar.bz2
-  # - ForceBalance very_simple.in
   # - py.test -v --cov=eex/ --durations=5
 
 notifications:

--- a/src/abinitio.py
+++ b/src/abinitio.py
@@ -1051,9 +1051,9 @@ class AbInitio(Target):
         self.respterm = R
         X += R
         if AGrad:
-            G += flat(dqPdqM.T * col(dR))
+            G += flat(np.dot(dqPdqM.T, col(dR)))
             if AHess:
-                H += np.diag(flat(dqPdqM.T * col(ddR)))
+                H += np.diag(flat(np.dot(dqPdqM.T, col(ddR))))
 
         if not in_fd():
             self.esp_trm = X

--- a/src/abinitio.py
+++ b/src/abinitio.py
@@ -986,8 +986,8 @@ class AbInitio(Target):
             # for i in range(NP):
             #     print "Now working on parameter number", i
             #     dqPdqM.append(f12d3p(fdwrap(new_charges,mvals,i), h = self.h)[0])
-            # dqPdqM = mat(dqPdqM).T
-            dqPdqM = np.matrix([(f12d3p(fdwrap(new_charges,mvals,i), h = self.h, f0 = charge0)[0] if i in self.pgrad else np.zeros_like(charge0)) for i in range(NP)]).T
+            # dqPdqM = np.matrix(dqPdqM).T
+            dqPdqM = np.array([(f12d3p(fdwrap(new_charges,mvals,i), h = self.h, f0 = charge0)[0] if i in self.pgrad else np.zeros_like(charge0)) for i in range(NP)]).T
         xyzs = np.array(self.mol.xyzs)
         espqvals = np.array(self.espval)
         espxyz   = np.array(self.espxyz)
@@ -1007,23 +1007,23 @@ class AbInitio(Target):
         for i in range(self.ns):
             P   = self.boltz_wts[i]
             Z  += P
-            dVdqP   = np.matrix(self.invdists[i])
+            dVdqP   = np.array(self.invdists[i])
             espqval = espqvals[i]
-            espmval = dVdqP * col(new_charges(mvals))
+            espmval = np.dot(dVdqP, col(new_charges(mvals)))
             desp    = flat(espmval) - espqval
             X      += P * np.dot(desp, desp) / self.nesp
             Q      += P * np.dot(espqval, espqval) / self.nesp
             D      += P * (np.dot(espqval, espqval) / self.nesp - (np.sum(espqval) / self.nesp)**2)
             if AGrad:
-                dVdqM   = (dVdqP * dqPdqM).T
+                dVdqM   = np.dot(dVdqP, dqPdqM).T
                 for p, vsd in ddVdqPdVS.items():
-                    dVdqM[p,:] += flat(vsd[i] * col(new_charges(mvals)))
-                G      += flat(P * 2 * dVdqM * col(desp)) / self.nesp
+                    dVdqM[p,:] += flat(np.dot(vsd[i], col(new_charges(mvals))))
+                G      += flat(P * 2 * np.dot(dVdqM, col(desp))) / self.nesp
                 if AHess:
                     d2VdqM2 = np.zeros(dVdqM.shape)
                     for p, vsd in dddVdqPdVS2.items():
-                        d2VdqM2[p,:] += flat(vsd[i] * col(new_charges(mvals)))
-                    H      += np.array(P * 2 * (dVdqM * dVdqM.T + d2VdqM2 * col(desp))) / self.nesp
+                        d2VdqM2[p,:] += flat(np.dot(vsd[i], col(new_charges(mvals))))
+                    H      += np.array(P * 2 * (np.dot(dVdqM, dVdqM.T) + np.dot(d2VdqM2, col(desp)))) / self.nesp
         # Redundant but we keep it anyway
         D /= Z
         X /= Z

--- a/src/data/npt.py
+++ b/src/data/npt.py
@@ -489,7 +489,7 @@ def main():
     # Density
     #----
     # Build the first density derivative.
-    GRho = mBeta * (flat(np.mat(G) * col(Rhos)) / L - np.mean(Rhos) * np.mean(G, axis=1))
+    GRho = mBeta * (flat(np.dot(G, col(Rhos))) / L - np.mean(Rhos) * np.mean(G, axis=1))
     # Print out the density and its derivative.
     Sep = printcool("Density: % .4f +- % .4f kg/m^3\nAnalytic Derivative:" % (Rho_avg, Rho_err))
     FF.print_map(vals=GRho)
@@ -534,12 +534,12 @@ def main():
 
     # Build the first Hvap derivative.
     GHvap = np.mean(G,axis=1)
-    GHvap += mBeta * (flat(np.mat(G) * col(Energies)) / L - Ene_avg * np.mean(G, axis=1))
+    GHvap += mBeta * (flat(np.dot(G, col(Energies))) / L - Ene_avg * np.mean(G, axis=1))
     GHvap /= NMol
     GHvap -= np.mean(mG,axis=1)
-    GHvap -= mBeta * (flat(np.mat(mG) * col(mEnergies)) / L - mEne_avg * np.mean(mG, axis=1))
+    GHvap -= mBeta * (flat(np.dot(mG, col(mEnergies))) / L - mEne_avg * np.mean(mG, axis=1))
     GHvap *= -1
-    GHvap -= mBeta * (flat(np.mat(G) * col(pV)) / L - np.mean(pV) * np.mean(G, axis=1)) / NMol
+    GHvap -= mBeta * (flat(np.dot(G, col(pV))) / L - np.mean(pV) * np.mean(G, axis=1)) / NMol
 
     Sep = printcool("Enthalpy of Vaporization: % .4f +- %.4f kJ/mol\nAnalytic Derivative:" % (Hvap_avg, Hvap_err))
     FF.print_map(vals=GHvap)
@@ -547,9 +547,9 @@ def main():
     # Define some things to make the analytic derivatives easier.
     Gbar = np.mean(G,axis=1)
     def deprod(vec):
-        return flat(np.mat(G)*col(vec))/L
+        return flat(np.dot(G,col(vec)))/L
     def covde(vec):
-        return flat(np.mat(G)*col(vec))/L - Gbar*np.mean(vec)
+        return flat(np.dot(G,col(vec)))/L - Gbar*np.mean(vec)
     def avg(vec):
         return np.mean(vec)
 
@@ -681,9 +681,9 @@ def main():
     Dy = Dips[:,1]
     Dz = Dips[:,2]
     D2 = avg(Dx**2)+avg(Dy**2)+avg(Dz**2)-avg(Dx)**2-avg(Dy)**2-avg(Dz)**2
-    GD2  = 2*(flat(np.mat(GDx)*col(Dx))/L - avg(Dx)*(np.mean(GDx,axis=1))) - Beta*(covde(Dx**2) - 2*avg(Dx)*covde(Dx))
-    GD2 += 2*(flat(np.mat(GDy)*col(Dy))/L - avg(Dy)*(np.mean(GDy,axis=1))) - Beta*(covde(Dy**2) - 2*avg(Dy)*covde(Dy))
-    GD2 += 2*(flat(np.mat(GDz)*col(Dz))/L - avg(Dz)*(np.mean(GDz,axis=1))) - Beta*(covde(Dz**2) - 2*avg(Dz)*covde(Dz))
+    GD2  = 2*(flat(np.dot(GDx,col(Dx)))/L - avg(Dx)*(np.mean(GDx,axis=1))) - Beta*(covde(Dx**2) - 2*avg(Dx)*covde(Dx))
+    GD2 += 2*(flat(np.dot(GDy,col(Dy)))/L - avg(Dy)*(np.mean(GDy,axis=1))) - Beta*(covde(Dy**2) - 2*avg(Dy)*covde(Dy))
+    GD2 += 2*(flat(np.dot(GDz,col(Dz)))/L - avg(Dz)*(np.mean(GDz,axis=1))) - Beta*(covde(Dz**2) - 2*avg(Dz)*covde(Dz))
     GEps0 = prefactor*(GD2/avg(V) - mBeta*covde(V)*D2/avg(V)**2)/T
     Sep = printcool("Dielectric constant:           % .4e +- %.4e\nAnalytic Derivative:" % (Eps0, Eps0_err))
     FF.print_map(vals=GEps0)

--- a/src/data/npt_lipid.py
+++ b/src/data/npt_lipid.py
@@ -420,7 +420,7 @@ def main():
     # Density
     #----
     # Build the first density derivative.
-    GRho = mBeta * (flat(np.mat(G) * col(Rhos)) / L - np.mean(Rhos) * np.mean(G, axis=1))
+    GRho = mBeta * (flat(np.dot(G, col(Rhos))) / L - np.mean(Rhos) * np.mean(G, axis=1))
     # Print out the density and its derivative.
     Sep = printcool("Density: % .4f +- % .4f kg/m^3\nAnalytic Derivative:" % (Rho_avg, Rho_err))
     FF.print_map(vals=GRho)
@@ -457,9 +457,9 @@ def main():
     # Define some things to make the analytic derivatives easier.
     Gbar = np.mean(G,axis=1)
     def deprod(vec):
-        return flat(np.mat(G)*col(vec))/L
+        return flat(np.dot(G),col(vec))/L
     def covde(vec):
-        return flat(np.mat(G)*col(vec))/L - Gbar*np.mean(vec)
+        return flat(np.dot(G),col(vec))/L - Gbar*np.mean(vec)
     def avg(vec):
         return np.mean(vec)
 
@@ -592,9 +592,9 @@ def main():
     Dy = Dips[:,1]
     Dz = Dips[:,2]
     D2 = avg(Dx**2)+avg(Dy**2)+avg(Dz**2)-avg(Dx)**2-avg(Dy)**2-avg(Dz)**2
-    GD2  = 2*(flat(np.mat(GDx)*col(Dx))/L - avg(Dx)*(np.mean(GDx,axis=1))) - Beta*(covde(Dx**2) - 2*avg(Dx)*covde(Dx))
-    GD2 += 2*(flat(np.mat(GDy)*col(Dy))/L - avg(Dy)*(np.mean(GDy,axis=1))) - Beta*(covde(Dy**2) - 2*avg(Dy)*covde(Dy))
-    GD2 += 2*(flat(np.mat(GDz)*col(Dz))/L - avg(Dz)*(np.mean(GDz,axis=1))) - Beta*(covde(Dz**2) - 2*avg(Dz)*covde(Dz))
+    GD2  = 2*(flat(np.dot(GDx,col(Dx)))/L - avg(Dx)*(np.mean(GDx,axis=1))) - Beta*(covde(Dx**2) - 2*avg(Dx)*covde(Dx))
+    GD2 += 2*(flat(np.dot(GDy,col(Dy)))/L - avg(Dy)*(np.mean(GDy,axis=1))) - Beta*(covde(Dy**2) - 2*avg(Dy)*covde(Dy))
+    GD2 += 2*(flat(np.dot(GDz,col(Dz)))/L - avg(Dz)*(np.mean(GDz,axis=1))) - Beta*(covde(Dz**2) - 2*avg(Dz)*covde(Dz))
     GEps0 = prefactor*(GD2/avg(V) - mBeta*covde(V)*D2/avg(V)**2)/T
     Sep = printcool("Dielectric constant:           % .4e +- %.4e\nAnalytic Derivative:" % (Eps0, Eps0_err))
     FF.print_map(vals=GEps0)
@@ -611,7 +611,7 @@ def main():
     #----
     Al_avg, Al_err = mean_stderr(Als)
     # Build the first A_l derivative.
-    GAl = mBeta * (flat(np.mat(G) * col(Als)) / L - np.mean(Als) * np.mean(G, axis=1))
+    GAl = mBeta * (flat(np.dot(G, col(Als))) / L - np.mean(Als) * np.mean(G, axis=1))
     # Print out A_l and its derivative.
     Sep = printcool("Average Area per Lipid: % .4f +- % .4f nm^2\nAnalytic Derivative:" % (Al_avg, Al_err))
     FF.print_map(vals=GAl)
@@ -674,7 +674,9 @@ def main():
     #----
     Scd_avg, Scd_e = mean_stderr(Scds)
     Scd_err = flat(Scd_e)
-    GScd = mBeta * (((np.mat(G) * Scds) / L) - (np.mat(np.average(G, axis = 1)).T * np.average(Scds, axis = 0)))
+    # In case I did the conversion incorrectly, this is the code that was here previously:
+    # GScd = mBeta * (((np.mat(G) * Scds) / L) - (np.mat(np.average(G, axis = 1)).T * np.average(Scds, axis = 0)))
+    GScd = mBeta * (((np.dot(G, Scds)) / L) - np.dot(np.average(G, axis = 1).T, np.average(Scds, axis = 0)))
     # Print out S_cd and its derivative.
     scd_avgerr = ' '.join('%.4f +- %.4f \n' % F for F in zip(Scd_avg, Scd_err))
     Sep = printcool("Deuterium order parameter: %s \nAnalytic Derivative:" % scd_avgerr)

--- a/src/data/npt_lipid.py
+++ b/src/data/npt_lipid.py
@@ -343,7 +343,7 @@ def main():
                                     ("temperature", "%s %s" % (temperature, temperature)), ("pressure", "%s %s" % (pressure, pressure)),
                                     ("nequil", lipid_nequil), ("minimize", minimize),
                                     ("nsave", int(1000 * lipid_intvl / lipid_timestep)),
-                                    ("verbose", True), ('save_traj', TgtOptions['save_traj']), 
+                                    ("verbose", False), ('save_traj', TgtOptions['save_traj']), 
                                     ("threads", threads), ("anisotropic", anisotropic), 
                                     ("mts", mts), ("faststep", faststep), ("bilayer", True)])
 
@@ -457,9 +457,9 @@ def main():
     # Define some things to make the analytic derivatives easier.
     Gbar = np.mean(G,axis=1)
     def deprod(vec):
-        return flat(np.dot(G),col(vec))/L
+        return flat(np.dot(G,col(vec)))/L
     def covde(vec):
-        return flat(np.dot(G),col(vec))/L - Gbar*np.mean(vec)
+        return flat(np.dot(G,col(vec)))/L - Gbar*np.mean(vec)
     def avg(vec):
         return np.mean(vec)
 
@@ -676,7 +676,7 @@ def main():
     Scd_err = flat(Scd_e)
     # In case I did the conversion incorrectly, this is the code that was here previously:
     # GScd = mBeta * (((np.mat(G) * Scds) / L) - (np.mat(np.average(G, axis = 1)).T * np.average(Scds, axis = 0)))
-    GScd = mBeta * (((np.dot(G, Scds)) / L) - np.dot(np.average(G, axis = 1).T, np.average(Scds, axis = 0)))
+    GScd = mBeta * (((np.dot(G, Scds)) / L) - np.dot(col(np.average(G, axis = 1)), row(np.average(Scds, axis = 0))))
     # Print out S_cd and its derivative.
     scd_avgerr = ' '.join('%.4f +- %.4f \n' % F for F in zip(Scd_avg, Scd_err))
     Sep = printcool("Deuterium order parameter: %s \nAnalytic Derivative:" % scd_avgerr)

--- a/src/forcefield.py
+++ b/src/forcefield.py
@@ -972,7 +972,7 @@ class FF(forcebalance.BaseClass):
                 logger.error('What the hell did you do?\n')
                 raise RuntimeError
         else:
-            pvals = flat(np.matrix(self.tmI)*col(mvals)) + self.pvals0
+            pvals = flat(np.dot(self.tmI,col(mvals))) + self.pvals0
         concern= ['polarizability','epsilon','VDWT']
         # Guard against certain types of parameters changing sign.
 
@@ -1002,7 +1002,7 @@ class FF(forcebalance.BaseClass):
         if self.logarithmic_map:
             logger.error('create_mvals has not been implemented for logarithmic_map\n')
             raise RuntimeError
-        mvals = flat(invert_svd(self.tmI) * col(pvals - self.pvals0))
+        mvals = flat(np.dot(invert_svd(self.tmI), col(pvals-self.pvals0)))
 
         return mvals
 
@@ -1362,7 +1362,7 @@ class FF(forcebalance.BaseClass):
         # There is a bad bug here .. this matrix multiplication operation doesn't work!!
         # I will proceed using loops. This is unsettling.
         # Input matrices are qmat2 and self.rs (diagonal)
-        transmat = np.matrix(qmat2) * np.matrix(np.diag(self.rs))
+        transmat = np.dot(qmat2, np.diag(self.rs))
         transmat1 = np.zeros((self.np, self.np))
         for i in range(self.np):
             for k in range(self.np):

--- a/src/hydration.py
+++ b/src/hydration.py
@@ -348,7 +348,7 @@ class Hydration(Target):
                     if AGrad: 
                         dEg = results['Potential_Derivatives']
                         dEaq = results['Potential_Derivatives'] + results['Hydration_Derivatives']
-                        data[p]['dHyd'] = (flat(np.matrix(dEaq)*col(expmbH)/L)-np.mean(dEg,axis=1)*np.mean(expmbH)) / np.mean(expmbH)
+                        data[p]['dHyd'] = (flat(np.dot(dEaq,col(expmbH))/L)-np.mean(dEg,axis=1)*np.mean(expmbH)) / np.mean(expmbH)
                 elif p == "liq":
                     Eg = results['Potentials'] - results['Hydration']
                     Eaq = results['Potentials']
@@ -361,7 +361,7 @@ class Hydration(Target):
                     if AGrad: 
                         dEg = results['Potential_Derivatives'] - results['Hydration_Derivatives']
                         dEaq = results['Potential_Derivatives']
-                        data[p]['dHyd'] = -(flat(np.matrix(dEg)*col(exppbH)/L)-np.mean(dEaq,axis=1)*np.mean(exppbH)) / np.mean(exppbH)
+                        data[p]['dHyd'] = -(flat(np.dot(dEg, col(exppbH))/L)-np.mean(dEaq,axis=1)*np.mean(exppbH)) / np.mean(exppbH)
                 os.chdir('..')
             # Calculate the hydration free energy using gas phase, liquid phase or the average of both.
             # Note that the molecular dynamics methods return energies in kJ/mol.
@@ -408,7 +408,7 @@ class Hydration(Target):
                     dE = results['Potential_Derivatives']
                     dH = results['Hydration_Derivatives']
                     # Calculate the parametric derivative of the average hydration energy.
-                    data[p]['dHyd'] = np.mean(dH,axis=1)-beta*(flat(np.matrix(dE)*col(H)/len(H))-np.mean(dE,axis=1)*np.mean(H))
+                    data[p]['dHyd'] = np.mean(dH,axis=1)-beta*(flat(np.dot(dE, col(H))/len(H))-np.mean(dE,axis=1)*np.mean(H))
                 os.chdir('..')
             # Calculate the hydration free energy as the average of liquid and gas hydration energies.
             # Note that the molecular dynamics methods return energies in kJ/mol.

--- a/src/legacy/abinitio.py
+++ b/src/legacy/abinitio.py
@@ -1197,7 +1197,7 @@ class AbInitio(Target):
             # for i in range(NP):
             #     print "Now working on parameter number", i
             #     dqPdqM.append(f12d3p(fdwrap(new_charges,mvals,i), h = self.h)[0])
-            # dqPdqM = mat(dqPdqM).T
+            # dqPdqM = np.matrix(dqPdqM).T
             dqPdqM = np.matrix([(f12d3p(fdwrap(new_charges,mvals,i), h = self.h, f0 = charge0)[0] if i in self.pgrad else np.zeros_like(charge0)) for i in range(NP)]).T
         xyzs = np.array(self.mol.xyzs)
         espqvals = np.array(self.espval)

--- a/src/lipid.py
+++ b/src/lipid.py
@@ -704,7 +704,7 @@ class Lipid(Target):
             # The weights that we want are the last ones.
             W = flat(W2[:,i])
             C = weight_info(W, PT, np.ones(len(Points), dtype=int)*Shots, verbose=mbar_verbose)
-            Gbar = flat(np.mat(G)*col(W))
+            Gbar = flat(np.dot(G,col(W)))
             mBeta = -1/kb/T
             Beta  = 1/kb/T
             kT    = kb*T
@@ -712,12 +712,12 @@ class Lipid(Target):
             def avg(vec):
                 return np.dot(W,vec)
             def covde(vec):
-                return flat(np.mat(G)*col(W*vec)) - avg(vec)*Gbar
+                return flat(np.dot(G,col(W*vec))) - avg(vec)*Gbar
             def deprod(vec):
-                return flat(np.mat(G)*col(W*vec))
+                return flat(np.dot(G,col(W*vec)))
             ## Density.
             Rho_calc[PT]   = np.dot(W,R)
-            Rho_grad[PT]   = mBeta*(flat(np.mat(G)*col(W*R)) - np.dot(W,R)*Gbar)
+            Rho_grad[PT]   = mBeta*(flat(np.dot(G,col(W*R))) - np.dot(W,R)*Gbar)
             ## Ignore enthalpy.
             ## Thermal expansion coefficient.
             Alpha_calc[PT] = 1e4 * (avg(H*V)-avg(H)*avg(V))/avg(V)/(kT*T)
@@ -749,13 +749,13 @@ class Lipid(Target):
             prefactor = 30.348705333964077
             D2 = avg(Dx**2)+avg(Dy**2)+avg(Dz**2)-avg(Dx)**2-avg(Dy)**2-avg(Dz)**2
             Eps0_calc[PT] = 1.0 + prefactor*(D2/avg(V))/T
-            GD2  = 2*(flat(np.mat(GDx)*col(W*Dx)) - avg(Dx)*flat(np.mat(GDx)*col(W))) - Beta*(covde(Dx**2) - 2*avg(Dx)*covde(Dx))
-            GD2 += 2*(flat(np.mat(GDy)*col(W*Dy)) - avg(Dy)*flat(np.mat(GDy)*col(W))) - Beta*(covde(Dy**2) - 2*avg(Dy)*covde(Dy))
-            GD2 += 2*(flat(np.mat(GDz)*col(W*Dz)) - avg(Dz)*flat(np.mat(GDz)*col(W))) - Beta*(covde(Dz**2) - 2*avg(Dz)*covde(Dz))
+            GD2  = 2*(flat(np.dot(GDx,col(W*Dx))) - avg(Dx)*flat(np.dot(GDx,col(W)))) - Beta*(covde(Dx**2) - 2*avg(Dx)*covde(Dx))
+            GD2 += 2*(flat(np.dot(GDy,col(W*Dy))) - avg(Dy)*flat(np.dot(GDy,col(W)))) - Beta*(covde(Dy**2) - 2*avg(Dy)*covde(Dy))
+            GD2 += 2*(flat(np.dot(GDz,col(W*Dz))) - avg(Dz)*flat(np.dot(GDz,col(W)))) - Beta*(covde(Dz**2) - 2*avg(Dz)*covde(Dz))
             Eps0_grad[PT] = prefactor*(GD2/avg(V) - mBeta*covde(V)*D2/avg(V)**2)/T
             ## Average area per lipid
             Al_calc[PT]   = np.dot(W,A)
-            Al_grad[PT]   = mBeta*(flat(np.mat(G)*col(W*A)) - np.dot(W,A)*Gbar)
+            Al_grad[PT]   = mBeta*(flat(np.dot(G,col(W*A))) - np.dot(W,A)*Gbar)
             ## Bilayer Isothermal compressibility.
             A_m2 = A * 1e-18
             kbT = 1.3806488e-23 * T
@@ -769,7 +769,9 @@ class Lipid(Target):
             LKappa_grad[PT] = (1e3 * 2 * kbT / 128) * (GLKappa1 - GLKappa2)
             ## Deuterium order parameter
             Scd_calc[PT]   = np.dot(W,S)
-            Scd_grad[PT]   = mBeta * (flat(np.average(np.mat(G) * (S * W[:, np.newaxis]), axis = 1)) - np.average(np.average(S * W[:, np.newaxis], axis = 0), axis = 0) * Gbar) 
+            # LPW: In case I did not do the conversion correctly, the line of code previously here was:
+            # Scd_grad[PT]   = mBeta * (flat(np.average(np.mat(G) * (S * W[:, np.newaxis]), axis = 1)) - np.average(np.average(S * W[:, np.newaxis], axis = 0), axis = 0) * Gbar) 
+            Scd_grad[PT]   = mBeta * (flat(np.average(np.dot(G, (S * W[:, np.newaxis]), axis = 1))) - np.average(np.average(S * W[:, np.newaxis], axis = 0), axis = 0) * Gbar) 
             ## Estimation of errors.
             Rho_std[PT]    = np.sqrt(sum(C**2 * np.array(Rho_errs)**2))
             Alpha_std[PT]   = np.sqrt(sum(C**2 * np.array(Alpha_errs)**2)) * 1e4
@@ -777,7 +779,9 @@ class Lipid(Target):
             Cp_std[PT]   = np.sqrt(sum(C**2 * np.array(Cp_errs)**2))
             Eps0_std[PT]   = np.sqrt(sum(C**2 * np.array(Eps0_errs)**2))
             Al_std[PT]    = np.sqrt(sum(C**2 * np.array(Al_errs)**2))
-            Scd_std[PT]    = np.sqrt(sum(np.mat(C**2) * np.array(Scd_errs)**2))
+            # LPW: In case I did not do the conversion correctly, the line of code previously here was:
+            # Scd_std[PT]    = np.sqrt(sum(np.mat(C**2) * np.array(Scd_errs)**2))
+            Scd_std[PT]    = np.sqrt(sum(np.dot(C**2, np.array(Scd_errs)**2)))
             LKappa_std[PT]   = np.sqrt(sum(C**2 * np.array(LKappa_errs)**2)) * 1e6
 
         # Get contributions to the objective function

--- a/src/lipid.py
+++ b/src/lipid.py
@@ -771,7 +771,7 @@ class Lipid(Target):
             Scd_calc[PT]   = np.dot(W,S)
             # LPW: In case I did not do the conversion correctly, the line of code previously here was:
             # Scd_grad[PT]   = mBeta * (flat(np.average(np.mat(G) * (S * W[:, np.newaxis]), axis = 1)) - np.average(np.average(S * W[:, np.newaxis], axis = 0), axis = 0) * Gbar) 
-            Scd_grad[PT]   = mBeta * (flat(np.average(np.dot(G, (S * W[:, np.newaxis]), axis = 1))) - np.average(np.average(S * W[:, np.newaxis], axis = 0), axis = 0) * Gbar) 
+            Scd_grad[PT]   = mBeta * (flat(np.average(np.dot(G, (S * W[:, np.newaxis])), axis = 1)) - np.average(np.average(S * W[:, np.newaxis], axis = 0), axis = 0) * Gbar) 
             ## Estimation of errors.
             Rho_std[PT]    = np.sqrt(sum(C**2 * np.array(Rho_errs)**2))
             Alpha_std[PT]   = np.sqrt(sum(C**2 * np.array(Alpha_errs)**2)) * 1e4
@@ -781,7 +781,7 @@ class Lipid(Target):
             Al_std[PT]    = np.sqrt(sum(C**2 * np.array(Al_errs)**2))
             # LPW: In case I did not do the conversion correctly, the line of code previously here was:
             # Scd_std[PT]    = np.sqrt(sum(np.mat(C**2) * np.array(Scd_errs)**2))
-            Scd_std[PT]    = np.sqrt(sum(np.dot(C**2, np.array(Scd_errs)**2)))
+            Scd_std[PT]    = np.sqrt(sum(np.dot(row(C**2), np.array(Scd_errs)**2)))
             LKappa_std[PT]   = np.sqrt(sum(C**2 * np.array(LKappa_errs)**2)) * 1e6
 
         # Get contributions to the objective function

--- a/src/liquid.py
+++ b/src/liquid.py
@@ -975,7 +975,7 @@ class Liquid(Target):
                 mGbar = flat(np.dot(mG, col(mW)))
                 Hvap_calc[PT]  = np.dot(mW,mE) - np.dot(W,E)/NMol + kb*T - np.dot(W, PV)/NMol
                 Hvap_grad[PT]  = mGbar + mBeta*(flat(np.dot(mG,col(mW*mE))) - np.dot(mW,mE)*mGbar)
-                Hvap_grad[PT] -= (Gbar + mBeta*(flat(np.dot(G),col(W*E))) - np.dot(W,E)*Gbar)) / NMol
+                Hvap_grad[PT] -= (Gbar + mBeta*(flat(np.dot(G,col(W*E))) - np.dot(W,E)*Gbar)) / NMol
                 Hvap_grad[PT] -= (mBeta*(flat(np.dot(G,col(W*PV))) - np.dot(W,PV)*Gbar)) / NMol
                 if self.do_self_pol:
                     Hvap_calc[PT] -= EPol

--- a/src/liquid.py
+++ b/src/liquid.py
@@ -954,7 +954,7 @@ class Liquid(Target):
             # The weights that we want are the last ones.
             W = flat(W2[:,i])
             C = weight_info(W, PT, np.ones(len(Points), dtype=int)*Shots, verbose=mbar_verbose)
-            Gbar = flat(np.matrix(G)*col(W))
+            Gbar = flat(np.dot(G, col(W)))
             mBeta = -1/kb/T
             Beta  = 1/kb/T
             kT    = kb*T
@@ -962,21 +962,21 @@ class Liquid(Target):
             def avg(vec):
                 return np.dot(W,vec)
             def covde(vec):
-                return flat(np.matrix(G)*col(W*vec)) - avg(vec)*Gbar
+                return flat(np.dot(G, col(W*vec))) - avg(vec)*Gbar
             def deprod(vec):
-                return flat(np.matrix(G)*col(W*vec))
+                return flat(np.dot(G, col(W*vec)))
             ## Density.
             Rho_calc[PT]   = np.dot(W,R)
-            Rho_grad[PT]   = mBeta*(flat(np.matrix(G)*col(W*R)) - np.dot(W,R)*Gbar)
+            Rho_grad[PT]   = mBeta*(flat(np.dot(G, col(W*R))) - np.dot(W,R)*Gbar)
             ## Enthalpy of vaporization.
             if PT in mPoints:
                 ii = mPoints.index(PT)
                 mW = flat(mW2[:,ii])
-                mGbar = flat(np.matrix(mG)*col(mW))
+                mGbar = flat(np.dot(mG, col(mW)))
                 Hvap_calc[PT]  = np.dot(mW,mE) - np.dot(W,E)/NMol + kb*T - np.dot(W, PV)/NMol
-                Hvap_grad[PT]  = mGbar + mBeta*(flat(np.matrix(mG)*col(mW*mE)) - np.dot(mW,mE)*mGbar)
-                Hvap_grad[PT] -= (Gbar + mBeta*(flat(np.matrix(G)*col(W*E)) - np.dot(W,E)*Gbar)) / NMol
-                Hvap_grad[PT] -= (mBeta*(flat(np.matrix(G)*col(W*PV)) - np.dot(W,PV)*Gbar)) / NMol
+                Hvap_grad[PT]  = mGbar + mBeta*(flat(np.dot(mG,col(mW*mE))) - np.dot(mW,mE)*mGbar)
+                Hvap_grad[PT] -= (Gbar + mBeta*(flat(np.dot(G),col(W*E))) - np.dot(W,E)*Gbar)) / NMol
+                Hvap_grad[PT] -= (mBeta*(flat(np.dot(G,col(W*PV))) - np.dot(W,PV)*Gbar)) / NMol
                 if self.do_self_pol:
                     Hvap_calc[PT] -= EPol
                     Hvap_grad[PT] -= GEPol
@@ -1031,9 +1031,9 @@ class Liquid(Target):
             prefactor = 30.348705333964077
             D2 = avg(Dx**2)+avg(Dy**2)+avg(Dz**2)-avg(Dx)**2-avg(Dy)**2-avg(Dz)**2
             Eps0_calc[PT] = 1.0 + prefactor*(D2/avg(V))/T
-            GD2  = 2*(flat(np.matrix(GDx)*col(W*Dx)) - avg(Dx)*flat(np.matrix(GDx)*col(W))) - Beta*(covde(Dx**2) - 2*avg(Dx)*covde(Dx))
-            GD2 += 2*(flat(np.matrix(GDy)*col(W*Dy)) - avg(Dy)*flat(np.matrix(GDy)*col(W))) - Beta*(covde(Dy**2) - 2*avg(Dy)*covde(Dy))
-            GD2 += 2*(flat(np.matrix(GDz)*col(W*Dz)) - avg(Dz)*flat(np.matrix(GDz)*col(W))) - Beta*(covde(Dz**2) - 2*avg(Dz)*covde(Dz))
+            GD2  = 2*(flat(np.dot(GDx,col(W*Dx))) - avg(Dx)*flat(np.dot(GDx,col(W)))) - Beta*(covde(Dx**2) - 2*avg(Dx)*covde(Dx))
+            GD2 += 2*(flat(np.dot(GDy,col(W*Dy))) - avg(Dy)*flat(np.dot(GDy,col(W)))) - Beta*(covde(Dy**2) - 2*avg(Dy)*covde(Dy))
+            GD2 += 2*(flat(np.dot(GDz,col(W*Dz))) - avg(Dz)*flat(np.dot(GDz,col(W)))) - Beta*(covde(Dz**2) - 2*avg(Dz)*covde(Dz))
             Eps0_grad[PT] = prefactor*(GD2/avg(V) - mBeta*covde(V)*D2/avg(V)**2)/T
             ## Surface Tension (Already computed in nvt.py)
             if PT in stResults:

--- a/src/molecule.py
+++ b/src/molecule.py
@@ -352,12 +352,12 @@ def CubicLattice(a):
     bet  = beta*np.pi/180
     gamm = gamma*np.pi/180
     v = np.sqrt(1 - cos(alph)**2 - cos(bet)**2 - cos(gamm)**2 + 2*cos(alph)*cos(bet)*cos(gamm))
-    Mat = np.matrix([[a, b*cos(gamm), c*cos(bet)],
-                  [0, b*sin(gamm), c*((cos(alph)-cos(bet)*cos(gamm))/sin(gamm))],
-                  [0, 0, c*v/sin(gamm)]])
-    L1 = Mat*np.matrix([[1],[0],[0]])
-    L2 = Mat*np.matrix([[0],[1],[0]])
-    L3 = Mat*np.matrix([[0],[0],[1]])
+    Mat = np.array([[a, b*cos(gamm), c*cos(bet)],
+                    [0, b*sin(gamm), c*((cos(alph)-cos(bet)*cos(gamm))/sin(gamm))],
+                    [0, 0, c*v/sin(gamm)]])
+    L1 = Mat.dot(np.array([[1],[0],[0]]))
+    L2 = Mat.dot(np.array([[0],[1],[0]]))
+    L3 = Mat.dot(np.array([[0],[0],[1]]))
     return Box(a,b,c,alpha,beta,gamma,np.array(L1).flatten(),np.array(L2).flatten(),np.array(L3).flatten(),v*a*b*c)
 
 def BuildLatticeFromLengthsAngles(a, b, c, alpha, beta, gamma):
@@ -366,12 +366,12 @@ def BuildLatticeFromLengthsAngles(a, b, c, alpha, beta, gamma):
     bet  = beta*np.pi/180
     gamm = gamma*np.pi/180
     v = np.sqrt(1 - cos(alph)**2 - cos(bet)**2 - cos(gamm)**2 + 2*cos(alph)*cos(bet)*cos(gamm))
-    Mat = np.matrix([[a, b*cos(gamm), c*cos(bet)],
-                  [0, b*sin(gamm), c*((cos(alph)-cos(bet)*cos(gamm))/sin(gamm))],
-                  [0, 0, c*v/sin(gamm)]])
-    L1 = Mat*np.matrix([[1],[0],[0]])
-    L2 = Mat*np.matrix([[0],[1],[0]])
-    L3 = Mat*np.matrix([[0],[0],[1]])
+    Mat = np.array([[a, b*cos(gamm), c*cos(bet)],
+                    [0, b*sin(gamm), c*((cos(alph)-cos(bet)*cos(gamm))/sin(gamm))],
+                    [0, 0, c*v/sin(gamm)]])
+    L1 = Mat.dot(np.array([[1],[0],[0]]))
+    L2 = Mat.dot(np.array([[0],[1],[0]]))
+    L3 = Mat.dot(np.array([[0],[0],[1]]))
     return Box(a,b,c,alpha,beta,gamma,np.array(L1).flatten(),np.array(L2).flatten(),np.array(L3).flatten(),v*a*b*c)
 
 def BuildLatticeFromVectors(v1, v2, v3):
@@ -386,12 +386,12 @@ def BuildLatticeFromVectors(v1, v2, v3):
     bet  = beta*np.pi/180
     gamm = gamma*np.pi/180
     v = np.sqrt(1 - cos(alph)**2 - cos(bet)**2 - cos(gamm)**2 + 2*cos(alph)*cos(bet)*cos(gamm))
-    Mat = np.matrix([[a, b*cos(gamm), c*cos(bet)],
-                  [0, b*sin(gamm), c*((cos(alph)-cos(bet)*cos(gamm))/sin(gamm))],
-                  [0, 0, c*v/sin(gamm)]])
-    L1 = Mat*np.matrix([[1],[0],[0]])
-    L2 = Mat*np.matrix([[0],[1],[0]])
-    L3 = Mat*np.matrix([[0],[0],[1]])
+    Mat = np.array([[a, b*cos(gamm), c*cos(bet)],
+                    [0, b*sin(gamm), c*((cos(alph)-cos(bet)*cos(gamm))/sin(gamm))],
+                    [0, 0, c*v/sin(gamm)]])
+    L1 = Mat.dot(np.array([[1],[0],[0]]))
+    L2 = Mat.dot(np.array([[0],[1],[0]]))
+    L3 = Mat.dot(np.array([[0],[0],[1]]))
     return Box(a,b,c,alpha,beta,gamma,np.array(L1).flatten(),np.array(L2).flatten(),np.array(L3).flatten(),v*a*b*c)
 
 #===========================#
@@ -612,26 +612,26 @@ def either(A, B, key):
 #===========================#
 def EulerMatrix(T1,T2,T3):
     """ Constructs an Euler matrix from three Euler angles. """
-    DMat = np.matrix(np.zeros((3,3)))
+    DMat = np.zeros((3,3))
     DMat[0,0] = np.cos(T1)
     DMat[0,1] = np.sin(T1)
     DMat[1,0] = -np.sin(T1)
     DMat[1,1] = np.cos(T1)
     DMat[2,2] = 1
-    CMat = np.matrix(np.zeros((3,3)))
+    CMat = np.zeros((3,3))
     CMat[0,0] = 1
     CMat[1,1] = np.cos(T2)
     CMat[1,2] = np.sin(T2)
     CMat[2,1] = -np.sin(T2)
     CMat[2,2] = np.cos(T2)
-    BMat = np.matrix(np.zeros((3,3)))
+    BMat = np.zeros((3,3))
     BMat[0,0] = np.cos(T3)
     BMat[0,1] = np.sin(T3)
     BMat[1,0] = -np.sin(T3)
     BMat[1,1] = np.cos(T3)
     BMat[2,2] = 1
-    EMat = BMat*CMat*DMat
-    return np.matrix(EMat)
+    EMat = m_dot(BMat, CMat, DMat)
+    return EMat
 
 def ComputeOverlap(theta,elem,xyz1,xyz2):
     """
@@ -639,7 +639,7 @@ def ComputeOverlap(theta,elem,xyz1,xyz2):
     fictitious density.  Good for fine-tuning alignment but gets stuck
     in local minima.
     """
-    xyz2R = np.array(EulerMatrix(theta[0],theta[1],theta[2])*np.matrix(xyz2.T)).T
+    xyz2R = np.dot(EulerMatrix(theta[0],theta[1],theta[2]), xyz2.T).T
     Obj = 0.0
     elem = np.array(elem)
     for i in set(elem):
@@ -658,7 +658,7 @@ def AlignToDensity(elem,xyz1,xyz2,binary=False):
     grid = np.pi*np.array(list(itertools.product([0,1],[0,1],[0,1])))
     ovlp = np.array([ComputeOverlap(e, elem, xyz1, xyz2) for e in grid]) # Mao
     t1 = grid[np.argmin(ovlp)]
-    xyz2R = np.array(EulerMatrix(t1[0],t1[1],t1[2])*np.matrix(xyz2.T)).T.copy()
+    xyz2R = np.dot(EulerMatrix(t1[0],t1[1],t1[2]), xyz2.T).T.copy()
     return xyz2R
 
 def AlignToMoments(elem,xyz1,xyz2=None):
@@ -681,7 +681,7 @@ def AlignToMoments(elem,xyz1,xyz2=None):
         if np.abs(determ + 1.0) > Thresh:
             print("in AlignToMoments, determinant is % .3f" % determ)
         BB[:,2] *= -1
-    xyzr = np.array(np.matrix(BB).T * np.matrix(xyz).T).T.copy()
+    xyzr = np.dot(BB.T, xyz.T).T.copy()
     if xyz2 is not None:
         xyzrr = AlignToDensity(elem,xyz1,xyzr,binary=True)
         return xyzrr
@@ -708,20 +708,17 @@ def get_rotate_translate(matrix1,matrix2):
 
     # Do the SVD in order to get rotation matrix
     v,s,wt = np.linalg.svd(covar)
-    v = np.matrix(v)
-    wt = np.matrix(wt)
 
     # Rotation matrix
     # Transposition of v,wt
-    wvt = wt.T*v.T
+    wvt = np.dot(wt.T, v.T)
 
     # Ensure a right-handed coordinate system
-    d = np.matrix(np.eye(3))
+    d = np.eye(3)
     if np.linalg.det(wvt) < 0:
         d[2,2] = -1.0
 
-    rot_matrix = np.array((wt.T*d*v.T).T)
-    # rot_matrix = np.transpose(np.dot(np.transpose(wt),np.transpose(v)))
+    rot_matrix = m_dot(wt.T,d,v.T).T
     trans_matrix = avg_pos2-np.dot(avg_pos1,rot_matrix)
     return trans_matrix, rot_matrix
 

--- a/src/molecule.py
+++ b/src/molecule.py
@@ -17,6 +17,7 @@ from warnings import warn
 
 import numpy as np
 from numpy import sin, cos, arccos
+from numpy.linalg import multi_dot
 from pkg_resources import parse_version
 
 # For Python 3 compatibility
@@ -630,7 +631,7 @@ def EulerMatrix(T1,T2,T3):
     BMat[1,0] = -np.sin(T3)
     BMat[1,1] = np.cos(T3)
     BMat[2,2] = 1
-    EMat = m_dot(BMat, CMat, DMat)
+    EMat = multi_dot([BMat, CMat, DMat])
     return EMat
 
 def ComputeOverlap(theta,elem,xyz1,xyz2):
@@ -718,7 +719,7 @@ def get_rotate_translate(matrix1,matrix2):
     if np.linalg.det(wvt) < 0:
         d[2,2] = -1.0
 
-    rot_matrix = m_dot(wt.T,d,v.T).T
+    rot_matrix = multi_dot([wt.T,d,v.T]).T
     trans_matrix = avg_pos2-np.dot(avg_pos1,rot_matrix)
     return trans_matrix, rot_matrix
 

--- a/src/nifty.py
+++ b/src/nifty.py
@@ -26,7 +26,7 @@ import sys
 from select import select
 
 import numpy as np
-import numpy.linalg.multi_dot as mdot
+from numpy.linalg import multi_dot
 
 # For Python 3 compatibility
 try:
@@ -552,7 +552,7 @@ def invert_svd(X,thresh=1e-12):
         else:
             si[i] = 0.0
     si     = np.diag(si)
-    Xt     = mdot([v, si, uh])
+    Xt     = multi_dot([v, si, uh])
     return Xt
 
 #==============================#
@@ -582,6 +582,8 @@ def get_least_squares(x, y, w = None, thresh=1e-12):
     """
     # X is a 'tall' matrix.
     X = np.array(x)
+    if len(X.shape) == 1:
+        X = X[:,np.newaxis]
     Y = col(y)
     n_x = X.shape[0]
     n_fit = X.shape[1]
@@ -600,10 +602,10 @@ def get_least_squares(x, y, w = None, thresh=1e-12):
     #     MPPI = np.linalg.inv(WH*X)
     # else:
     # This resembles the formula (X'WX)^-1 X' W^1/2
-    MPPI = np.linalg.pinv(WH*X)
-    Beta = mdot(MPPI, WH, Y)
-    Hat = mdot(WH, X, MPPI)
-    yfit = flat(mdot(Hat, Y))
+    MPPI = np.linalg.pinv(np.dot(WH, X))
+    Beta = multi_dot([MPPI, WH, Y])
+    Hat = multi_dot([WH, X, MPPI])
+    yfit = flat(np.dot(Hat, Y))
     # Return three things: the least-squares coefficients, the hat matrix (turns y into yfit), and yfit
     # We could get these all from MPPI, but I might get confused later on, so might as well do it here :P
     return np.array(Beta).flatten(), np.array(Hat), np.array(yfit).flatten(), np.array(MPPI)

--- a/src/optimizer.py
+++ b/src/optimizer.py
@@ -16,7 +16,7 @@ from builtins import object
 import os, pickle, re, sys
 # import cProfile
 import numpy as np
-from numpy.linalg import multi_dot as mdot
+from numpy.linalg import multi_dot
 from copy import deepcopy
 import forcebalance
 from forcebalance.parser import parse_inputs
@@ -585,8 +585,8 @@ class Optimizer(forcebalance.BaseClass):
                         Hnew = H_stor.copy()
                         Dx   = col(xk - xk_prev)
                         Dy   = col(G  - G_prev)
-                        Mat1 = (Dy*Dy.T)/(Dy.T*Dx)[0,0]
-                        Mat2 = ((Hnew*Dx)*(Hnew*Dx).T)/(Dx.T*Hnew*Dx)[0,0]
+                        Mat1 = (np.dot(Dy,Dy.T))/(np.dot(Dy.T,Dx))[0,0]
+                        Mat2 = (np.dot(np.dot(Hnew,Dx),np.dot(Hnew,Dx).T))/(multi_dot([Dx.T,Hnew,Dx]))[0,0]
                         Hnew += Mat1-Mat2
                         H = Hnew.copy()
                         data['H'] = H.copy()
@@ -806,7 +806,7 @@ class Optimizer(forcebalance.BaseClass):
             pmat2d(H,precision=5, loglevel=DEBUG)
             
             Hi = invert_svd(H)
-            dx = flat(-1 * Hi * col(G))
+            dx = flat(-1 * np.dot(Hi, col(G)))
             
             logger.debug(" dx:\n")
             pvec1d(dx,precision=5, loglevel=DEBUG)
@@ -825,10 +825,10 @@ class Optimizer(forcebalance.BaseClass):
                 logger.debug(" HT: (Scal = %.4f)\n" % (1+(L-1)**2))
                 pmat2d(HT,precision=5, loglevel=DEBUG)
                 Hi = invert_svd(HT)
-                dx = flat(-1 * Hi * col(G))
+                dx = flat(-1 * np.dot(Hi, col(G)))
                 logger.debug(" dx:\n")
                 pvec1d(dx,precision=5, loglevel=DEBUG)
-                sol = flat(0.5*mdot([row(dx), H, col(dx)]))[0] + np.dot(dx,G)
+                sol = flat(0.5*multi_dot([row(dx), H, col(dx)]))[0] + np.dot(dx,G)
                 for i in self.excision:    # Reinsert deleted coordinates - don't take a step in those directions
                     dx = np.insert(dx, i, 0)
                 return dx, sol

--- a/src/quantity.py
+++ b/src/quantity.py
@@ -190,7 +190,7 @@ class Quantity_Density(Quantity):
         # Average and error.
         Rho_avg, Rho_err = mean_stderr(Density)
         # Analytic first derivative.
-        Rho_grad = mBeta * (flat(np.mat(G) * col(Density)) / len(Density) \
+        Rho_grad = mBeta * (flat(np.dot(G, col(Density))) / len(Density) \
                             - np.mean(Density) * np.mean(G, axis=1))
             
         return Rho_avg, Rho_err, Rho_grad
@@ -289,13 +289,13 @@ class Quantity_H_vap(Quantity):
                            + (self.pressure**2) * (Vol_err**2)/(float(nmol)**2)/(pconv**2))
         # Analytic first derivative.
         Hvap_grad  = np.mean(Gm, axis=1)
-        Hvap_grad += mBeta * (flat(np.mat(Gm) * col(mEnergy)) / len(mEnergy) \
+        Hvap_grad += mBeta * (flat(np.dot(Gm, col(mEnergy))) / len(mEnergy) \
                                - np.mean(mEnergy) * np.mean(Gm, axis=1))
         Hvap_grad -= np.mean(G, axis=1)/nmol
-        Hvap_grad += Beta * (flat(np.mat(G) * col(Energy)) / len(Energy) \
+        Hvap_grad += Beta * (flat(np.dot(G, col(Energy))) / len(Energy) \
                                - np.mean(Energy) * np.mean(G, axis=1))/nmol
         Hvap_grad += (Beta*self.pressure/nmol/pconv) * \
-          (flat(np.mat(G) * col(Volume)) / len(Volume) \
+          (flat(np.dot(G, col(Volume))) / len(Volume) \
            - np.mean(Volume) * np.mean(G, axis=1))
 
         return Hvap_avg, Hvap_err, Hvap_grad

--- a/tools/TagMol2.py
+++ b/tools/TagMol2.py
@@ -78,11 +78,11 @@ class MolG(nx.Graph):
 
 def col(vec):
     """Given any list, array, or matrix, return a 1-column matrix."""
-    return np.mat(np.array(vec).reshape(-1, 1))
+    return np.array(vec).reshape(-1, 1)
 
 def row(vec):
     """Given any list, array, or matrix, return a 1-row matrix."""
-    return np.mat(np.array(vec).reshape(1, -1))
+    return np.array(vec).reshape(1, -1)
 
 def flat(vec):
     """Given any list, array, or matrix, return a single-index array."""
@@ -153,7 +153,7 @@ def get_equivalent_atoms(MyG):
 def charge_as_array(M2Mol, QMat):
     oldq = np.array([atom.charge for atom in M2Mol.atoms])
     def get_symq(q):
-        return np.array([float("% .6f" % i) for i in flat(np.mat(QMat) * col(oldq))])
+        return np.array([float("% .6f" % i) for i in flat(np.dot(QMat, col(oldq)))])
     J = 0
     M = 0
     oldq  = get_symq(oldq)


### PR DESCRIPTION
This PR gets rid of all calls to `np.matrix` in order to avoid pending deprecation warnings.