### PR TITLE
major improvements for smirnoff and optgeo targets

### DIFF
--- a/src/opt_geo_target.py
+++ b/src/opt_geo_target.py
@@ -215,7 +215,7 @@ class OptGeoTarget(Target):
         return v_ic
 
     def indicate(self):
-        title_str = "Optimized Geometries, Objective = % .5e" % self.objective
+        title_str = "%s, Objective = % .5e" % (self.name, self.objective)
         #QYD: This title is carefully placed to align correctly
         column_head_str1 =  " %-20s %13s     %13s     %15s   %15s   %17s " % ("System", "Bonds", "Angles", "Dihedrals", "Impropers", "Term.")
         column_head_str2 =  " %-20s %9s %7s %9s %7s %9s %7s %9s %7s %17s " % ('', 'RMSD', 'denom', 'RMSD', 'denom', 'RMSD', 'denom', 'RMSD', 'denom', '')

--- a/src/opt_geo_target.py
+++ b/src/opt_geo_target.py
@@ -9,7 +9,7 @@ import shutil
 import numpy as np
 import re
 import subprocess
-from collections import OrderedDict
+from collections import OrderedDict, defaultdict
 from forcebalance.nifty import col, eqcgmx, flat, floatornan, fqcgmx, invert_svd, kb, printcool, printcool_dictionary, bohr2ang, warn_press_key
 from forcebalance.target import Target
 from forcebalance.molecule import Molecule
@@ -17,7 +17,7 @@ from forcebalance.finite_difference import fdwrap, f1d2p, f12d3p, in_fd
 from forcebalance.output import getLogger
 logger = getLogger(__name__)
 
-def periodic_diff(a, b, v_periodic=np.pi*2):
+def periodic_diff(a, b, v_periodic):
     ''' convenient function for computing the minimum difference in periodic coordinates
     Parameters
     ----------
@@ -49,7 +49,19 @@ def periodic_diff(a, b, v_periodic=np.pi*2):
     h = 0.5 * v_periodic
     return (a - b + h) % v_periodic - h
 
-
+def compute_rmsd(ref, tar, v_periodic=None):
+    """
+    Compute the RMSD between two arrays, supporting periodic difference
+    """
+    assert len(ref) == len(tar), 'array length must match'
+    n = len(ref)
+    if n == 0: return 0.0
+    if v_periodic is not None:
+        diff = periodic_diff(ref, tar, v_periodic)
+    else:
+        diff = ref - tar
+    rmsd = np.sqrt(np.sum(diff**2) / n)
+    return rmsd
 
 class OptGeoTarget(Target):
     """ Subclass of Target for fitting MM optimized geometries to QM optimized geometries. """
@@ -60,43 +72,20 @@ class OptGeoTarget(Target):
         ## Build keyword dictionaries to pass to engine.
         engine_args = OrderedDict(list(self.OptionDict.items()) + list(options.items()))
         del engine_args['name']
-        ## Create engine objects.
-        self.engines = OrderedDict()
-        for sysname, sysopt in self.sys_opts.items():
-            if self.engine_.__name__ == 'OpenMM':
-                # path to pdb file
-                pdbpath = os.path.join(self.root, self.tgtdir, sysopt['topology'])
-                # use the PDB file with topology
-                M = Molecule(pdbpath)
-                # replace geometry with values from xyz file for higher presision
-                M0 = Molecule(os.path.join(self.root, self.tgtdir, sysopt['geometry']))
-                M.xyzs = M0.xyzs
-                # here mol=M is given for the purpose of using the topology from the input pdb file
-                # if we don't do this, pdb=top.pdb option will only copy some basic information but not the topology into OpenMM.mol (openmmio.py line 615)
-                self.engines[sysname] = self.engine_(target=self, mol=M, name=sysname, pdb=pdbpath, **engine_args)
-            elif self.engine_.__name__ == 'SMIRNOFF':
-                # SMIRNOFF is a subclass of OpenMM engine but it requires the mol2 input
-                # note: OpenMM.mol is a Molecule class instance;  mol2 is a file format.
-                # path to .pdb file
-                pdbpath = os.path.join(self.root, self.tgtdir, sysopt['topology'])
-                # a list of paths to .mol2 files
-                mol2path = [os.path.join(self.root, self.tgtdir, f) for f in sysopt['mol2']]
-                # use the PDB file with topology
-                M = Molecule(os.path.join(self.root, self.tgtdir, sysopt['topology']))
-                # replace geometry with values from xyz file for higher presision
-                M0 = Molecule(os.path.join(self.root, self.tgtdir, sysopt['geometry']))
-                M.xyzs = M0.xyzs
-                # here mol=M is given for the purpose of using the topology from the input pdb file
-                # if we don't do this, pdb=top.pdb option will only copy some basic information but not the topology into OpenMM.mol (openmmio.py line 615)
-                self.engines[sysname] = self.engine_(target=self, mol=M, name=sysname, pdb=pdbpath, mol2=mol2path, **engine_args)
+        ## Create engine objects
+        self.create_engines(engine_args)
         ## Create internal coordinates
         self._build_internal_coordinates()
         ## Option for how much data to write to disk.
         self.set_option(tgt_opts,'writelevel','writelevel')
 
-    def parse_optgeo_options(self, filename):
+    def create_engines(self, engine_args):
+        raise NotImplementedError("create_engines() should be implemented in subclass")
+
+    @staticmethod
+    def parse_optgeo_options(filename):
         """ Parse an optgeo_options.txt file into specific OptGeoTarget Target Options"""
-        logger.info("Reading interactions from file: %s\n" % filename)
+        logger.info("Reading optgeo options from file: %s\n" % filename)
         global_opts = OrderedDict()
         sys_opts = OrderedDict()
         section = None
@@ -151,20 +140,20 @@ class OptGeoTarget(Target):
                         # special parsing for mol2 option for SMIRNOFF engine
                         # the value is a list of filenames
                         section_opts[key] = ls[1:]
-            # apply a few default global options
-            global_opts.setdefault('bond_denom', 0.02)
-            global_opts.setdefault('angle_denom', 0.05)
-            global_opts.setdefault('dihedral_denom', 0.2)
-            global_opts.setdefault('improper_denom', 0.2)
-            # copy global options into each system
-            for sys_name, sys_opt_dict in sys_opts.items():
-                for k,v in global_opts.items():
-                    # do not overwrite system options
-                    sys_opt_dict.setdefault(k, v)
-                for k in ['name', 'geometry', 'topology']:
-                    if k not in sys_opt_dict:
-                        warn_press_key("key %s missing in system section named %s" %(k, sys_name))
-            return sys_opts
+        # apply a few default global options
+        global_opts.setdefault('bond_denom', 0.02)
+        global_opts.setdefault('angle_denom', 0.05)
+        global_opts.setdefault('dihedral_denom', 0.2)
+        global_opts.setdefault('improper_denom', 0.2)
+        # copy global options into each system
+        for sys_name, sys_opt_dict in sys_opts.items():
+            for k,v in global_opts.items():
+                # do not overwrite system options
+                sys_opt_dict.setdefault(k, v)
+            for k in ['name', 'geometry', 'topology']:
+                if k not in sys_opt_dict:
+                    warn_press_key("key %s missing in system section named %s" %(k, sys_name))
+        return sys_opts
 
     def _build_internal_coordinates(self):
         "Build internal coordinates system with geometric.internal.PrimitiveInternalCoordinates"
@@ -175,7 +164,7 @@ class OptGeoTarget(Target):
         for sysname, sysopt in self.sys_opts.items():
             geofile = os.path.join(self.root, self.tgtdir, sysopt['geometry'])
             topfile = os.path.join(self.root, self.tgtdir, sysopt['topology'])
-            logger.info("Building internal coordinates from file: %s\n" % topfile)
+            # logger.info("Building internal coordinates from file: %s\n" % topfile)
             m0 = Molecule(geofile)
             m = Molecule(topfile)
             p_IC = PrimitiveInternalCoordinates(m)
@@ -235,11 +224,17 @@ class OptGeoTarget(Target):
     def get(self, mvals, AGrad=False, AHess=False):
         Answer = {'X':0.0, 'G':np.zeros(self.FF.np), 'H':np.zeros((self.FF.np, self.FF.np))}
         self.PrintDict = OrderedDict()
-        def compute(mvals):
+        # enable self.system_mval_masks (supported by OptGeoTarget_SMIRNOFF)
+        enable_system_mval_mask = hasattr(self, 'system_mval_masks')
+        def compute(mvals, p_idx=None):
             ''' Compute total objective value for each system '''
             self.FF.make(mvals)
             v_obj_list = []
             for sysname, sysopt in self.sys_opts.items():
+                # use self.system_mval_masks to skip evaluations when computing gradients
+                if enable_system_mval_mask and in_fd() and (p_idx is not None) and (self.system_mval_masks[sysname][p_idx] == False):
+                    v_obj_list += [0, 0, 0, 0]
+                    continue
                 # read denominators from system options
                 bond_denom = sysopt['bond_denom']
                 angle_denom = sysopt['angle_denom']
@@ -255,19 +250,19 @@ class OptGeoTarget(Target):
                 # objective contribution from bonds
                 vref_bonds = self.internal_coordinates[sysname]['vref_bonds']
                 vtar_bonds = v_ic['bonds']
-                rmsd_bond = np.sqrt(np.sum((vref_bonds - vtar_bonds)**2)/len(vref_bonds))
+                rmsd_bond = compute_rmsd(vref_bonds, vtar_bonds)
                 # objective contribution from angles
                 vref_angles = self.internal_coordinates[sysname]['vref_angles']
                 vtar_angles = v_ic['angles']
-                rmsd_angle = np.sqrt(np.sum(periodic_diff(vref_angles, vtar_angles)**2)/len(vref_angles))
+                rmsd_angle = compute_rmsd(vref_angles, vtar_angles, v_periodic=np.pi*2)
                 # objective contribution from dihedrals
                 vref_dihedrals = self.internal_coordinates[sysname]['vref_dihedrals']
                 vtar_dihedrals = v_ic['dihedrals']
-                rmsd_dihedral = np.sqrt(np.sum(periodic_diff(vref_dihedrals, vtar_dihedrals)**2)/len(vref_dihedrals))
+                rmsd_dihedral = compute_rmsd(vref_dihedrals, vtar_dihedrals, v_periodic=np.pi*2)
                 # objective contribution from improper dihedrals
                 vref_impropers = self.internal_coordinates[sysname]['vref_impropers']
                 vtar_impropers = v_ic['impropers']
-                rmsd_improper = np.sqrt(np.sum(periodic_diff(vref_impropers, vtar_impropers)**2)/len(vref_impropers))
+                rmsd_improper = compute_rmsd(vref_impropers, vtar_impropers, v_periodic=np.pi*2)
                 # add total objective value to result list
                 sys_obj_list = [rmsd_bond * scale_bond, rmsd_angle * scale_angle, \
                                 rmsd_dihedral * scale_dihedral, rmsd_improper * scale_improper]
@@ -281,14 +276,15 @@ class OptGeoTarget(Target):
             return np.array(v_obj_list, dtype=float)
 
         V = compute(mvals)
-
+        Answer['X'] = np.dot(V,V)
         # write objective decomposition if wanted
         if self.writelevel > 0:
             # recover mvals
             self.FF.make(mvals)
             with open('rmsd_decomposition.txt', 'w') as fout:
-                fout.write('%-25s %15s %15s %15s\n' % ("Internal Coordinate", "Ref QM Value", "Cur MM Value", "Difference"))
                 for sysname in self.internal_coordinates:
+                    fout.write("\n[ %s ]\n" % sysname)
+                    fout.write('%-25s %15s %15s %15s\n' % ("Internal Coordinate", "Ref QM Value", "Cur MM Value", "Difference"))
                     # reference data
                     sys_data = self.internal_coordinates[sysname]
                     sys_data['ic_bonds']
@@ -301,15 +297,15 @@ class OptGeoTarget(Target):
                         tar_v = v_ic[p]
                         # print each value
                         for ic, v1, v2 in zip(ic_list, ref_v, tar_v):
-                            diff = periodic_diff(v1, v2) if p != 'bonds' else v1-v2
+                            diff = periodic_diff(v1, v2, v_periodic=np.pi*2) if p != 'bonds' else v1-v2
                             fout.write('%-25s %15.5f %15.5f %+15.3e\n' % (ic, v1, v2, diff))
 
         # compute gradients and hessian
         dV = np.zeros((self.FF.np,len(V)))
         if AGrad or AHess:
             for p in self.pgrad:
-                dV[p,:], _ = f12d3p(fdwrap(compute, mvals, p), h = self.h, f0 = V)
-        Answer['X'] = np.dot(V,V)
+                dV[p,:], _ = f12d3p(fdwrap(compute, mvals, p, p_idx = p), h = self.h, f0 = V)
+
         for p in self.pgrad:
             Answer['G'][p] = 2*np.dot(V, dV[p,:])
             for q in self.pgrad:

--- a/src/smirnoff_hack.py
+++ b/src/smirnoff_hack.py
@@ -47,5 +47,19 @@ def cached_generate_conformers(self, molecule, n_conformers=1, clear_existing=Tr
     molecule._conformers = TOOLKIT_CACHE_molecule_conformers[cache_key]
 OpenEyeToolkitWrapper.generate_conformers = cached_generate_conformers
 
-
 # final timing: 56s
+
+# cache the ForceField creation
+
+import hashlib
+from openforcefield.typing.engines.smirnoff import ForceField
+SMIRNOFF_FORCE_FIELD_CACHE = {}
+def getForceField(*ffpaths):
+    hasher = hashlib.md5()
+    for path in ffpaths:
+        with open(path, 'rb') as f:
+            hasher.update(f.read())
+    cache_key = hasher.hexdigest()
+    if cache_key not in SMIRNOFF_FORCE_FIELD_CACHE:
+        SMIRNOFF_FORCE_FIELD_CACHE[cache_key] = ForceField(*ffpaths, allow_cosmetic_attributes=True)
+    return SMIRNOFF_FORCE_FIELD_CACHE[cache_key]

--- a/src/smirnoffio.py
+++ b/src/smirnoffio.py
@@ -64,7 +64,7 @@ def smirnoff_analyze_parameter_coverage(forcefield, targets):
     parameter_counter = Counter()
     # build the openforcefield.typing.engines.smirnoff.ForceField object
     absffpath = os.path.join(forcefield.root,forcefield.ffdir,forcefield.offxml)
-    ff = ForceField(absffpath, allow_cosmetic_attributes=True)
+    ff = smirnoff_hack.getForceField(absffpath) #ForceField(absffpath, allow_cosmetic_attributes=True)
     # analyze each target
     for target in targets:
         off_topology = None
@@ -219,10 +219,10 @@ class SMIRNOFF(OpenMM):
         # Create the OpenFF ForceField object.
         if hasattr(self, 'FF'):
             self.offxml = [self.FF.offxml]
-            self.forcefield = ForceField(os.path.join(self.root, self.FF.ffdir, self.FF.offxml), allow_cosmetic_attributes=True)
+            self.forcefield = smirnoff_hack.getForceField(os.path.join(self.root, self.FF.ffdir, self.FF.offxml))
         else:
             self.offxml = listfiles(kwargs.get('offxml'), 'offxml', err=True)
-            self.forcefield = ForceField(*self.offxml, allow_cosmetic_attributes=True)
+            self.forcefield = smirnoff_hack.getForceField(*self.offxml)
 
         ## Load mol2 files for smirnoff topology
         openff_mols = []
@@ -306,7 +306,8 @@ class SMIRNOFF(OpenMM):
         if len(kwargs) > 0:
             self.simkwargs = kwargs
 
-        self.forcefield = ForceField(*self.offxml, allow_cosmetic_attributes=True)
+        #self.forcefield = ForceField(*self.offxml, allow_cosmetic_attributes=True)
+        self.forcefield = smirnoff_hack.getForceField(*self.offxml)
         self.system = self.forcefield.create_openmm_system(self.off_topology)
 
         # Commenting out all virtual site stuff for now.

--- a/src/smirnoffio.py
+++ b/src/smirnoffio.py
@@ -345,7 +345,7 @@ class SMIRNOFF(OpenMM):
         X0 = np.array([j for i, j in enumerate(self.simulation.context.getState(getPositions=True).getPositions().value_in_unit(angstrom)) if self.AtomMask[i]])
         # Minimize the energy.  Optimizer works best in "steps".
         for logc in np.linspace(0, np.log10(crit), steps):
-            self.simulation.minimizeEnergy(tolerance=10**logc*kilojoule/mole, maxIterations=1000)
+            self.simulation.minimizeEnergy(tolerance=10**logc*kilojoule/mole, maxIterations=10000)
         # Get the optimized geometry.
         S = self.simulation.context.getState(getPositions=True, getEnergy=True)
         X1 = np.array([j for i, j in enumerate(S.getPositions().value_in_unit(angstrom)) if self.AtomMask[i]])

--- a/src/smirnoffio.py
+++ b/src/smirnoffio.py
@@ -72,7 +72,21 @@ def smirnoff_analyze_parameter_coverage(forcefield, targets):
         if isinstance(target, forcebalance.target.RemoteTarget):
             if target.r_tgt_opts['type'].endswith('SMIRNOFF'):
                 target_path = os.path.join(target.root, target.tgtdir)
-                openff_mols = [OffMolecule.from_file(os.path.join(target_path,fnm)) for fnm in target.r_tgt_opts.get('mol2', [])]
+                if target.r_tgt_opts['type'] == 'OPTGEOTARGET_SMIRNOFF':
+                    # parse optgeo_options_txt and get the names of the mol2 files
+                    optgeo_options_txt = os.path.join(target_path, target.r_tgt_opts['optgeo_options_txt'])
+                    sys_opts = forcebalance.opt_geo_target.OptGeoTarget.parse_optgeo_options(optgeo_options_txt)
+                    openff_mols = [OffMolecule.from_file(os.path.join(target_path,fnm), allow_undefined_stereo=True) \
+                                   for sysopt in sys_opts.values() for fnm in sysopt['mol2']]
+                else:
+                    openff_mols = [OffMolecule.from_file(os.path.join(target_path,fnm), allow_undefined_stereo=True) \
+                                   for fnm in target.r_tgt_opts.get('mol2', [])]
+                off_topology = OffTopology.from_molecules(openff_mols)
+        elif isinstance(target, forcebalance.opt_geo_target.OptGeoTarget):
+            if target.engine_.__name__ == 'SMIRNOFF':
+                target_path = os.path.join(target.root, target.tgtdir)
+                openff_mols = [OffMolecule.from_file(os.path.join(target_path,fnm), allow_undefined_stereo=True) \
+                    for sysopt in target.sys_opts.values() for fnm in sysopt['mol2']]
                 off_topology = OffTopology.from_molecules(openff_mols)
         elif hasattr(target, 'engine') and isinstance(target.engine, SMIRNOFF) and hasattr(target.engine,'off_topology'):
             off_topology = target.engine.off_topology
@@ -213,7 +227,11 @@ class SMIRNOFF(OpenMM):
         ## Load mol2 files for smirnoff topology
         openff_mols = []
         for fnm in self.mol2:
-            mol = OffMolecule.from_file(fnm)
+            try:
+                mol = OffMolecule.from_file(fnm, allow_undefined_stereo=True)
+            except Exception as e:
+                logger.error("Error when loading %s" % fnm)
+                raise e
             openff_mols.append(mol)
         self.off_topology = OffTopology.from_openmm(self.pdb.topology, unique_molecules=openff_mols)
 
@@ -372,6 +390,17 @@ class SMIRNOFF(OpenMM):
 
         return (D - A - B) / 4.184
 
+    def get_smirks_counter(self):
+        """Get a counter for the time of appreance of each SMIRKS"""
+        smirks_counter = Counter()
+        molecule_force_list = self.forcefield.label_molecules(self.off_topology)
+        for mol_idx, mol_forces in enumerate(molecule_force_list):
+            for force_tag, force_dict in mol_forces.items():
+                # e.g. force_tag = 'Bonds'
+                for parameter in force_dict.values():
+                    smirks_counter[parameter.smirks] += 1
+        return smirks_counter
+
 class Liquid_SMIRNOFF(Liquid):
     """ Condensed phase property matching using OpenMM. """
     def __init__(self,options,tgt_opts,forcefield):
@@ -427,10 +456,43 @@ class AbInitio_SMIRNOFF(AbInitio):
         self.set_option(tgt_opts,'mol2',forceprint=True)
         self.set_option(tgt_opts,'coords',default="all.gro")
         self.set_option(tgt_opts,'openmm_precision','precision',default="double", forceprint=True)
-        self.set_option(tgt_opts,'openmm_platform','platname',default="CUDA", forceprint=True)
+        self.set_option(tgt_opts,'openmm_platform','platname',default="Reference", forceprint=True)
         self.engine_ = SMIRNOFF
         ## Initialize base class.
         super(AbInitio_SMIRNOFF,self).__init__(options,tgt_opts,forcefield)
+
+    def submit_jobs(self, mvals, AGrad=False, AHess=False):
+        # we update the self.pgrads here so it's not overwritten in rtarget.py
+        self.smirnoff_update_pgrads()
+
+    def smirnoff_update_pgrads(self):
+        """
+        Update self.pgrads based on smirks present in mol2 files
+
+        This can greatly improve gradients evaluation in big optimizations
+
+        Note
+        ----
+        1. This function assumes the names of the forcefield parameters has the smirks as the last item
+        2. This function assumes params only affect the smirks of its own. This might not be true if parameter_eval is used.
+        """
+        orig_pgrad_set = set(self.pgrad)
+        # smirks to param_idxs map
+        smirks_params_map = defaultdict(list)
+        for pname, pidx in self.FF.map.items():
+            smirks = pname.rsplit('/',maxsplit=1)[-1]
+            smirks_params_map[smirks].append(pidx)
+        pgrads_set = set()
+        # get the smirks for this target, keep only the pidx corresponding to these smirks
+        smirks_counter = self.engine.get_smirks_counter()
+        for smirks in smirks_counter:
+            if smirks_counter[smirks] > 0:
+                pidx_list = smirks_params_map[smirks]
+                # update the set of parameters present in this target
+                pgrads_set.update(pidx_list)
+        # this ensure we do not add any new items into self.pgrad
+        pgrads_set.intersection_update(orig_pgrad_set)
+        self.pgrad = sorted(list(pgrads_set))
 
 
 class Vibration_SMIRNOFF(Vibration):
@@ -455,6 +517,58 @@ class OptGeoTarget_SMIRNOFF(OptGeoTarget):
         self.engine_ = SMIRNOFF
         ## Initialize base class.
         super(OptGeoTarget_SMIRNOFF,self).__init__(options,tgt_opts,forcefield)
+
+    def create_engines(self, engine_args):
+        """ create a dictionary of self.engines = {sysname: Engine} """
+        self.engines = OrderedDict()
+        for sysname, sysopt in self.sys_opts.items():
+            # SMIRNOFF is a subclass of OpenMM engine but it requires the mol2 input
+            # note: OpenMM.mol is a Molecule class instance;  mol2 is a file format.
+            # path to .pdb file
+            pdbpath = os.path.join(self.root, self.tgtdir, sysopt['topology'])
+            # a list of paths to .mol2 files
+            mol2path = [os.path.join(self.root, self.tgtdir, f) for f in sysopt['mol2']]
+            # use the PDB file with topology
+            M = Molecule(os.path.join(self.root, self.tgtdir, sysopt['topology']))
+            # replace geometry with values from xyz file for higher presision
+            M0 = Molecule(os.path.join(self.root, self.tgtdir, sysopt['geometry']))
+            M.xyzs = M0.xyzs
+            # here mol=M is given for the purpose of using the topology from the input pdb file
+            # if we don't do this, pdb=top.pdb option will only copy some basic information but not the topology into OpenMM.mol (openmmio.py line 615)
+            self.engines[sysname] = self.engine_(target=self, mol=M, name=sysname, pdb=pdbpath, mol2=mol2path, **engine_args)
+        self.build_system_mval_masks()
+
+    def build_system_mval_masks(self):
+        """
+        Build a mask of mvals for each system, to speed up finite difference gradients
+
+        Note
+        ----
+        1. This function assumes the names of the forcefield parameters has the smirks as the last item
+        2. This function assumes params only affect the smirks of its own. This might not be true if parameter_eval is used.
+        """
+        # only need to build once
+        if hasattr(self, 'system_mval_masks'): return
+        n_params = len(self.FF.map)
+        # default mask with all False
+        system_mval_masks = {sysname: np.zeros(n_params, dtype=bool) for sysname in self.sys_opts}
+        # smirks to param_idxs map
+        smirks_params_map = defaultdict(list)
+        for pname, pidx in self.FF.map.items():
+            smirks = pname.rsplit('/',maxsplit=1)[-1]
+            smirks_params_map[smirks].append(pidx)
+        # go over all smirks for each system
+        for sysname in self.sys_opts:
+            engine = self.engines[sysname]
+            smirks_counter = engine.get_smirks_counter()
+            for smirks in smirks_counter:
+                if smirks_counter[smirks] > 0:
+                    pidx_list = smirks_params_map[smirks]
+                    # set mask value to True for present smirks
+                    system_mval_masks[sysname][pidx_list] = True
+        # finish
+        logger.info("system_mval_masks is built for faster gradient evaluations")
+        self.system_mval_masks = system_mval_masks
 
 # class BindingEnergy_SMIRNOFF(BindingEnergy):
 #     """ Binding energy matching using OpenMM. """
@@ -511,4 +625,3 @@ class OptGeoTarget_SMIRNOFF(OptGeoTarget):
 #         ## Send back the trajectory file.
 #         if self.save_traj > 0:
 #             self.extra_output = ['openmm-md.dcd']
-


### PR DESCRIPTION
This PR mainly contains refactoring and improvements of the molecules `sminoffio.py` and `opt_geo_target.py`

For the `sminoffio.py`
1. The `smirnoff_analyze_parameter_coverage()` function now supports optgeo_target, which contains many molecules and engines. The analysis is done by aggregating all mol2 files into an OpenFF topology.

2. New keyword is added to the openff API, to fix errors in OpenFF toolkit about geometries that are "planar" have undefined stereo chemistry. Error handling is also added to print out information about the file.
    ```
    OffMolecule.from_file(fnm, allow_undefined_stereo=True)
    ```

3. Performance of numerical gradient evaluations are greatly improved, by implementing `smirnoff_update_pgrads` in `AbInitio_SMIRNOFF` and `build_system_mval_masks` in `OptGeoTarget_SMIRNOFF`.


For the `opt_geo_target.py`:
1. Robustness is improved, by implementing the `compute_rmsd` function. Internal coordinate groups that have no elements will give 0 rmsd contribution.

2. Engine creation in `__init__()` is refactored and moved to the subclasses.

3. Numerical gradients can now use the information of `system_mval_masks` to skip gradients of parameters that are not affecting the molecule. Since each molecule usually is only affected by <20 parameters, this could directly accelerate the fitting by 25x when a total of 500 parameters are used.