### PR TITLE
Energy_rms_override option

### DIFF
--- a/src/abinitio.py
+++ b/src/abinitio.py
@@ -115,6 +115,7 @@ class AbInitio(Target):
         self.set_option(tgt_opts,'w_force','w_force')
         if not self.force:
             self.w_force = 0.0
+        self.set_option(tgt_opts,'energy_rms_override','energy_rms_override')
         self.set_option(tgt_opts,'force_map','force_map')
         self.set_option(tgt_opts,'w_netforce','w_netforce')
         self.set_option(tgt_opts,'w_torque','w_torque')
@@ -860,6 +861,10 @@ class AbInitio(Target):
         if np.sum(W_Components) > 0 and self.w_normalize:
             W_Components /= np.sum(W_Components)
 
+        if self.energy_rms_override != 0.0:
+            QQ0[0] = self.energy_rms_override ** 2
+            Q0[0] = 0.0
+            
         def compute_objective(SPX_like,divide=1,L=None,R=None,L2=None,R2=None):
             a = 0
             n = 1

--- a/src/parser.py
+++ b/src/parser.py
@@ -239,6 +239,7 @@ tgt_opts_types = {
                  "hfe_temperature"  : (298.15, -100, 'Simulation temperature for hydration free energies (Kelvin)', 'Hydration free energy using molecular dynamics', 'hydration'),
                  "hfe_pressure"   : (1.0, -100, 'Simulation temperature for hydration free energies (atm)', 'Hydration free energy using molecular dynamics', 'hydration'),
                  "energy_denom"   : (1.0, 0, 'Energy normalization for binding energies in kcal/mol (default is to use stdev)', 'Binding energy targets', 'binding'),
+                 "energy_rms_override"   : (0.0, 0, 'If nonzero, override the Energy RMS used to normalize the energy part of the objective function term', 'Energy matching', 'abinitio'),
                  "rmsd_denom"     : (0.1, 0, 'RMSD normalization for optimized geometries in Angstrom', 'Binding energy targets', 'binding'),
                  "wavenumber_tol" : (10.0, 0, 'Frequency normalization (in wavenumber) for vibrational frequencies', 'Vibrational frequency targets', 'vibration'),
                  "dipole_denom"   : (1.0, 0, 'Dipole normalization (Debye) ; set to 0 if a zero weight is desired', 'Monomer property targets', 'monomer'),


### PR DESCRIPTION
Add an option to force the QM energy RMS to a user-specified constant instead of calculating it from the QM data. This may be useful in cases where we want to use the same RMS value for several different targets.