### PR TITLE
Parse OpenMM XML format with either atom type / class specification

### DIFF
--- a/src/openmmio.py
+++ b/src/openmmio.py
@@ -516,7 +516,13 @@ class OpenMM_Reader(BaseReader):
                 pfx = list(element.iterancestors())[0].attrib["name"]
                 Involved = '.'.join([pfx+"-"+element.attrib[i] for i in suffix_dict[ParentType][InteractionType]])
             else:
-                Involved = '.'.join([element.attrib[i] for i in suffix_dict[ParentType][InteractionType] if i in element.attrib])
+                Involved1 = '.'.join([element.attrib[i] for i in suffix_dict[ParentType][InteractionType] if i in element.attrib])
+                suffix2 = [i.replace('class','type') for i in suffix_dict[ParentType][InteractionType]]
+                suffix3 = [i.replace('type','class') for i in suffix_dict[ParentType][InteractionType]]
+                Involved2 = '.'.join([element.attrib[i] for i in suffix2 if i in element.attrib])
+                Involved3 = '.'.join([element.attrib[i] for i in suffix3 if i in element.attrib])
+                # Keep the Involved string that is the longest (assuming that is the one that properly matched)
+                Involved = [Involved1, Involved2, Involved3][np.argmax(np.array([len(Involved1),len(Involved2),len(Involved3)]))]
             return "/".join([InteractionType, parameter, Involved])
         except:
             logger.info("Minor warning: Parameter ID %s doesn't contain any atom types, redundancies are possible\n" % ("/".join([InteractionType, parameter])))


### PR DESCRIPTION
Previously, OpenMM XML parameter lines such as the one below will cause an error in ForceBalance because the codes assumed these interactions were defined in terms of atom classes (not atom types) which led to incorrect parameter names.  The fixed version will attempt to parse parameter lines defined using either atom types or atom classes (but not mixing both).

```    <Bond k="310787.5199999999" length="0.0973" type1="ho" type2="oh" parameterize="length,k"/>
```