### PR TITLE
Improved force field parameter representation and SMIRKS-based masking

### DIFF
--- a/src/smirnoffio.py
+++ b/src/smirnoffio.py
@@ -558,9 +558,16 @@ class OptGeoTarget_SMIRNOFF(OptGeoTarget):
         system_mval_masks = {sysname: np.zeros(n_params, dtype=bool) for sysname in self.sys_opts}
         # smirks to param_idxs map
         smirks_params_map = defaultdict(list)
-        for pname, pidx in self.FF.map.items():
+        # New code for mapping smirks to mathematical parameter IDs
+        for pname in self.FF.pTree:
             smirks = pname.rsplit('/',maxsplit=1)[-1]
-            smirks_params_map[smirks].append(pidx)
+            # print("pname %s mathid %s -> smirks %s" % (pname, str(self.FF.get_mathid(pname)), smirks))
+            for pidx in self.FF.get_mathid(pname):
+                smirks_params_map[smirks].append(pidx)
+        # Old code for mapping smirks to mathematical parameter IDs
+        # for pname, pidx in self.FF.map.items():
+        #     smirks = pname.rsplit('/',maxsplit=1)[-1]
+        #     smirks_params_map[smirks].append(pidx)
         # go over all smirks for each system
         for sysname in self.sys_opts:
             engine = self.engines[sysname]

--- a/studies/022_opt_geo_target/optimize.in
+++ b/studies/022_opt_geo_target/optimize.in
@@ -15,13 +15,13 @@ penalty_type L2
 jobtype optimize
 
 # (list) The names of force fields, corresponding to directory forcefields/file_name.(itp|gen)
-forcefield smirnoff99Frosst.offxml
+forcefield smirnoff99Frosst_experimental.offxml
 
 # (int) Maximum number of steps in an optimization
 maxstep 100
 
 # (float) Convergence criterion of step size (just needs to fall below this threshold)
-convergence_step 0.1
+convergence_step 0.01
 
 # (float) Convergence criterion of objective function (in MainOptimizer this is the stdev of x2 over 10 steps)
 convergence_objective 0.1
@@ -38,7 +38,7 @@ finite_difference_h 0.001
 # (float) Factor for multiplicative penalty function in objective function
 penalty_additive 1.0
 
-trust0 0.25
+trust0 -0.1
 mintrust 0.05
 error_tolerance 1.0
 adaptive_factor 0.2
@@ -74,7 +74,6 @@ pdb input.pdb
 mol2 9HXanthene.mol2
 weight 1.0
 # (float) Wavenumber tolerance, normalizes the objective function.
-# This is set to a large value only for demo purpose
 wavenumber_tol 200.0
 $end
 

--- a/studies/022_opt_geo_target/optimize.out
+++ b/studies/022_opt_geo_target/optimize.out
@@ -57,40 +57,49 @@ Reading options from file: optimize.in
 #| [95m  Options at their default values are not printed   [0m |#
 #| [95m        Use 'verbose_options True' to Enable        [0m |#
 #========================================================#
-Reading force field from file: smirnoff99Frosst.offxml
+Reading force field from file: smirnoff99Frosst_experimental.offxml
+In assign_field, matches = ["['Bonds/Bond/k/[#6X3:1]-[#6X3:2]']"]
+Adding edge between Bonds/Bond/k/[#6X3:1]-[#6X3:2] and Bonds/Bond/k/[#6X3:1]:[#6X3:2]
 #=========================================================#
 #| [92m Starting parameter indices, physical values and IDs [0m |#
 #=========================================================#
-   0 [  9.3800e+02 ] : HarmonicBondForce/Bond/k/[#6X3:1]:[#6X3:2]
-   1 [  1.4000e+00 ] : HarmonicBondForce/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [  9.0000e+02 ] : HarmonicBondForce/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [  1.3230e+00 ] : HarmonicBondForce/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [  6.8000e+02 ] : HarmonicBondForce/Bond/k/[#6X4:1]-[#1:2]
-   5 [  1.0900e+00 ] : HarmonicBondForce/Bond/length/[#6X4:1]-[#1:2]
-   6 [  7.3400e+02 ] : HarmonicBondForce/Bond/k/[#6X3:1]-[#1:2]
-   7 [  1.0800e+00 ] : HarmonicBondForce/Bond/length/[#6X3:1]-[#1:2]
-   8 [  1.0950e+02 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [  7.0000e+01 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [  1.2000e+02 ] : HarmonicAngleForce/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [  1.4000e+02 ] : HarmonicAngleForce/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [  1.2000e+02 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [  1.0000e+02 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [  1.2000e+02 ] : HarmonicAngleForce/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [  1.4000e+02 ] : HarmonicAngleForce/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [  3.6250e+00 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
-  17 [  1.0500e+00 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [  1.5700e-02 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X4]
-  19 [  1.4870e+00 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [  1.5000e-02 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X3]
-  21 [  1.4590e+00 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [  1.0940e-01 ] : NonbondedForce/Atom/epsilon/[#6X4:1]
-  23 [  1.9080e+00 ] : NonbondedForce/Atom/rmin_half/[#6X4:1]
-  24 [  1.7000e-01 ] : NonbondedForce/Atom/epsilon/[#8X2H0+0:1]
-  25 [  1.6837e+00 ] : NonbondedForce/Atom/rmin_half/[#8X2H0+0:1]
+   0 [  8.2000e+02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [  1.4000e+00 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [  9.0000e+02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  1.3230e+00 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [  6.8000e+02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  1.0900e+00 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [  7.3400e+02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  1.0800e+00 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [  1.0950e+02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [  7.0000e+01 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [  1.2000e+02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [  1.4000e+02 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [  1.2000e+02 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [  1.0000e+02 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [  1.2000e+02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [  1.4000e+02 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [  3.6250e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  1.0500e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [  1.5700e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [  1.4870e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [  1.5000e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [  1.4590e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  1.0940e-01 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  1.9080e+00 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [  1.7000e-01 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [  1.6837e+00 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
 -----------------------------------------------------------
 #=========================================================#
 #| [91m Rescaling Factors by Type (Lower Takes Precedence): [0m |#
 #=========================================================#
+   Bonds/Bond/k                         : 9.00000e+02
+   Bonds/Bond/length                    : 1.40000e+00
+   Angles/Angle/angle                   : 1.20000e+02
+   Angles/Angle/k                       : 1.40000e+02
+   ProperTorsions/Proper/k1             : 3.62500e+00
+   vdW/Atom/epsilon                     : 1.70000e-01
+   vdW/Atom/rmin_half                   : 1.90800e+00
    HarmonicBondForce/Bond/k             : 1.00000e+01
    HarmonicBondForce/Bond/length        : 1.00000e-02
    HarmonicAngleForce/Angle/k           : 1.00000e+01
@@ -102,42 +111,68 @@ Reading force field from file: smirnoff99Frosst.offxml
 #========================================================#
 #| [91m   Rescaling Types / Factors by Parameter Number:   [0m |#
 #========================================================#
-   0 [    HarmonicBondForce/Bond/k      : 1.00000e+01 ] : HarmonicBondForce/Bond/k/[#6X3:1]:[#6X3:2]
-   1 [    HarmonicBondForce/Bond/length  : 1.00000e-02 ] : HarmonicBondForce/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [    HarmonicBondForce/Bond/k      : 1.00000e+01 ] : HarmonicBondForce/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [    HarmonicBondForce/Bond/length  : 1.00000e-02 ] : HarmonicBondForce/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [    HarmonicBondForce/Bond/k      : 1.00000e+01 ] : HarmonicBondForce/Bond/k/[#6X4:1]-[#1:2]
-   5 [    HarmonicBondForce/Bond/length  : 1.00000e-02 ] : HarmonicBondForce/Bond/length/[#6X4:1]-[#1:2]
-   6 [    HarmonicBondForce/Bond/k      : 1.00000e+01 ] : HarmonicBondForce/Bond/k/[#6X3:1]-[#1:2]
-   7 [    HarmonicBondForce/Bond/length  : 1.00000e-02 ] : HarmonicBondForce/Bond/length/[#6X3:1]-[#1:2]
-   8 [    HarmonicAngleForce/Angle/angle  : 1.00000e+01 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [    HarmonicAngleForce/Angle/k    : 1.00000e+01 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [    HarmonicAngleForce/Angle/angle  : 1.00000e+01 ] : HarmonicAngleForce/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [    HarmonicAngleForce/Angle/k    : 1.00000e+01 ] : HarmonicAngleForce/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [    HarmonicAngleForce/Angle/angle  : 1.00000e+01 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [    HarmonicAngleForce/Angle/k    : 1.00000e+01 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [    HarmonicAngleForce/Angle/angle  : 1.00000e+01 ] : HarmonicAngleForce/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [    HarmonicAngleForce/Angle/k    : 1.00000e+01 ] : HarmonicAngleForce/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [    PeriodicTorsionForce/Proper/k1  : 1.00000e+00 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
-  17 [    PeriodicTorsionForce/Proper/k1  : 1.00000e+00 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [    NonbondedForce/Atom/epsilon   : 1.00000e-02 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X4]
-  19 [    NonbondedForce/Atom/rmin_half  : 1.00000e-01 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [    NonbondedForce/Atom/epsilon   : 1.00000e-02 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X3]
-  21 [    NonbondedForce/Atom/rmin_half  : 1.00000e-01 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [    NonbondedForce/Atom/epsilon   : 1.00000e-02 ] : NonbondedForce/Atom/epsilon/[#6X4:1]
-  23 [    NonbondedForce/Atom/rmin_half  : 1.00000e-01 ] : NonbondedForce/Atom/rmin_half/[#6X4:1]
-  24 [    NonbondedForce/Atom/epsilon   : 1.00000e-02 ] : NonbondedForce/Atom/epsilon/[#8X2H0+0:1]
-  25 [    NonbondedForce/Atom/rmin_half  : 1.00000e-01 ] : NonbondedForce/Atom/rmin_half/[#8X2H0+0:1]
+   0 [    Bonds/Bond/k                  : 9.00000e+02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [    Bonds/Bond/length             : 1.40000e+00 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [    Bonds/Bond/k                  : 9.00000e+02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [    Bonds/Bond/length             : 1.40000e+00 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [    Bonds/Bond/k                  : 9.00000e+02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [    Bonds/Bond/length             : 1.40000e+00 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [    Bonds/Bond/k                  : 9.00000e+02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [    Bonds/Bond/length             : 1.40000e+00 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [    Angles/Angle/angle            : 1.20000e+02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [    Angles/Angle/k                : 1.40000e+02 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [    Angles/Angle/angle            : 1.20000e+02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [    Angles/Angle/k                : 1.40000e+02 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [    Angles/Angle/angle            : 1.20000e+02 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [    Angles/Angle/k                : 1.40000e+02 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [    Angles/Angle/angle            : 1.20000e+02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [    Angles/Angle/k                : 1.40000e+02 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [    ProperTorsions/Proper/k1      : 3.62500e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [    ProperTorsions/Proper/k1      : 3.62500e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [    vdW/Atom/epsilon              : 1.70000e-01 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [    vdW/Atom/rmin_half            : 1.90800e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [    vdW/Atom/epsilon              : 1.70000e-01 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [    vdW/Atom/rmin_half            : 1.90800e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [    vdW/Atom/epsilon              : 1.70000e-01 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [    vdW/Atom/rmin_half            : 1.90800e+00 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [    vdW/Atom/epsilon              : 1.70000e-01 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [    vdW/Atom/rmin_half            : 1.90800e+00 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
 ----------------------------------------------------------
 #========================================================#
 #| [92m               Setup for force field                [0m |#
 #========================================================#
-fnms                      ['smirnoff99Frosst.offxml'] 
+fnms                      ['smirnoff99Frosst_experimental.offxml'] 
 priors                    OrderedDict([('HarmonicBondForce/Bond/k', 10.0), ('HarmonicBondForce/Bond/length', 0.01), ('HarmonicAngleForce/Angle/k', 10.0), ('HarmonicAngleForce/Angle/angle', 10.0), ('PeriodicTorsionForce/Proper/k1', 1.0), ('NonbondedForce/Atom/epsilon', 0.01), ('NonbondedForce/Atom/rmin_half', 0.1)]) 
 ----------------------------------------------------------
-Backing up: optimize.tmp/optgeo to: optimize.bak/optgeo_8.tar.bz2
-Reading interactions from file: targets/optgeo/optgeo_options.txt
-Building internal coordinates from file: /home2/qyd/projects/forcebalance-dev/studies/022_opt_geo_target/targets/optgeo/conf.pdb
+Backing up: optimize.tmp/optgeo to: optimize.bak/optgeo_32.tar.bz2
+Reading optgeo options from file: targets/optgeo/optgeo_options.txt
+pname Bonds/Bond/k/[#6X3:1]-[#6X3:2] mathid [0] -> smirks [#6X3:1]-[#6X3:2]
+pname Bonds/Bond/length/[#6X3:1]:[#6X3:2] mathid [1] -> smirks [#6X3:1]:[#6X3:2]
+pname Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2] mathid [2] -> smirks [#6X3a:1]-[#8X2H0:2]
+pname Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2] mathid [3] -> smirks [#6X3a:1]-[#8X2H0:2]
+pname Bonds/Bond/k/[#6X4:1]-[#1:2] mathid [4] -> smirks [#6X4:1]-[#1:2]
+pname Bonds/Bond/length/[#6X4:1]-[#1:2] mathid [5] -> smirks [#6X4:1]-[#1:2]
+pname Bonds/Bond/k/[#6X3:1]-[#1:2] mathid [6] -> smirks [#6X3:1]-[#1:2]
+pname Bonds/Bond/length/[#6X3:1]-[#1:2] mathid [7] -> smirks [#6X3:1]-[#1:2]
+pname Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3] mathid [8] -> smirks [#1:1]-[#6X4:2]-[#1:3]
+pname Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3] mathid [9] -> smirks [#1:1]-[#6X4:2]-[#1:3]
+pname Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3] mathid [10] -> smirks [*:1]~[#6X3:2]~[*:3]
+pname Angles/Angle/k/[*:1]~[#6X3:2]~[*:3] mathid [11] -> smirks [*:1]~[#6X3:2]~[*:3]
+pname Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3] mathid [12] -> smirks [#1:1]-[#6X3:2]~[*:3]
+pname Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3] mathid [13] -> smirks [#1:1]-[#6X3:2]~[*:3]
+pname Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3] mathid [14] -> smirks [#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+pname Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3] mathid [15] -> smirks [#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+pname ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4] mathid [16] -> smirks [*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+pname ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4] mathid [17] -> smirks [*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+pname vdW/Atom/epsilon/[#1:1]-[#6X4] mathid [18] -> smirks [#1:1]-[#6X4]
+pname vdW/Atom/rmin_half/[#1:1]-[#6X4] mathid [19] -> smirks [#1:1]-[#6X4]
+pname vdW/Atom/epsilon/[#1:1]-[#6X3] mathid [20] -> smirks [#1:1]-[#6X3]
+pname vdW/Atom/rmin_half/[#1:1]-[#6X3] mathid [21] -> smirks [#1:1]-[#6X3]
+pname vdW/Atom/epsilon/[#6X4:1] mathid [22] -> smirks [#6X4:1]
+pname vdW/Atom/rmin_half/[#6X4:1] mathid [23] -> smirks [#6X4:1]
+pname vdW/Atom/epsilon/[#8X2H0+0:1] mathid [24] -> smirks [#8X2H0+0:1]
+pname vdW/Atom/rmin_half/[#8X2H0+0:1] mathid [25] -> smirks [#8X2H0+0:1]
+pname Bonds/Bond/k/[#6X3:1]:[#6X3:2] mathid [0] -> smirks [#6X3:1]:[#6X3:2]
 #========================================================#
 #| [92m             Setup for target optgeo :              [0m |#
 #========================================================#
@@ -149,7 +184,7 @@ tgtdir                    targets/optgeo
 optgeo_options            targets/optgeo/optgeo_options.txt 
 writelevel                1 
 ----------------------------------------------------------
-Backing up: optimize.tmp/vibration to: optimize.bak/vibration_2.tar.bz2
+Backing up: optimize.tmp/vibration to: optimize.bak/vibration_23.tar.bz2
 #========================================================#
 #| [92m            Setup for target vibration :            [0m |#
 #========================================================#
@@ -162,6 +197,40 @@ type                      VIBRATION_SMIRNOFF
 tgtdir                    targets/vibration 
 denom                     200.0 
 ----------------------------------------------------------
+#========================================================#
+#| [92m        SMIRNOFF Parameter Coverage Analysis        [0m |#
+#========================================================#
+Force field assignment data written to /home/leeping/src/forcebalance/studies/022_opt_geo_target/smirnoff_parameter_assignments.json
+ idx Parameter                                                                                                   Count
+----------------------------------------------------------------------------------------------------------------------
+   0 Bonds/Bond/k/[#6X3:1]-[#6X3:2]                                                                       :          0
+   1 Bonds/Bond/length/[#6X3:1]:[#6X3:2]                                                                  :         24
+   2 Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]                                                                    :          4
+   3 Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]                                                               :          4
+   4 Bonds/Bond/k/[#6X4:1]-[#1:2]                                                                         :          4
+   5 Bonds/Bond/length/[#6X4:1]-[#1:2]                                                                    :          4
+   6 Bonds/Bond/k/[#6X3:1]-[#1:2]                                                                         :         16
+   7 Bonds/Bond/length/[#6X3:1]-[#1:2]                                                                    :         16
+   8 Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]                                                            :          2
+   9 Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]                                                                :          2
+  10 Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]                                                              :         40
+  11 Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]                                                                  :         40
+  12 Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]                                                             :         32
+  13 Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]                                                                 :         32
+  14 Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]                                              :          2
+  15 Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]                                                  :          2
+  16 ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]                                               :         96
+  17 ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]                                               :          0
+  18 vdW/Atom/epsilon/[#1:1]-[#6X4]                                                                       :          4
+  19 vdW/Atom/rmin_half/[#1:1]-[#6X4]                                                                     :          4
+  20 vdW/Atom/epsilon/[#1:1]-[#6X3]                                                                       :         16
+  21 vdW/Atom/rmin_half/[#1:1]-[#6X3]                                                                     :         16
+  22 vdW/Atom/epsilon/[#6X4:1]                                                                            :          2
+  23 vdW/Atom/rmin_half/[#6X4:1]                                                                          :          2
+  24 vdW/Atom/epsilon/[#8X2H0+0:1]                                                                        :          2
+  25 vdW/Atom/rmin_half/[#8X2H0+0:1]                                                                      :          2
+SNIRNOFF Parameter Coverage Analysis result: 24/26 parameters are covered.
+----------------------------------------------------------------------------------------------------------------------
 Using parabolic regularization (Gaussian prior) with strength 1.0e+00 (+), 0.0e+00 (x)
 #========================================================#
 #| [92m           Setup for objective function :           [0m |#
@@ -173,11 +242,11 @@ normalize_weights         False
 #| [92m                Setup for optimizer                 [0m |#
 #========================================================#
 jobtype                   OPTIMIZE 
-trust0                    0.25 
+trust0                    -0.1 
 mintrust                  0.05 
 eps                       0.01 
 convergence_objective     0.1 
-convergence_step          0.1 
+convergence_step          0.01 
 convergence_gradient      0.1 
 adapt_fac                 0.2 
 adapt_damp                1.0 
@@ -186,12 +255,12 @@ input_file                optimize.in
 ----------------------------------------------------------
 #========================================================#
 #| [1m                  Main Optimizer                    [0m |#
-#| [1m   Newton-Raphson Method (Adaptive Trust Radius)    [0m |#
+#| [1m  Newton-Raphson Method (Hessian Diagonal Search)   [0m |#
 #| [1m                                                    [0m |#
 #| [1m       [0mConvergence criteria (1 of 3 needed):        [0m |#
 #| [1m          [0mObjective Function  : 1.000e-01           [0m |#
 #| [1m          [0mNorm of Gradient    : 1.000e-01           [0m |#
-#| [1m          [0mParameter step size : 1.000e-01           [0m |#
+#| [1m          [0mParameter step size : 1.000e-02           [0m |#
 #========================================================#
 #========================================================#
 #|       Color Key for Objective Function -=X2=-        |#
@@ -206,206 +275,226 @@ input_file                optimize.in
 #========================================================#
 
 #======================================================================================================================#
-#| [92m                                  Optimized Geometries, Objective =  5.48557e+00                                  [0m |#
+#| [92m                                         optgeo, Objective =  5.60077e+00                                         [0m |#
 #| [92m  System                       Bonds            Angles           Dihedrals         Impropers               Term.  [0m |#
 #| [92m                            RMSD   denom      RMSD   denom      RMSD   denom      RMSD   denom                    [0m |#
 #======================================================================================================================#
-9HXanthene                    0.021    0.01     0.027    0.03     0.076    0.20     0.005    0.20             5.486 
+9HXanthene                    0.022    0.01     0.026    0.03     0.076    0.20     0.005    0.20             5.601 
 ------------------------------------------------------------------------------------------------------------------------
 
 #==========================================================================#
 #|                       Frequencies (wavenumbers)                        |#
-#|  Target: vibration  Type: Vibration_SMIRNOFF  Objective = 2.32082e+01  |#
+#|  Target: vibration  Type: Vibration_SMIRNOFF  Objective = 1.63529e+01  |#
 #|  Mode #            Reference   Calculated   Difference   Ref(dot)Calc  |#
 #==========================================================================#
-    0                   31.1817      39.5880       8.4063         0.9917 
-    1                  127.2863     137.0455       9.7592         0.9969 
-    2                  200.5311     228.9315      28.4004         0.9372 
-    3                  245.4174     234.9776     -10.4398         0.9372 
-    4                  258.8788     240.5108     -18.3680         0.9955 
-    5                  295.5887     307.4914      11.9027         0.9868 
-    6                  385.5805     343.9707     -41.6098         0.9888 
-    7                  413.3227     432.0155      18.6928         0.0037 
-    8                  461.1571     437.3206     -23.8365         0.0006 
-    9                  468.4759     443.7455     -24.7304         0.9877 
-    10                 553.9686     505.7497     -48.2189         0.9592 
-    11                 557.9183     524.8687     -33.0496         0.9531 
-    12                 559.2968     558.3256      -0.9712         0.9390 
-    13                 609.7540     622.7650      13.0110         0.0013 
-    14                 650.9588     634.9113     -16.0475         0.0037 
-    15                 691.9021     663.3716     -28.5305         0.7621 
-    16                 731.3959     690.2186     -41.1773         0.9542 
-    17                 748.6224     711.4277     -37.1947         0.9897 
-    18                 757.4865     733.1037     -24.3828         0.9530 
-    19                 793.4162     791.2665      -2.1497         0.0493 
-    20                 796.3137     791.3024      -5.0113         0.0481 
-    21                 829.9391     798.9558     -30.9833         0.9768 
-    22                 886.2937     885.6260      -0.6677         0.0059 
-    23                 898.9488     892.3635      -6.5853         0.3125 
-    24                 905.1053     912.2779       7.1726         0.0659 
-    25                 931.8180     954.5618      22.7438         0.0033 
-    26                 972.6908     973.1083       0.4175         0.3438 
-    27                 981.1443    1019.3588      38.2145         0.0018 
-    28                1002.3531    1034.2162      31.8631         0.0023 
-    29                1002.6108    1093.8774      91.2666         0.0577 
-    30                1006.9971    1096.9093      89.9122         0.4570 
-    31                1043.4229    1148.9419     105.5190         0.0009 
-    32                1045.2039    1171.7953     126.5914         0.0007 
-    33                1101.4212    1172.1451      70.7239         0.0015 
-    34                1122.1664    1172.7740      50.6076         0.7413 
-    35                1175.8590    1208.0771      32.2181         0.0606 
-    36                1177.5535    1226.4928      48.9393         0.0211 
-    37                1180.0345    1285.3706     105.3361         0.0051 
-    38                1198.0738    1285.9386      87.8648         0.0002 
-    39                1209.4283    1294.0627      84.6344         0.1762 
-    40                1213.4868    1321.5111     108.0243         0.0302 
-    41                1233.7197    1331.1122      97.3925         0.0215 
-    42                1248.6007    1429.5401     180.9394         0.0041 
-    43                1296.1008    1451.5319     155.4311         0.7927 
-    44                1311.1904    1492.1654     180.9750         0.1158 
-    45                1325.6114    1570.3027     244.6913         0.0318 
-    46                1351.5363    1660.5989     309.0626         0.0045 
-    47                1456.1390    1674.9029     218.7639         0.8023 
-    48                1461.1551    1699.6550     238.4999         0.0132 
-    49                1467.0845    1717.3464     250.2619         0.3477 
-    50                1486.3167    1757.5737     271.2570         0.6228 
-    51                1498.4933    1775.8689     277.3756         0.3020 
-    52                1571.5221    1814.6929     243.1708         0.5892 
-    53                1591.5923    1815.5314     223.9391         0.6939 
-    54                1597.5166    1847.2643     249.7477         0.0303 
-    55                1620.6702    1875.4551     254.7849         0.0292 
-    56                2881.8985    2911.1127      29.2142         0.8773 
-    57                2918.3100    2981.1389      62.8289         0.8759 
-    58                3057.8158    3066.2460       8.4302         0.3032 
-    59                3058.9610    3066.2905       7.3295         0.2553 
-    60                3076.7507    3066.3656     -10.3851         0.4442 
-    61                3076.9099    3066.3993     -10.5106         0.4796 
-    62                3093.3546    3067.2109     -26.1437         0.0798 
-    63                3093.7472    3067.2203     -26.5269         0.0626 
-    64                3108.9905    3068.2866     -40.7039         0.7017 
-    65                3109.6289    3068.3759     -41.2530         0.7082 
+    0                   31.1817      59.1509      27.9692         0.9889 
+    1                  127.2863     138.1796      10.8933         0.9964 
+    2                  200.5311     226.9475      26.4164         0.9293 
+    3                  245.4174     233.4222     -11.9952         0.9369 
+    4                  258.8788     237.7302     -21.1486         0.9954 
+    5                  295.5887     328.3613      32.7726         0.9643 
+    6                  385.5805     339.2087     -46.3718         0.9883 
+    7                  413.3227     422.1269       8.8042         0.0037 
+    8                  461.1571     432.3367     -28.8204         0.0005 
+    9                  468.4759     437.7756     -30.7003         0.9870 
+    10                 553.9686     496.0575     -57.9111         0.9586 
+    11                 557.9183     538.5051     -19.4132         0.9233 
+    12                 559.2968     553.8717      -5.4251         0.9377 
+    13                 609.7540     614.2380       4.4840         0.0013 
+    14                 650.9588     626.0091     -24.9497         0.0038 
+    15                 691.9021     651.5243     -40.3778         0.7263 
+    16                 731.3959     690.6470     -40.7489         0.9425 
+    17                 748.6224     698.8110     -49.8114         0.9911 
+    18                 757.4865     714.2426     -43.2439         0.9216 
+    19                 793.4162     765.1066     -28.3096         0.0494 
+    20                 796.3137     769.5714     -26.7423         0.0027 
+    21                 829.9391     770.2690     -59.6701         0.0015 
+    22                 886.2937     876.8456      -9.4481         0.0056 
+    23                 898.9488     887.2329     -11.7159         0.3103 
+    24                 905.1053     899.3195      -5.7858         0.0788 
+    25                 931.8180     924.3367      -7.4813         0.0033 
+    26                 972.6908     952.1554     -20.5354         0.4205 
+    27                 981.1443     969.2404     -11.9039         0.0018 
+    28                1002.3531     988.5139     -13.8392         0.0022 
+    29                1002.6108    1061.4178      58.8070         0.0592 
+    30                1006.9971    1064.7993      57.8022         0.4661 
+    31                1043.4229    1111.3572      67.9343         0.0072 
+    32                1045.2039    1134.9794      89.7755         0.0183 
+    33                1101.4212    1137.0113      35.5901         0.0177 
+    34                1122.1664    1137.3491      15.1827         0.0231 
+    35                1175.8590    1188.4798      12.6208         0.0868 
+    36                1177.5535    1198.1008      20.5473         0.1143 
+    37                1180.0345    1263.1525      83.1180         0.0109 
+    38                1198.0738    1267.5931      69.5193         0.0024 
+    39                1209.4283    1285.2813      75.8530         0.8708 
+    40                1213.4868    1291.6105      78.1237         0.0261 
+    41                1233.7197    1308.4152      74.6955         0.0190 
+    42                1248.6007    1418.0212     169.4205         0.0084 
+    43                1296.1008    1442.0352     145.9344         0.5166 
+    44                1311.1904    1482.3771     171.1867         0.1863 
+    45                1325.6114    1567.7639     242.1525         0.0370 
+    46                1351.5363    1619.5299     267.9936         0.4541 
+    47                1456.1390    1644.7712     188.6322         0.0236 
+    48                1461.1551    1664.8380     203.6829         0.0310 
+    49                1467.0845    1670.6934     203.6089         0.2365 
+    50                1486.3167    1711.8776     225.5609         0.0585 
+    51                1498.4933    1717.3606     218.8673         0.0762 
+    52                1571.5221    1753.5068     181.9847         0.5970 
+    53                1591.5923    1755.8471     164.2548         0.7103 
+    54                1597.5166    1793.3017     195.7851         0.0303 
+    55                1620.6702    1825.8107     205.1405         0.0284 
+    56                2881.8985    2910.8170      28.9185         0.8773 
+    57                2918.3100    2981.0460      62.7360         0.8759 
+    58                3057.8158    3064.2002       6.3844         0.3510 
+    59                3058.9610    3064.3613       5.4003         0.3058 
+    60                3076.7507    3064.7347     -12.0160         0.2361 
+    61                3076.9099    3064.8123     -12.0976         0.2433 
+    62                3093.3546    3065.4833     -27.8713         0.0885 
+    63                3093.7472    3065.5292     -28.2180         0.1397 
+    64                3108.9905    3066.4682     -42.5223         0.7988 
+    65                3109.6289    3066.8364     -42.7925         0.8207 
 ----------------------------------------------------------------------------
 #====================================================================#
 #| [94m                  Objective Function Breakdown                  [0m |#
 #| [94m  Target Name              Residual  x  Weight  =  Contribution [0m |#
 #====================================================================#
-optgeo                         5.48557      1.000 [94m     5.48557e+00[0m 
-vibration                     23.20816      1.000 [94m     2.32082e+01[0m 
+optgeo                         5.60077      1.000 [94m     5.60077e+00[0m 
+vibration                     16.35288      1.000 [94m     1.63529e+01[0m 
 Regularization                 0.00000      1.000 [94m     0.00000e+00[0m 
-Total                                             [94m     2.86937e+01[0m 
+Total                                             [94m     2.19537e+01[0m 
 ----------------------------------------------------------------------
 
   Step       |k|        |dk|       |grad|       -=X2=-     Delta(X2)    StepQual
-     0   0.000e+00   0.000e+00   7.817e+00[1m   2.86937e+01[0m   0.000e+00      0.000
+     0   0.000e+00   0.000e+00   2.654e+02[1m   2.19537e+01[0m   0.000e+00      0.000
 
 #========================================================#
 #| [94m                   Total Gradient                   [0m |#
 #========================================================#
-   0 [  6.29042981e-01 ] : HarmonicBondForce/Bond/k/[#6X3:1]:[#6X3:2]
-   1 [  4.23735228e-01 ] : HarmonicBondForce/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [  9.62440887e-02 ] : HarmonicBondForce/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [ -1.09489786e+00 ] : HarmonicBondForce/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [  1.00825973e-01 ] : HarmonicBondForce/Bond/k/[#6X4:1]-[#1:2]
-   5 [ -4.19242952e-01 ] : HarmonicBondForce/Bond/length/[#6X4:1]-[#1:2]
-   6 [ -1.36536618e-01 ] : HarmonicBondForce/Bond/k/[#6X3:1]-[#1:2]
-   7 [ -1.52105505e+00 ] : HarmonicBondForce/Bond/length/[#6X3:1]-[#1:2]
-   8 [  8.93835352e-01 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [  6.38068999e-01 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [ -6.91093191e-01 ] : HarmonicAngleForce/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [  8.26022914e-01 ] : HarmonicAngleForce/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [  3.15869209e+00 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [  6.12011968e+00 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [  1.17589942e+00 ] : HarmonicAngleForce/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [  8.89654096e-04 ] : HarmonicAngleForce/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [  2.30097697e+00 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
-  17 [ -5.12733496e-02 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [  9.31081803e-02 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X4]
-  19 [  1.25324037e-01 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [  3.23168484e-01 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X3]
-  21 [  4.37535178e-01 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [  4.60446228e-03 ] : NonbondedForce/Atom/epsilon/[#6X4:1]
-  23 [  3.55062796e-02 ] : NonbondedForce/Atom/rmin_half/[#6X4:1]
-  24 [  3.63633287e-03 ] : NonbondedForce/Atom/epsilon/[#8X2H0+0:1]
-  25 [  4.59623839e-02 ] : NonbondedForce/Atom/rmin_half/[#8X2H0+0:1]
+   0 [  4.41764031e+01 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [  8.06913714e+01 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [  7.77711193e+00 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [ -1.53864038e+02 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [  8.97283289e+00 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [ -5.33406770e+01 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [ -1.37984988e+01 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [ -1.70363979e+02 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [  1.05168255e+01 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [  7.91094133e+00 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [ -1.34572642e+01 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [  9.40186191e+00 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [  8.34240806e+00 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [  7.28754349e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [  1.42241302e+01 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [ -1.07191023e-01 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [  2.26687326e-01 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  0.00000000e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [  1.25197866e+00 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [  1.89778833e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [  4.75651899e+00 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [  7.18732208e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  4.40975946e-02 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  4.24312354e-01 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [  4.72051166e-02 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [  6.52015727e-01 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
 ----------------------------------------------------------
 Calculating nonlinear optimization step
-Finding trust radius: H+0.0000*I, length 2.2392e+00 (target 2.5000e-01)
-Finding trust radius: H+9.0000*I, length 5.8235e-01 (target 2.5000e-01)
-Finding trust radius: H+61.6869*I, length 1.1590e-01 (target 2.5000e-01)
-Finding trust radius: H+30.0993*I, length 2.2082e-01 (target 2.5000e-01)
-Finding trust radius: H+30.0993*I, length 2.2082e-01 (target 2.5000e-01)
-Finding trust radius: H+20.5808*I, length 3.0534e-01 (target 2.5000e-01)
-Finding trust radius: H+40.8412*I, length 1.6864e-01 (target 2.5000e-01)
-Finding trust radius: H+27.6613*I, length 2.3759e-01 (target 2.5000e-01)
-Finding trust radius: H+26.6996*I, length 2.4494e-01 (target 2.5000e-01)
-Finding trust radius: H+25.8184*I, length 2.5210e-01 (target 2.5000e-01)
-Finding trust radius: H+26.0609*I, length 2.5008e-01 (target 2.5000e-01)
-Finding trust radius: H+26.0751*I, length 2.4997e-01 (target 2.5000e-01)
-Finding trust radius: H+26.0711*I, length 2.5000e-01 (target 2.5000e-01)
-Finding trust radius: H+26.0712*I, length 2.5000e-01 (target 2.5000e-01)
-Finding trust radius: H+26.0713*I, length 2.5000e-01 (target 2.5000e-01)
-Trust-radius step found (length 2.5000e-01),  2.6071e+01 added to Hessian diagonal
+Finding trust radius: H+0.0000*I, length 6.4421e-01 (target 1.0000e-01)
+Finding trust radius: H+9.0000*I, length 3.2061e-01 (target 1.0000e-01)
+Finding trust radius: H+61.6869*I, length 1.9578e-01 (target 1.0000e-01)
+Finding trust radius: H+34.3013*I, length 2.2304e-01 (target 1.0000e-01)
+Finding trust radius: H+246.7477*I, length 1.4369e-01 (target 1.0000e-01)
+Finding trust radius: H+158.6628*I, length 1.5994e-01 (target 1.0000e-01)
+Finding trust radius: H+807.4923*I, length 9.6018e-02 (target 1.0000e-01)
+Finding trust radius: H+577.7227*I, length 1.0986e-01 (target 1.0000e-01)
+Finding trust radius: H+2398.9145*I, length 5.5269e-02 (target 1.0000e-01)
+Finding trust radius: H+807.4923*I, length 9.6018e-02 (target 1.0000e-01)
+Finding trust radius: H+1315.5499*I, length 7.6549e-02 (target 1.0000e-01)
+Finding trust radius: H+555.1823*I, length 1.1150e-01 (target 1.0000e-01)
+Finding trust radius: H+764.2909*I, length 9.8280e-02 (target 1.0000e-01)
+Finding trust radius: H+739.3851*I, length 9.9647e-02 (target 1.0000e-01)
+Finding trust radius: H+731.9794*I, length 1.0006e-01 (target 1.0000e-01)
+Finding trust radius: H+733.0323*I, length 1.0000e-01 (target 1.0000e-01)
+Finding trust radius: H+733.1843*I, length 9.9995e-02 (target 1.0000e-01)
+Finding trust radius: H+732.8803*I, length 1.0001e-01 (target 1.0000e-01)
+Starting Hessian diagonal search with step size 1.0000e-01
+Hessian diagonal search: H+733.0323*I, length 1.0000e-01, result  1.1864e+01
+Hessian diagonal search: H+12387.3064*I, length 1.7383e-02, result -3.3540e+00
+Hessian diagonal search: H+61293.4299*I, length 4.1266e-03, result -1.0259e+00
+Hessian diagonal search: H+12387.3064*I, length 1.7383e-02, result -3.3540e+00
+Hessian diagonal search: H+26683.6765*I, length 8.9490e-03, result -2.0479e+00
+Hessian diagonal search: H+6261.1904*I, length 2.9506e-02, result -4.1592e+00
+Hessian diagonal search: H+3509.9895*I, length 4.3795e-02, result -3.5622e+00
+Hessian diagonal search: H+6952.2969*I, length 2.7323e-02, result -4.1004e+00
+Hessian diagonal search: H+5998.5990*I, length 3.0434e-02, result -4.1723e+00
+Hessian diagonal search: H+4969.7927*I, length 3.4753e-02, result -4.1369e+00
+Hessian diagonal search: H+5727.1403*I, length 3.1460e-02, result -4.1782e+00
+Hessian diagonal search: H+5666.7778*I, length 3.1698e-02, result -4.1783e+00
+Hessian diagonal search: H+5685.0884*I, length 3.1625e-02, result -4.1783e+00
+Hessian diagonal search: H+5686.2405*I, length 3.1621e-02, result -4.1783e+00
+Hessian diagonal search: H+5682.6859*I, length 3.1635e-02, result -4.1783e+00
+Hessian diagonal search: H+5683.9363*I, length 3.1630e-02, result -4.1783e+00
+Optimization step found (length 3.1625e-02)
 #========================================================#
 #| [95m  Mathematical Parameters (Current + Step = Next)   [0m |#
 #========================================================#
-   0 [  0.0000e+00 - 2.1658e-02 = -2.1658e-02 ] : HarmonicBondForce/Bond/k/[#6X3:1]:[#6X3:2]
-   1 [  0.0000e+00 - 1.5499e-02 = -1.5499e-02 ] : HarmonicBondForce/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [  0.0000e+00 - 3.3086e-03 = -3.3086e-03 ] : HarmonicBondForce/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [  0.0000e+00 + 3.8515e-02 =  3.8515e-02 ] : HarmonicBondForce/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [  0.0000e+00 - 3.5830e-03 = -3.5830e-03 ] : HarmonicBondForce/Bond/k/[#6X4:1]-[#1:2]
-   5 [  0.0000e+00 + 1.4582e-02 =  1.4582e-02 ] : HarmonicBondForce/Bond/length/[#6X4:1]-[#1:2]
-   6 [  0.0000e+00 + 4.8760e-03 =  4.8760e-03 ] : HarmonicBondForce/Bond/k/[#6X3:1]-[#1:2]
-   7 [  0.0000e+00 + 5.0631e-02 =  5.0631e-02 ] : HarmonicBondForce/Bond/length/[#6X3:1]-[#1:2]
-   8 [  0.0000e+00 - 3.0446e-02 = -3.0446e-02 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [  0.0000e+00 - 2.2106e-02 = -2.2106e-02 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [  0.0000e+00 + 2.7732e-02 =  2.7732e-02 ] : HarmonicAngleForce/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [  0.0000e+00 - 2.8116e-02 = -2.8116e-02 ] : HarmonicAngleForce/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [  0.0000e+00 - 7.6431e-02 = -7.6431e-02 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [  0.0000e+00 - 2.0970e-01 = -2.0970e-01 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [  0.0000e+00 - 4.1109e-02 = -4.1109e-02 ] : HarmonicAngleForce/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [  0.0000e+00 + 6.4454e-06 =  6.4454e-06 ] : HarmonicAngleForce/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [  0.0000e+00 - 5.1256e-02 = -5.1256e-02 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
-  17 [  0.0000e+00 + 2.0210e-03 =  2.0210e-03 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [  0.0000e+00 - 3.2216e-03 = -3.2216e-03 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X4]
-  19 [  0.0000e+00 - 4.3314e-03 = -4.3314e-03 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [  0.0000e+00 - 1.0968e-02 = -1.0968e-02 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X3]
-  21 [  0.0000e+00 - 1.4817e-02 = -1.4817e-02 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [  0.0000e+00 - 1.4900e-04 = -1.4900e-04 ] : NonbondedForce/Atom/epsilon/[#6X4:1]
-  23 [  0.0000e+00 - 1.1381e-03 = -1.1381e-03 ] : NonbondedForce/Atom/rmin_half/[#6X4:1]
-  24 [  0.0000e+00 - 1.1816e-04 = -1.1816e-04 ] : NonbondedForce/Atom/epsilon/[#8X2H0+0:1]
-  25 [  0.0000e+00 - 1.4725e-03 = -1.4725e-03 ] : NonbondedForce/Atom/rmin_half/[#8X2H0+0:1]
+   0 [  0.0000e+00 - 6.6980e-03 = -6.6980e-03 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [  0.0000e+00 - 6.8872e-03 = -6.8872e-03 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [  0.0000e+00 - 1.1571e-03 = -1.1571e-03 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  0.0000e+00 + 1.5559e-02 =  1.5559e-02 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [  0.0000e+00 - 1.4773e-03 = -1.4773e-03 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  0.0000e+00 + 6.9353e-03 =  6.9353e-03 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [  0.0000e+00 + 1.9753e-03 =  1.9753e-03 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  0.0000e+00 + 2.1787e-02 =  2.1787e-02 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [  0.0000e+00 - 1.6047e-03 = -1.6047e-03 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [  0.0000e+00 - 1.2080e-03 = -1.2080e-03 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [  0.0000e+00 + 2.4450e-03 =  2.4450e-03 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [  0.0000e+00 - 1.4200e-03 = -1.4200e-03 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [  0.0000e+00 + 1.0860e-03 =  1.0860e-03 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [  0.0000e+00 - 1.0810e-02 = -1.0810e-02 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [  0.0000e+00 - 1.8520e-03 = -1.8520e-03 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [  0.0000e+00 + 1.0402e-05 =  1.0402e-05 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [  0.0000e+00 + 6.1563e-04 =  6.1563e-04 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  0.0000e+00 - 1.7438e-20 = -1.7438e-20 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [  0.0000e+00 - 1.8325e-04 = -1.8325e-04 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [  0.0000e+00 - 2.7552e-04 = -2.7552e-04 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [  0.0000e+00 - 6.9613e-04 = -6.9613e-04 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [  0.0000e+00 - 1.0502e-03 = -1.0502e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  0.0000e+00 - 5.9446e-06 = -5.9446e-06 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  0.0000e+00 - 5.5130e-05 = -5.5130e-05 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [  0.0000e+00 - 8.3738e-06 = -8.3738e-06 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [  0.0000e+00 - 1.2985e-04 = -1.2985e-04 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
 ----------------------------------------------------------
 #========================================================#
 #| [95m    Physical Parameters (Current + Step = Next)     [0m |#
 #========================================================#
-   0 [  9.3800e+02 - 2.1658e-01 =  9.3778e+02 ] : HarmonicBondForce/Bond/k/[#6X3:1]:[#6X3:2]
-   1 [  1.4000e+00 - 1.5499e-04 =  1.3998e+00 ] : HarmonicBondForce/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [  9.0000e+02 - 3.3086e-02 =  8.9997e+02 ] : HarmonicBondForce/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [  1.3230e+00 + 3.8515e-04 =  1.3234e+00 ] : HarmonicBondForce/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [  6.8000e+02 - 3.5830e-02 =  6.7996e+02 ] : HarmonicBondForce/Bond/k/[#6X4:1]-[#1:2]
-   5 [  1.0900e+00 + 1.4582e-04 =  1.0901e+00 ] : HarmonicBondForce/Bond/length/[#6X4:1]-[#1:2]
-   6 [  7.3400e+02 + 4.8760e-02 =  7.3405e+02 ] : HarmonicBondForce/Bond/k/[#6X3:1]-[#1:2]
-   7 [  1.0800e+00 + 5.0631e-04 =  1.0805e+00 ] : HarmonicBondForce/Bond/length/[#6X3:1]-[#1:2]
-   8 [  1.0950e+02 - 3.0446e-01 =  1.0920e+02 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [  7.0000e+01 - 2.2106e-01 =  6.9779e+01 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [  1.2000e+02 + 2.7732e-01 =  1.2028e+02 ] : HarmonicAngleForce/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [  1.4000e+02 - 2.8116e-01 =  1.3972e+02 ] : HarmonicAngleForce/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [  1.2000e+02 - 7.6431e-01 =  1.1924e+02 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [  1.0000e+02 - 2.0970e+00 =  9.7903e+01 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [  1.2000e+02 - 4.1109e-01 =  1.1959e+02 ] : HarmonicAngleForce/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [  1.4000e+02 + 6.4454e-05 =  1.4000e+02 ] : HarmonicAngleForce/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [  3.6250e+00 - 5.1256e-02 =  3.5737e+00 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
-  17 [  1.0500e+00 + 2.0210e-03 =  1.0520e+00 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [  1.5700e-02 - 3.2216e-05 =  1.5668e-02 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X4]
-  19 [  1.4870e+00 - 4.3314e-04 =  1.4866e+00 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [  1.5000e-02 - 1.0968e-04 =  1.4890e-02 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X3]
-  21 [  1.4590e+00 - 1.4817e-03 =  1.4575e+00 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [  1.0940e-01 - 1.4900e-06 =  1.0940e-01 ] : NonbondedForce/Atom/epsilon/[#6X4:1]
-  23 [  1.9080e+00 - 1.1381e-04 =  1.9079e+00 ] : NonbondedForce/Atom/rmin_half/[#6X4:1]
-  24 [  1.7000e-01 - 1.1816e-06 =  1.7000e-01 ] : NonbondedForce/Atom/epsilon/[#8X2H0+0:1]
-  25 [  1.6837e+00 - 1.4725e-04 =  1.6836e+00 ] : NonbondedForce/Atom/rmin_half/[#8X2H0+0:1]
+   0 [  8.2000e+02 - 6.0282e+00 =  8.1397e+02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [  1.4000e+00 - 9.6420e-03 =  1.3904e+00 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [  9.0000e+02 - 1.0414e+00 =  8.9896e+02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  1.3230e+00 + 2.1783e-02 =  1.3448e+00 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [  6.8000e+02 - 1.3296e+00 =  6.7867e+02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  1.0900e+00 + 9.7095e-03 =  1.0997e+00 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [  7.3400e+02 + 1.7778e+00 =  7.3578e+02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  1.0800e+00 + 3.0501e-02 =  1.1105e+00 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [  1.0950e+02 - 1.9256e-01 =  1.0931e+02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [  7.0000e+01 - 1.6912e-01 =  6.9831e+01 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [  1.2000e+02 + 2.9341e-01 =  1.2029e+02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [  1.4000e+02 - 1.9880e-01 =  1.3980e+02 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [  1.2000e+02 + 1.3032e-01 =  1.2013e+02 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [  1.0000e+02 - 1.5134e+00 =  9.8487e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [  1.2000e+02 - 2.2224e-01 =  1.1978e+02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [  1.4000e+02 + 1.4562e-03 =  1.4000e+02 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [  3.6250e+00 + 2.2316e-03 =  3.6272e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  1.0500e+00 + 0.0000e+00 =  1.0500e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [  1.5700e-02 - 3.1153e-05 =  1.5669e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [  1.4870e+00 - 5.2569e-04 =  1.4865e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [  1.5000e-02 - 1.1834e-04 =  1.4882e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [  1.4590e+00 - 2.0038e-03 =  1.4570e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  1.0940e-01 - 1.0106e-06 =  1.0940e-01 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  1.9080e+00 - 1.0519e-04 =  1.9079e+00 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [  1.7000e-01 - 1.4235e-06 =  1.7000e-01 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [  1.6837e+00 - 2.4775e-04 =  1.6835e+00 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
 ----------------------------------------------------------
-Backing up optimize.sav -> optimize.bak/optimize_8.sav
+Backing up optimize.sav -> optimize.bak/optimize_6.sav
 Input file with saved parameters: optimize.sav
 #========================================================#
 #| [94m     Iteration 1: Evaluating objective function     [0m |#
@@ -413,211 +502,235 @@ Input file with saved parameters: optimize.sav
 #========================================================#
 
 #======================================================================================================================#
-#| [92m                                  Optimized Geometries, Objective =  5.35245e+00                                  [0m |#
+#| [92m                                         optgeo, Objective =  5.08226e+00                                         [0m |#
 #| [92m  System                       Bonds            Angles           Dihedrals         Impropers               Term.  [0m |#
 #| [92m                            RMSD   denom      RMSD   denom      RMSD   denom      RMSD   denom                    [0m |#
 #======================================================================================================================#
-9HXanthene                    0.021    0.01     0.026    0.03     0.076    0.20     0.005    0.20             5.352 
+9HXanthene                    0.021    0.01     0.025    0.03     0.076    0.20     0.005    0.20             5.082 
 ------------------------------------------------------------------------------------------------------------------------
 
 #==========================================================================#
 #|                       Frequencies (wavenumbers)                        |#
-#|  Target: vibration  Type: Vibration_SMIRNOFF  Objective = 2.15041e+01  |#
+#|  Target: vibration  Type: Vibration_SMIRNOFF  Objective = 1.26921e+01  |#
 #|  Mode #            Reference   Calculated   Difference   Ref(dot)Calc  |#
 #==========================================================================#
-    0                   31.1817      39.2174       8.0357         0.9917 
-    1                  127.2863     136.5470       9.2607         0.9969 
-    2                  200.5311     228.0132      27.4821         0.9373 
-    3                  245.4174     234.8837     -10.5337         0.9372 
-    4                  258.8788     239.7227     -19.1561         0.9954 
-    5                  295.5887     306.1616      10.5729         0.9869 
-    6                  385.5805     343.7071     -41.8734         0.9888 
-    7                  413.3227     433.3492      20.0265         0.0037 
-    8                  461.1571     437.0924     -24.0647         0.0006 
-    9                  468.4759     445.0837     -23.3922         0.9878 
-    10                 553.9686     506.4681     -47.5005         0.9589 
-    11                 557.9183     524.7963     -33.1220         0.9532 
-    12                 559.2968     557.2617      -2.0351         0.9392 
-    13                 609.7540     622.1573      12.4033         0.0013 
-    14                 650.9588     634.2114     -16.7474         0.0037 
-    15                 691.9021     662.3634     -29.5387         0.7531 
-    16                 731.3959     689.9542     -41.4417         0.9567 
-    17                 748.6224     712.1194     -36.5030         0.9909 
-    18                 757.4865     732.3970     -25.0895         0.9540 
-    19                 793.4162     775.1791     -18.2371         0.0495 
-    20                 796.3137     776.2063     -20.1074         0.0485 
-    21                 829.9391     798.1916     -31.7475         0.9772 
-    22                 886.2937     883.7661      -2.5276         0.0059 
-    23                 898.9488     890.4967      -8.4521         0.3125 
-    24                 905.1053     905.4626       0.3573         0.0744 
-    25                 931.8180     937.9000       6.0820         0.0034 
-    26                 972.6908     962.3348     -10.3560         0.3984 
-    27                 981.1443    1018.0116      36.8673         0.0018 
-    28                1002.3531    1032.4271      30.0740         0.0023 
-    29                1002.6108    1075.2630      72.6522         0.0577 
-    30                1006.9971    1078.5157      71.5186         0.4672 
-    31                1043.4229    1144.5871     101.1642         0.0005 
-    32                1045.2039    1151.9589     106.7550         0.0007 
-    33                1101.4212    1152.3215      50.9003         0.0015 
-    34                1122.1664    1167.7546      45.5882         0.7440 
-    35                1175.8590    1205.7250      29.8660         0.0705 
-    36                1177.5535    1223.6582      46.1047         0.0501 
-    37                1180.0345    1281.2839     101.2494         0.2796 
-    38                1198.0738    1285.1289      87.0551         0.2175 
-    39                1209.4283    1286.4727      77.0444         0.1464 
-    40                1213.4868    1315.4213     101.9345         0.0329 
-    41                1233.7197    1325.1118      91.3921         0.0219 
-    42                1248.6007    1425.2792     176.6785         0.0058 
-    43                1296.1008    1444.4540     148.3532         0.7399 
-    44                1311.1904    1486.0244     174.8340         0.1372 
-    45                1325.6114    1562.5326     236.9212         0.0307 
-    46                1351.5363    1646.6307     295.0944         0.0042 
-    47                1456.1390    1664.9867     208.8477         0.8510 
-    48                1461.1551    1694.0062     232.8511         0.0092 
-    49                1467.0845    1707.2216     240.1371         0.3512 
-    50                1486.3167    1749.2075     262.8908         0.5663 
-    51                1498.4933    1772.4410     273.9477         0.2406 
-    52                1571.5221    1807.8248     236.3027         0.5844 
-    53                1591.5923    1808.6903     217.0980         0.7009 
-    54                1597.5166    1840.2956     242.7790         0.0308 
-    55                1620.6702    1870.0033     249.3331         0.0291 
-    56                2881.8985    2911.4415      29.5430         0.8771 
-    57                2918.3100    2980.6267      62.3167         0.8761 
-    58                3057.8158    3066.2535       8.4377         0.3535 
-    59                3058.9610    3066.3001       7.3391         0.3147 
-    60                3076.7507    3066.3770     -10.3737         0.3883 
-    61                3076.9099    3066.4073     -10.5026         0.4180 
-    62                3093.3546    3067.1788     -26.1758         0.0736 
-    63                3093.7472    3067.1885     -26.5587         0.0557 
-    64                3108.9905    3068.2775     -40.7130         0.7075 
-    65                3109.6289    3068.3671     -41.2618         0.7138 
+    0                   31.1817      58.5546      27.3729         0.9896 
+    1                  127.2863     138.4285      11.1422         0.9962 
+    2                  200.5311     226.7545      26.2234         0.9297 
+    3                  245.4174     234.0549     -11.3625         0.9371 
+    4                  258.8788     238.5788     -20.3000         0.9950 
+    5                  295.5887     327.6623      32.0736         0.9671 
+    6                  385.5805     338.2137     -47.3668         0.9890 
+    7                  413.3227     426.2949      12.9722         0.0038 
+    8                  461.1571     429.3742     -31.7829         0.0005 
+    9                  468.4759     442.2267     -26.2492         0.9883 
+    10                 553.9686     500.6560     -53.3126         0.9596 
+    11                 557.9183     539.7662     -18.1521         0.9311 
+    12                 559.2968     556.5626      -2.7342         0.9412 
+    13                 609.7540     618.3188       8.5648         0.0013 
+    14                 650.9588     627.5670     -23.3918         0.0037 
+    15                 691.9021     647.8456     -44.0565         0.7663 
+    16                 731.3959     691.3408     -40.0551         0.9420 
+    17                 748.6224     704.8961     -43.7263         0.9927 
+    18                 757.4865     716.6557     -40.8308         0.9146 
+    19                 793.4162     748.6031     -44.8131         0.0492 
+    20                 796.3137     755.8152     -40.4985         0.0484 
+    21                 829.9391     769.4663     -60.4728         0.9610 
+    22                 886.2937     879.1133      -7.1804         0.0056 
+    23                 898.9488     883.5413     -15.4075         0.8224 
+    24                 905.1053     888.0482     -17.0571         0.0157 
+    25                 931.8180     905.5953     -26.2227         0.0033 
+    26                 972.6908     941.4902     -31.2006         0.4651 
+    27                 981.1443     962.8748     -18.2695         0.0017 
+    28                1002.3531     979.6165     -22.7366         0.0022 
+    29                1002.6108    1038.6833      36.0725         0.0583 
+    30                1006.9971    1042.4358      35.4387         0.4823 
+    31                1043.4229    1098.1745      54.7516         0.0064 
+    32                1045.2039    1111.9475      66.7436         0.0007 
+    33                1101.4212    1112.3394      10.9182         0.0015 
+    34                1122.1664    1118.3932      -3.7732         0.7110 
+    35                1175.8590    1182.7592       6.9002         0.1449 
+    36                1177.5535    1186.0974       8.5439         0.2013 
+    37                1180.0345    1242.1142      62.0797         0.0156 
+    38                1198.0738    1253.2794      55.2056         0.0066 
+    39                1209.4283    1271.6697      62.2414         0.4226 
+    40                1213.4868    1278.2167      64.7299         0.0123 
+    41                1233.7197    1293.8513      60.1316         0.0162 
+    42                1248.6007    1396.6810     148.0803         0.0099 
+    43                1296.1008    1422.8601     126.7593         0.4176 
+    44                1311.1904    1462.7857     151.5953         0.2204 
+    45                1325.6114    1543.7068     218.0954         0.0309 
+    46                1351.5363    1602.9592     251.4229         0.0046 
+    47                1456.1390    1606.5798     150.4408         0.4341 
+    48                1461.1551    1634.7399     173.5848         0.0266 
+    49                1467.0845    1653.6862     186.6017         0.3043 
+    50                1486.3167    1681.0531     194.7364         0.0406 
+    51                1498.4933    1684.2499     185.7566         0.0724 
+    52                1571.5221    1728.1234     156.6013         0.6057 
+    53                1591.5923    1732.4523     140.8600         0.7416 
+    54                1597.5166    1770.0301     172.5135         0.0331 
+    55                1620.6702    1809.3742     188.7040         0.0278 
+    56                2881.8985    2908.4794      26.5809         0.8771 
+    57                2918.3100    2977.6175      59.3075         0.8761 
+    58                3057.8158    3067.6455       9.8297         0.3205 
+    59                3058.9610    3067.8054       8.8444         0.2794 
+    60                3076.7507    3068.1683      -8.5824         0.2651 
+    61                3076.9099    3068.2591      -8.6508         0.2880 
+    62                3093.3546    3069.3236     -24.0310         0.0570 
+    63                3093.7472    3069.3707     -24.3765         0.0942 
+    64                3108.9905    3070.0710     -38.9195         0.7571 
+    65                3109.6289    3070.4183     -39.2106         0.7840 
 ----------------------------------------------------------------------------
 #===================================================================================#
 #| [94m                         Objective Function Breakdown                          [0m |#
 #| [94m  Target Name              Residual  x  Weight  =  Contribution (Current-Prev) [0m |#
 #===================================================================================#
-optgeo                         5.35245      1.000 [92m     5.35245e+00[0m ( -1.331e-01 ) 
-vibration                     21.50410      1.000 [92m     2.15041e+01[0m ( -1.704e+00 ) 
-Regularization                 0.06250      1.000 [91m     6.24999e-02[0m ( +6.250e-02 ) 
-Total                                             [92m     2.69191e+01[0m ( -1.775e+00 ) 
+optgeo                         5.08226      1.000 [92m     5.08226e+00[0m ( -5.185e-01 ) 
+vibration                     12.69208      1.000 [92m     1.26921e+01[0m ( -3.661e+00 ) 
+Regularization                 0.00100      1.000 [91m     1.00016e-03[0m ( +1.000e-03 ) 
+Total                                             [92m     1.77753e+01[0m ( -4.178e+00 ) 
 -------------------------------------------------------------------------------------
-Backing up result/optimize/smirnoff99Frosst.offxml -> result/optimize/smirnoff99Frosst_45.offxml
+Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_26.offxml
 #========================================================================#
 #|  The force field has been written to the result/optimize directory.  |#
 #|    Input file with optimization parameters saved to optimize.sav.    |#
 #========================================================================#
 
   Step       |k|        |dk|       |grad|       -=X2=-     Delta(X2)    StepQual
-     1   2.500e-01   2.500e-01   6.460e+00[92m   2.69191e+01[0m  -1.775e+00      0.996
+     1   3.163e-02   3.163e-02   1.829e+02[92m   1.77753e+01[0m  -4.178e+00      1.000
 
 #========================================================#
 #| [94m                   Total Gradient                   [0m |#
 #========================================================#
-   0 [  5.72806506e-01 ] : HarmonicBondForce/Bond/k/[#6X3:1]:[#6X3:2]
-   1 [  3.97342484e-01 ] : HarmonicBondForce/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [  8.79813505e-02 ] : HarmonicBondForce/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [ -1.00718173e+00 ] : HarmonicBondForce/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [  9.28590665e-02 ] : HarmonicBondForce/Bond/k/[#6X4:1]-[#1:2]
-   5 [ -3.68399028e-01 ] : HarmonicBondForce/Bond/length/[#6X4:1]-[#1:2]
-   6 [ -1.27338518e-01 ] : HarmonicBondForce/Bond/k/[#6X3:1]-[#1:2]
-   7 [ -1.26797798e+00 ] : HarmonicBondForce/Bond/length/[#6X3:1]-[#1:2]
-   8 [  7.75666442e-01 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [  5.67322813e-01 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [ -6.35199964e-01 ] : HarmonicAngleForce/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [  7.47675631e-01 ] : HarmonicAngleForce/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [  1.92300653e+00 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [  5.44396269e+00 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [  1.04593568e+00 ] : HarmonicAngleForce/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [ -1.76123938e-04 ] : HarmonicAngleForce/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [  1.37756823e+00 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
-  17 [ -5.03430352e-02 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [  7.65640656e-02 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X4]
-  19 [  1.03409540e-01 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [  2.84266739e-01 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X3]
-  21 [  3.80688743e-01 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [  3.65132807e-03 ] : NonbondedForce/Atom/epsilon/[#6X4:1]
-  23 [  3.16115977e-02 ] : NonbondedForce/Atom/rmin_half/[#6X4:1]
-  24 [  3.44880687e-03 ] : NonbondedForce/Atom/epsilon/[#8X2H0+0:1]
-  25 [  4.03830583e-02 ] : NonbondedForce/Atom/rmin_half/[#8X2H0+0:1]
+   0 [  3.61113001e+01 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [ -2.32891952e+01 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [  6.45155237e+00 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [ -1.09601431e+02 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [  8.40133701e+00 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [ -2.72514106e+01 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [ -1.13010470e+01 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  1.19231727e+02 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [  9.31610637e+00 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [  6.69027307e+00 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [ -1.15511402e+01 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [  7.55937685e+00 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [  3.34584196e+00 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [  6.21370170e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [  1.19890806e+01 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [ -1.07588101e-01 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [ -5.90323238e-01 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [ -3.48756098e-20 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [  1.01759403e+00 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [  1.52684492e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [  3.50888314e+00 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [  5.49487467e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  1.60085079e-02 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  1.29415275e-01 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [  2.76281981e-02 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [  3.88465080e-01 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
 ----------------------------------------------------------
-Increasing trust radius to  3.0000e-01
 Calculating nonlinear optimization step
-Finding trust radius: H+0.0000*I, length 1.9870e+00 (target 3.0000e-01)
-Finding trust radius: H+9.0000*I, length 5.0808e-01 (target 3.0000e-01)
-Finding trust radius: H+61.6869*I, length 9.7744e-02 (target 3.0000e-01)
-Finding trust radius: H+29.4754*I, length 1.9210e-01 (target 3.0000e-01)
-Finding trust radius: H+29.4754*I, length 1.9210e-01 (target 3.0000e-01)
-Finding trust radius: H+20.2615*I, length 2.6616e-01 (target 3.0000e-01)
-Finding trust radius: H+15.4279*I, length 3.3415e-01 (target 3.0000e-01)
-Finding trust radius: H+17.7830*I, length 2.9712e-01 (target 3.0000e-01)
-Finding trust radius: H+17.7736*I, length 2.9725e-01 (target 3.0000e-01)
-Finding trust radius: H+17.5400*I, length 3.0055e-01 (target 3.0000e-01)
-Finding trust radius: H+16.7172*I, length 3.1279e-01 (target 3.0000e-01)
-Finding trust radius: H+17.5779*I, length 3.0001e-01 (target 3.0000e-01)
-Finding trust radius: H+17.5790*I, length 3.0000e-01 (target 3.0000e-01)
-Finding trust radius: H+17.5787*I, length 3.0000e-01 (target 3.0000e-01)
-Finding trust radius: H+17.5788*I, length 3.0000e-01 (target 3.0000e-01)
-Finding trust radius: H+17.5787*I, length 3.0000e-01 (target 3.0000e-01)
-Trust-radius step found (length 3.0000e-01),  1.7579e+01 added to Hessian diagonal
+Finding trust radius: H+0.0000*I, length 6.5285e-01 (target 3.1625e-02)
+Finding trust radius: H+9.0000*I, length 3.7562e-01 (target 3.1625e-02)
+Finding trust radius: H+61.6869*I, length 2.4512e-01 (target 3.1625e-02)
+Finding trust radius: H+38.6904*I, length 2.7284e-01 (target 3.1625e-02)
+Finding trust radius: H+246.7477*I, length 1.5778e-01 (target 3.1625e-02)
+Finding trust radius: H+193.8192*I, length 1.7351e-01 (target 3.1625e-02)
+Finding trust radius: H+807.4923*I, length 8.5160e-02 (target 3.1625e-02)
+Finding trust radius: H+670.8516*I, length 9.5385e-02 (target 3.1625e-02)
+Finding trust radius: H+2398.9145*I, length 3.9691e-02 (target 3.1625e-02)
+Finding trust radius: H+1700.9039*I, length 5.1221e-02 (target 3.1625e-02)
+Finding trust radius: H+6764.9351*I, length 1.7867e-02 (target 3.1625e-02)
+Finding trust radius: H+2398.9145*I, length 3.9691e-02 (target 3.1625e-02)
+Finding trust radius: H+3805.2759*I, length 2.7913e-02 (target 3.1625e-02)
+Finding trust radius: H+4835.9536*I, length 2.3196e-02 (target 3.1625e-02)
+Finding trust radius: H+3480.3980*I, length 2.9896e-02 (target 3.1625e-02)
+Finding trust radius: H+3346.0538*I, length 3.0813e-02 (target 3.1625e-02)
+Finding trust radius: H+2965.7209*I, length 3.3792e-02 (target 3.1625e-02)
+Finding trust radius: H+3248.0369*I, length 3.1523e-02 (target 3.1625e-02)
+Finding trust radius: H+3228.0416*I, length 3.1672e-02 (target 3.1625e-02)
+Finding trust radius: H+3234.1723*I, length 3.1626e-02 (target 3.1625e-02)
+Finding trust radius: H+3234.8306*I, length 3.1621e-02 (target 3.1625e-02)
+Finding trust radius: H+3233.5141*I, length 3.1631e-02 (target 3.1625e-02)
+Starting Hessian diagonal search with step size 3.1626e-02
+Hessian diagonal search: H+3234.1723*I, length 3.1626e-02, result -3.8156e+00
+Hessian diagonal search: H+53120.6319*I, length 3.1432e-03, result -5.4363e-01
+Hessian diagonal search: H+50192.1516*I, length 3.3110e-03, result -5.7099e-01
+Hessian diagonal search: H+3234.1723*I, length 3.1626e-02, result -3.8156e+00
+Hessian diagonal search: H+2542.8514*I, length 3.7983e-02, result -4.2837e+00
+Hessian diagonal search: H+13628.1260*I, length 1.0234e-02, result -1.5839e+00
+Hessian diagonal search: H+26.8210*I, length 2.9516e-01, result  1.4323e+01
+Hessian diagonal search: H+5738.9649*I, length 2.0310e-02, result -2.7743e+00
+Hessian diagonal search: H+1098.4964*I, length 6.9669e-02, result -5.6292e+00
+Hessian diagonal search: H+504.5422*I, length 1.1218e-01, result -5.5893e+00
+Hessian diagonal search: H+808.9890*I, length 8.5061e-02, result -5.8175e+00
+Hessian diagonal search: H+787.2355*I, length 8.6524e-02, result -5.8227e+00
+Hessian diagonal search: H+727.5211*I, length 9.0837e-02, result -5.8258e+00
+Hessian diagonal search: H+637.5478*I, length 9.8298e-02, result -5.7898e+00
+Hessian diagonal search: H+746.2385*I, length 8.9435e-02, result -5.8267e+00
+Hessian diagonal search: H+746.8226*I, length 8.9392e-02, result -5.8267e+00
+Hessian diagonal search: H+746.5388*I, length 8.9413e-02, result -5.8267e+00
+Hessian diagonal search: H+746.3949*I, length 8.9424e-02, result -5.8267e+00
+Optimization step found (length 8.9413e-02)
 #========================================================#
 #| [95m  Mathematical Parameters (Current + Step = Next)   [0m |#
 #========================================================#
-   0 [ -2.1658e-02 - 2.7932e-02 = -4.9590e-02 ] : HarmonicBondForce/Bond/k/[#6X3:1]:[#6X3:2]
-   1 [ -1.5499e-02 - 2.0806e-02 = -3.6306e-02 ] : HarmonicBondForce/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [ -3.3086e-03 - 4.2732e-03 = -7.5819e-03 ] : HarmonicBondForce/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [  3.8515e-02 + 5.0598e-02 =  8.9113e-02 ] : HarmonicBondForce/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [ -3.5830e-03 - 4.7278e-03 = -8.3109e-03 ] : HarmonicBondForce/Bond/k/[#6X4:1]-[#1:2]
-   5 [  1.4582e-02 + 1.8192e-02 =  3.2775e-02 ] : HarmonicBondForce/Bond/length/[#6X4:1]-[#1:2]
-   6 [  4.8760e-03 + 6.5187e-03 =  1.1395e-02 ] : HarmonicBondForce/Bond/k/[#6X3:1]-[#1:2]
-   7 [  5.0631e-02 + 5.9936e-02 =  1.1057e-01 ] : HarmonicBondForce/Bond/length/[#6X3:1]-[#1:2]
-   8 [ -3.0446e-02 - 3.7485e-02 = -6.7931e-02 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [ -2.2106e-02 - 2.7680e-02 = -4.9786e-02 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [  2.7732e-02 + 3.3589e-02 =  6.1321e-02 ] : HarmonicAngleForce/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [ -2.8116e-02 - 3.5819e-02 = -6.3935e-02 ] : HarmonicAngleForce/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [ -7.6431e-02 - 5.9737e-02 = -1.3617e-01 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [ -2.0970e-01 - 2.6328e-01 = -4.7297e-01 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [ -4.1109e-02 - 5.2229e-02 = -9.3338e-02 ] : HarmonicAngleForce/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [  6.4454e-06 + 7.7745e-05 =  8.4191e-05 ] : HarmonicAngleForce/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [ -5.1256e-02 - 3.8284e-02 = -8.9540e-02 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
-  17 [  2.0210e-03 + 2.6599e-03 =  4.6810e-03 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [ -3.2216e-03 - 3.7569e-03 = -6.9786e-03 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X4]
-  19 [ -4.3314e-03 - 5.0675e-03 = -9.3990e-03 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [ -1.0968e-02 - 1.3533e-02 = -2.4500e-02 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X3]
-  21 [ -1.4817e-02 - 1.8083e-02 = -3.2899e-02 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [ -1.4900e-04 - 1.6054e-04 = -3.0955e-04 ] : NonbondedForce/Atom/epsilon/[#6X4:1]
-  23 [ -1.1381e-03 - 1.3954e-03 = -2.5335e-03 ] : NonbondedForce/Atom/rmin_half/[#6X4:1]
-  24 [ -1.1816e-04 - 1.5638e-04 = -2.7454e-04 ] : NonbondedForce/Atom/epsilon/[#8X2H0+0:1]
-  25 [ -1.4725e-03 - 1.7778e-03 = -3.2504e-03 ] : NonbondedForce/Atom/rmin_half/[#8X2H0+0:1]
+   0 [ -6.6980e-03 - 3.0791e-02 = -3.7489e-02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [ -6.8872e-03 + 1.1781e-02 =  4.8934e-03 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [ -1.1571e-03 - 5.7575e-03 = -6.9146e-03 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  1.5559e-02 + 4.8557e-02 =  6.4117e-02 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [ -1.4773e-03 - 7.3714e-03 = -8.8487e-03 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  6.9353e-03 + 2.2657e-02 =  2.9592e-02 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [  1.9753e-03 + 5.7265e-03 =  7.7018e-03 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  2.1787e-02 - 1.7893e-03 =  1.9997e-02 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [ -1.6047e-03 - 8.8631e-03 = -1.0468e-02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [ -1.2080e-03 - 5.6007e-03 = -6.8087e-03 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [  2.4450e-03 + 1.3010e-02 =  1.5455e-02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [ -1.4200e-03 - 4.7296e-03 = -6.1495e-03 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [  1.0860e-03 - 2.1484e-03 = -1.0623e-03 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [ -1.0810e-02 - 5.9097e-02 = -6.9907e-02 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [ -1.8520e-03 - 9.5586e-03 = -1.1411e-02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [  1.0402e-05 + 2.6574e-04 =  2.7614e-04 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [  6.1563e-04 + 8.5239e-04 =  1.4680e-03 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [ -1.7438e-20 + 1.9909e-19 =  1.8165e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [ -1.8325e-04 - 6.4759e-04 = -8.3085e-04 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [ -2.7552e-04 - 9.6210e-04 = -1.2376e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [ -6.9613e-04 - 2.4837e-03 = -3.1799e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [ -1.0502e-03 - 3.8568e-03 = -4.9069e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [ -5.9446e-06 + 2.5511e-05 =  1.9567e-05 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [ -5.5130e-05 + 2.6070e-04 =  2.0557e-04 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [ -8.3738e-06 - 9.1717e-06 = -1.7546e-05 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [ -1.2985e-04 - 2.0373e-04 = -3.3358e-04 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
 ----------------------------------------------------------
 #========================================================#
 #| [95m    Physical Parameters (Current + Step = Next)     [0m |#
 #========================================================#
-   0 [  9.3778e+02 - 2.7932e-01 =  9.3750e+02 ] : HarmonicBondForce/Bond/k/[#6X3:1]:[#6X3:2]
-   1 [  1.3998e+00 - 2.0806e-04 =  1.3996e+00 ] : HarmonicBondForce/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [  8.9997e+02 - 4.2732e-02 =  8.9992e+02 ] : HarmonicBondForce/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [  1.3234e+00 + 5.0598e-04 =  1.3239e+00 ] : HarmonicBondForce/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [  6.7996e+02 - 4.7278e-02 =  6.7992e+02 ] : HarmonicBondForce/Bond/k/[#6X4:1]-[#1:2]
-   5 [  1.0901e+00 + 1.8192e-04 =  1.0903e+00 ] : HarmonicBondForce/Bond/length/[#6X4:1]-[#1:2]
-   6 [  7.3405e+02 + 6.5187e-02 =  7.3411e+02 ] : HarmonicBondForce/Bond/k/[#6X3:1]-[#1:2]
-   7 [  1.0805e+00 + 5.9936e-04 =  1.0811e+00 ] : HarmonicBondForce/Bond/length/[#6X3:1]-[#1:2]
-   8 [  1.0920e+02 - 3.7485e-01 =  1.0882e+02 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [  6.9779e+01 - 2.7680e-01 =  6.9502e+01 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [  1.2028e+02 + 3.3589e-01 =  1.2061e+02 ] : HarmonicAngleForce/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [  1.3972e+02 - 3.5819e-01 =  1.3936e+02 ] : HarmonicAngleForce/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [  1.1924e+02 - 5.9737e-01 =  1.1864e+02 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [  9.7903e+01 - 2.6328e+00 =  9.5270e+01 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [  1.1959e+02 - 5.2229e-01 =  1.1907e+02 ] : HarmonicAngleForce/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [  1.4000e+02 + 7.7745e-04 =  1.4000e+02 ] : HarmonicAngleForce/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [  3.5737e+00 - 3.8284e-02 =  3.5355e+00 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
-  17 [  1.0520e+00 + 2.6599e-03 =  1.0547e+00 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [  1.5668e-02 - 3.7569e-05 =  1.5630e-02 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X4]
-  19 [  1.4866e+00 - 5.0675e-04 =  1.4861e+00 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [  1.4890e-02 - 1.3533e-04 =  1.4755e-02 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X3]
-  21 [  1.4575e+00 - 1.8083e-03 =  1.4557e+00 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [  1.0940e-01 - 1.6054e-06 =  1.0940e-01 ] : NonbondedForce/Atom/epsilon/[#6X4:1]
-  23 [  1.9079e+00 - 1.3954e-04 =  1.9077e+00 ] : NonbondedForce/Atom/rmin_half/[#6X4:1]
-  24 [  1.7000e-01 - 1.5638e-06 =  1.7000e-01 ] : NonbondedForce/Atom/epsilon/[#8X2H0+0:1]
-  25 [  1.6836e+00 - 1.7778e-04 =  1.6834e+00 ] : NonbondedForce/Atom/rmin_half/[#8X2H0+0:1]
+   0 [  8.1397e+02 - 2.7712e+01 =  7.8626e+02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [  1.3904e+00 + 1.6493e-02 =  1.4069e+00 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [  8.9896e+02 - 5.1818e+00 =  8.9378e+02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  1.3448e+00 + 6.7980e-02 =  1.4128e+00 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [  6.7867e+02 - 6.6342e+00 =  6.7204e+02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  1.0997e+00 + 3.1720e-02 =  1.1314e+00 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [  7.3578e+02 + 5.1538e+00 =  7.4093e+02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  1.1105e+00 - 2.5050e-03 =  1.1080e+00 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [  1.0931e+02 - 1.0636e+00 =  1.0824e+02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [  6.9831e+01 - 7.8410e-01 =  6.9047e+01 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [  1.2029e+02 + 1.5612e+00 =  1.2185e+02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [  1.3980e+02 - 6.6214e-01 =  1.3914e+02 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [  1.2013e+02 - 2.5781e-01 =  1.1987e+02 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [  9.8487e+01 - 8.2735e+00 =  9.0213e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [  1.1978e+02 - 1.1470e+00 =  1.1863e+02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [  1.4000e+02 + 3.7204e-02 =  1.4004e+02 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [  3.6272e+00 + 3.0899e-03 =  3.6303e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  1.0500e+00 + 0.0000e+00 =  1.0500e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [  1.5669e-02 - 1.1009e-04 =  1.5559e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [  1.4865e+00 - 1.8357e-03 =  1.4846e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [  1.4882e-02 - 4.2223e-04 =  1.4459e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [  1.4570e+00 - 7.3587e-03 =  1.4496e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  1.0940e-01 + 4.3369e-06 =  1.0940e-01 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  1.9079e+00 + 4.9741e-04 =  1.9084e+00 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [  1.7000e-01 - 1.5592e-06 =  1.7000e-01 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [  1.6835e+00 - 3.8872e-04 =  1.6831e+00 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
 ----------------------------------------------------------
 Input file with saved parameters: optimize.sav
 #========================================================#
@@ -626,1041 +739,7 @@ Input file with saved parameters: optimize.sav
 #========================================================#
 
 #======================================================================================================================#
-#| [92m                                  Optimized Geometries, Objective =  5.19410e+00                                  [0m |#
-#| [92m  System                       Bonds            Angles           Dihedrals         Impropers               Term.  [0m |#
-#| [92m                            RMSD   denom      RMSD   denom      RMSD   denom      RMSD   denom                    [0m |#
-#======================================================================================================================#
-9HXanthene                    0.021    0.01     0.025    0.03     0.076    0.20     0.005    0.20             5.194 
-------------------------------------------------------------------------------------------------------------------------
-
-#==========================================================================#
-#|                       Frequencies (wavenumbers)                        |#
-#|  Target: vibration  Type: Vibration_SMIRNOFF  Objective = 1.96744e+01  |#
-#|  Mode #            Reference   Calculated   Difference   Ref(dot)Calc  |#
-#==========================================================================#
-    0                   31.1817      38.6772       7.4955         0.9917 
-    1                  127.2863     136.2565       8.9702         0.9969 
-    2                  200.5311     227.5314      27.0003         0.9375 
-    3                  245.4174     234.7589     -10.6585         0.9372 
-    4                  258.8788     239.6295     -19.2493         0.9954 
-    5                  295.5887     305.2979       9.7092         0.9870 
-    6                  385.5805     343.3708     -42.2097         0.9888 
-    7                  413.3227     435.5229      22.2002         0.0037 
-    8                  461.1571     436.7794     -24.3777         0.0006 
-    9                  468.4759     447.3199     -21.1560         0.9880 
-    10                 553.9686     508.2885     -45.6801         0.9585 
-    11                 557.9183     525.7617     -32.1566         0.9532 
-    12                 559.2968     556.0352      -3.2616         0.9394 
-    13                 609.7540     621.2265      11.4725         0.0013 
-    14                 650.9588     633.3342     -17.6246         0.0038 
-    15                 691.9021     661.1794     -30.7227         0.7432 
-    16                 731.3959     690.9266     -40.4693         0.9581 
-    17                 748.6224     714.4934     -34.1290         0.9918 
-    18                 757.4865     731.4497     -26.0368         0.9554 
-    19                 793.4162     763.0875     -30.3287         0.0494 
-    20                 796.3137     765.0591     -31.2546         0.0486 
-    21                 829.9391     797.2810     -32.6581         0.9778 
-    22                 886.2937     881.4274      -4.8663         0.0059 
-    23                 898.9488     888.1640     -10.7848         0.3125 
-    24                 905.1053     898.7857      -6.3196         0.0803 
-    25                 931.8180     925.5169      -6.3011         0.0036 
-    26                 972.6908     956.0752     -16.6156         0.4405 
-    27                 981.1443    1016.1879      35.0436         0.0018 
-    28                1002.3531    1029.9856      27.6325         0.0023 
-    29                1002.6108    1061.2618      58.6510         0.0576 
-    30                1006.9971    1064.7421      57.7450         0.4770 
-    31                1043.4229    1137.0694      93.6465         0.0039 
-    32                1045.2039    1137.4520      92.2481         0.0027 
-    33                1101.4212    1139.0515      37.6303         0.9447 
-    34                1122.1664    1161.2022      39.0358         0.7470 
-    35                1175.8590    1202.6860      26.8270         0.0856 
-    36                1177.5535    1219.6978      42.1443         0.0933 
-    37                1180.0345    1274.6792      94.6447         0.2424 
-    38                1198.0738    1276.2255      78.1517         0.2136 
-    39                1209.4283    1285.0639      75.6356         0.8709 
-    40                1213.4868    1307.8516      94.3648         0.0358 
-    41                1233.7197    1318.0062      84.2865         0.0221 
-    42                1248.6007    1418.5573     169.9566         0.0085 
-    43                1296.1008    1436.2698     140.1690         0.6201 
-    44                1311.1904    1477.5921     166.4017         0.1653 
-    45                1325.6114    1552.4453     226.8339         0.0289 
-    46                1351.5363    1629.3042     277.7679         0.0038 
-    47                1456.1390    1652.5912     196.4522         0.8785 
-    48                1461.1551    1686.6764     225.5213         0.0053 
-    49                1467.0845    1693.8552     226.7707         0.3533 
-    50                1486.3167    1740.1222     253.8055         0.4824 
-    51                1498.4933    1769.0317     270.5384         0.1806 
-    52                1571.5221    1799.4535     227.9314         0.5790 
-    53                1591.5923    1800.4274     208.8351         0.7135 
-    54                1597.5166    1831.7774     234.2608         0.0313 
-    55                1620.6702    1863.4136     242.7434         0.0289 
-    56                2881.8985    2911.8511      29.9526         0.8769 
-    57                2918.3100    2979.9942      61.6842         0.8764 
-    58                3057.8158    3066.2700       8.4542         0.3809 
-    59                3058.9610    3066.3170       7.3560         0.3491 
-    60                3076.7507    3066.4122     -10.3385         0.3302 
-    61                3076.9099    3066.4403     -10.4696         0.3467 
-    62                3093.3546    3067.1516     -26.2030         0.0639 
-    63                3093.7472    3067.1619     -26.5853         0.0451 
-    64                3108.9905    3068.2828     -40.7077         0.7158 
-    65                3109.6289    3068.3729     -41.2560         0.7218 
-----------------------------------------------------------------------------
-#===================================================================================#
-#| [94m                         Objective Function Breakdown                          [0m |#
-#| [94m  Target Name              Residual  x  Weight  =  Contribution (Current-Prev) [0m |#
-#===================================================================================#
-optgeo                         5.19410      1.000 [92m     5.19410e+00[0m ( -1.584e-01 ) 
-vibration                     19.67437      1.000 [92m     1.96744e+01[0m ( -1.830e+00 ) 
-Regularization                 0.30105      1.000 [91m     3.01048e-01[0m ( +2.385e-01 ) 
-Total                                             [92m     2.51695e+01[0m ( -1.750e+00 ) 
--------------------------------------------------------------------------------------
-Backing up result/optimize/smirnoff99Frosst.offxml -> result/optimize/smirnoff99Frosst_46.offxml
-#========================================================================#
-#|  The force field has been written to the result/optimize directory.  |#
-#|    Input file with optimization parameters saved to optimize.sav.    |#
-#========================================================================#
-
-  Step       |k|        |dk|       |grad|       -=X2=-     Delta(X2)    StepQual
-     2   5.487e-01   3.000e-01   5.346e+00[92m   2.51695e+01[0m  -1.750e+00      0.999
-
-#========================================================#
-#| [94m                   Total Gradient                   [0m |#
-#========================================================#
-   0 [  4.92526123e-01 ] : HarmonicBondForce/Bond/k/[#6X3:1]:[#6X3:2]
-   1 [  3.60259997e-01 ] : HarmonicBondForce/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [  7.62413849e-02 ] : HarmonicBondForce/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [ -8.92969924e-01 ] : HarmonicBondForce/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [  8.31129340e-02 ] : HarmonicBondForce/Bond/k/[#6X4:1]-[#1:2]
-   5 [ -3.10128517e-01 ] : HarmonicBondForce/Bond/length/[#6X4:1]-[#1:2]
-   6 [ -1.14715197e-01 ] : HarmonicBondForce/Bond/k/[#6X3:1]-[#1:2]
-   7 [ -1.00982869e+00 ] : HarmonicBondForce/Bond/length/[#6X3:1]-[#1:2]
-   8 [  6.20268881e-01 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [  4.64796901e-01 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [ -4.44534837e-01 ] : HarmonicAngleForce/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [  6.17220835e-01 ] : HarmonicAngleForce/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [  1.42256399e+00 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [  4.56206891e+00 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [  8.91317130e-01 ] : HarmonicAngleForce/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [ -2.07211540e-03 ] : HarmonicAngleForce/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [  1.14200744e+00 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
-  17 [ -4.53494217e-02 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [  6.12882763e-02 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X4]
-  19 [  8.16562239e-02 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [  2.26342152e-01 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X3]
-  21 [  3.00789354e-01 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [  2.89906690e-03 ] : NonbondedForce/Atom/epsilon/[#6X4:1]
-  23 [  2.48825477e-02 ] : NonbondedForce/Atom/rmin_half/[#6X4:1]
-  24 [  2.81554674e-03 ] : NonbondedForce/Atom/epsilon/[#8X2H0+0:1]
-  25 [  3.43497326e-02 ] : NonbondedForce/Atom/rmin_half/[#8X2H0+0:1]
-----------------------------------------------------------
-Increasing trust radius to  3.4912e-01
-Calculating nonlinear optimization step
-Finding trust radius: H+0.0000*I, length 1.6658e+00 (target 3.4912e-01)
-Finding trust radius: H+9.0000*I, length 4.2415e-01 (target 3.4912e-01)
-Finding trust radius: H+61.6869*I, length 8.1146e-02 (target 3.4912e-01)
-Finding trust radius: H+9.0000*I, length 4.2415e-01 (target 3.4912e-01)
-Finding trust radius: H+23.5623*I, length 1.9463e-01 (target 3.4912e-01)
-Finding trust radius: H+3.4377*I, length 7.8202e-01 (target 3.4912e-01)
-Finding trust radius: H+14.7414*I, length 2.8909e-01 (target 3.4912e-01)
-Finding trust radius: H+12.3875*I, length 3.3237e-01 (target 3.4912e-01)
-Finding trust radius: H+12.0316*I, length 3.4009e-01 (target 3.4912e-01)
-Finding trust radius: H+11.4411*I, length 3.5371e-01 (target 3.4912e-01)
-Finding trust radius: H+10.4741*I, length 3.7859e-01 (target 3.4912e-01)
-Finding trust radius: H+11.6315*I, length 3.4920e-01 (target 3.4912e-01)
-Finding trust radius: H+11.6383*I, length 3.4904e-01 (target 3.4912e-01)
-Finding trust radius: H+11.6347*I, length 3.4912e-01 (target 3.4912e-01)
-Finding trust radius: H+11.6347*I, length 3.4912e-01 (target 3.4912e-01)
-Finding trust radius: H+11.6348*I, length 3.4912e-01 (target 3.4912e-01)
-Trust-radius step found (length 3.4912e-01),  1.1635e+01 added to Hessian diagonal
-#========================================================#
-#| [95m  Mathematical Parameters (Current + Step = Next)   [0m |#
-#========================================================#
-   0 [ -4.9590e-02 - 3.3931e-02 = -8.3521e-02 ] : HarmonicBondForce/Bond/k/[#6X3:1]:[#6X3:2]
-   1 [ -3.6306e-02 - 2.7236e-02 = -6.3541e-02 ] : HarmonicBondForce/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [ -7.5819e-03 - 5.2078e-03 = -1.2790e-02 ] : HarmonicBondForce/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [  8.9113e-02 + 6.4048e-02 =  1.5316e-01 ] : HarmonicBondForce/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [ -8.3109e-03 - 6.0688e-03 = -1.4380e-02 ] : HarmonicBondForce/Bond/k/[#6X4:1]-[#1:2]
-   5 [  3.2775e-02 + 2.1653e-02 =  5.4428e-02 ] : HarmonicBondForce/Bond/length/[#6X4:1]-[#1:2]
-   6 [  1.1395e-02 + 8.4234e-03 =  1.9818e-02 ] : HarmonicBondForce/Bond/k/[#6X3:1]-[#1:2]
-   7 [  1.1057e-01 + 6.6806e-02 =  1.7737e-01 ] : HarmonicBondForce/Bond/length/[#6X3:1]-[#1:2]
-   8 [ -6.7931e-02 - 4.2206e-02 = -1.1014e-01 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [ -4.9786e-02 - 3.1636e-02 = -8.1421e-02 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [  6.1321e-02 + 3.4685e-02 =  9.6006e-02 ] : HarmonicAngleForce/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [ -6.3935e-02 - 4.1238e-02 = -1.0517e-01 ] : HarmonicAngleForce/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [ -1.3617e-01 - 5.4151e-02 = -1.9032e-01 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [ -4.7297e-01 - 3.0964e-01 = -7.8261e-01 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [ -9.3338e-02 - 6.3501e-02 = -1.5684e-01 ] : HarmonicAngleForce/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [  8.4191e-05 + 2.6511e-04 =  3.4930e-04 ] : HarmonicAngleForce/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [ -8.9540e-02 - 4.0244e-02 = -1.2978e-01 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
-  17 [  4.6810e-03 + 3.5335e-03 =  8.2145e-03 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [ -6.9786e-03 - 4.2327e-03 = -1.1211e-02 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X4]
-  19 [ -9.3990e-03 - 5.6222e-03 = -1.5021e-02 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [ -2.4500e-02 - 1.4905e-02 = -3.9405e-02 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X3]
-  21 [ -3.2899e-02 - 1.9747e-02 = -5.2647e-02 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [ -3.0955e-04 - 1.6940e-04 = -4.7895e-04 ] : NonbondedForce/Atom/epsilon/[#6X4:1]
-  23 [ -2.5335e-03 - 1.4586e-03 = -3.9921e-03 ] : NonbondedForce/Atom/rmin_half/[#6X4:1]
-  24 [ -2.7454e-04 - 1.7224e-04 = -4.4679e-04 ] : NonbondedForce/Atom/epsilon/[#8X2H0+0:1]
-  25 [ -3.2504e-03 - 2.0277e-03 = -5.2781e-03 ] : NonbondedForce/Atom/rmin_half/[#8X2H0+0:1]
-----------------------------------------------------------
-#========================================================#
-#| [95m    Physical Parameters (Current + Step = Next)     [0m |#
-#========================================================#
-   0 [  9.3750e+02 - 3.3931e-01 =  9.3716e+02 ] : HarmonicBondForce/Bond/k/[#6X3:1]:[#6X3:2]
-   1 [  1.3996e+00 - 2.7236e-04 =  1.3994e+00 ] : HarmonicBondForce/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [  8.9992e+02 - 5.2078e-02 =  8.9987e+02 ] : HarmonicBondForce/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [  1.3239e+00 + 6.4048e-04 =  1.3245e+00 ] : HarmonicBondForce/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [  6.7992e+02 - 6.0688e-02 =  6.7986e+02 ] : HarmonicBondForce/Bond/k/[#6X4:1]-[#1:2]
-   5 [  1.0903e+00 + 2.1653e-04 =  1.0905e+00 ] : HarmonicBondForce/Bond/length/[#6X4:1]-[#1:2]
-   6 [  7.3411e+02 + 8.4234e-02 =  7.3420e+02 ] : HarmonicBondForce/Bond/k/[#6X3:1]-[#1:2]
-   7 [  1.0811e+00 + 6.6806e-04 =  1.0818e+00 ] : HarmonicBondForce/Bond/length/[#6X3:1]-[#1:2]
-   8 [  1.0882e+02 - 4.2206e-01 =  1.0840e+02 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [  6.9502e+01 - 3.1636e-01 =  6.9186e+01 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [  1.2061e+02 + 3.4685e-01 =  1.2096e+02 ] : HarmonicAngleForce/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [  1.3936e+02 - 4.1238e-01 =  1.3895e+02 ] : HarmonicAngleForce/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [  1.1864e+02 - 5.4151e-01 =  1.1810e+02 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [  9.5270e+01 - 3.0964e+00 =  9.2174e+01 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [  1.1907e+02 - 6.3501e-01 =  1.1843e+02 ] : HarmonicAngleForce/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [  1.4000e+02 + 2.6511e-03 =  1.4000e+02 ] : HarmonicAngleForce/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [  3.5355e+00 - 4.0244e-02 =  3.4952e+00 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
-  17 [  1.0547e+00 + 3.5335e-03 =  1.0582e+00 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [  1.5630e-02 - 4.2327e-05 =  1.5588e-02 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X4]
-  19 [  1.4861e+00 - 5.6222e-04 =  1.4855e+00 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [  1.4755e-02 - 1.4905e-04 =  1.4606e-02 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X3]
-  21 [  1.4557e+00 - 1.9747e-03 =  1.4537e+00 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [  1.0940e-01 - 1.6940e-06 =  1.0940e-01 ] : NonbondedForce/Atom/epsilon/[#6X4:1]
-  23 [  1.9077e+00 - 1.4586e-04 =  1.9076e+00 ] : NonbondedForce/Atom/rmin_half/[#6X4:1]
-  24 [  1.7000e-01 - 1.7224e-06 =  1.7000e-01 ] : NonbondedForce/Atom/epsilon/[#8X2H0+0:1]
-  25 [  1.6834e+00 - 2.0277e-04 =  1.6832e+00 ] : NonbondedForce/Atom/rmin_half/[#8X2H0+0:1]
-----------------------------------------------------------
-Input file with saved parameters: optimize.sav
-#========================================================#
-#| [94m     Iteration 3: Evaluating objective function     [0m |#
-#| [94m        and derivatives through second order        [0m |#
-#========================================================#
-
-#======================================================================================================================#
-#| [92m                                  Optimized Geometries, Objective =  5.01374e+00                                  [0m |#
-#| [92m  System                       Bonds            Angles           Dihedrals         Impropers               Term.  [0m |#
-#| [92m                            RMSD   denom      RMSD   denom      RMSD   denom      RMSD   denom                    [0m |#
-#======================================================================================================================#
-9HXanthene                    0.021    0.01     0.024    0.03     0.076    0.20     0.005    0.20             5.014 
-------------------------------------------------------------------------------------------------------------------------
-
-#==========================================================================#
-#|                       Frequencies (wavenumbers)                        |#
-#|  Target: vibration  Type: Vibration_SMIRNOFF  Objective = 1.77305e+01  |#
-#|  Mode #            Reference   Calculated   Difference   Ref(dot)Calc  |#
-#==========================================================================#
-    0                   31.1817      37.9489       6.7672         0.9918 
-    1                  127.2863     135.8913       8.6050         0.9969 
-    2                  200.5311     226.9579      26.4268         0.9377 
-    3                  245.4174     234.6203     -10.7971         0.9373 
-    4                  258.8788     239.5761     -19.3027         0.9954 
-    5                  295.5887     304.2062       8.6175         0.9871 
-    6                  385.5805     342.9760     -42.6045         0.9889 
-    7                  413.3227     436.4165      23.0938         0.9683 
-    8                  461.1571     437.5261     -23.6310         0.9817 
-    9                  468.4759     449.4092     -19.0667         0.9882 
-    10                 553.9686     509.9490     -44.0196         0.9582 
-    11                 557.9183     526.5084     -31.4099         0.9531 
-    12                 559.2968     554.6780      -4.6188         0.9397 
-    13                 609.7540     620.0501      10.2961         0.0013 
-    14                 650.9588     632.3088     -18.6500         0.0038 
-    15                 691.9021     659.8448     -32.0573         0.7326 
-    16                 731.3959     691.4762     -39.9197         0.9578 
-    17                 748.6224     716.6365     -31.9859         0.9920 
-    18                 757.4865     730.3194     -27.1671         0.9569 
-    19                 793.4162     752.0784     -41.3378         0.0492 
-    20                 796.3137     755.0573     -41.2564         0.0487 
-    21                 829.9391     796.2452     -33.6939         0.9785 
-    22                 886.2937     878.6842      -7.6095         0.0059 
-    23                 898.9488     885.4373     -13.5115         0.3125 
-    24                 905.1053     891.3504     -13.7549         0.0846 
-    25                 931.8180     914.1013     -17.7167         0.0037 
-    26                 972.6908     951.3762     -21.3146         0.4763 
-    27                 981.1443    1013.8566      32.7123         0.0018 
-    28                1002.3531    1026.8674      24.5143         0.0023 
-    29                1002.6108    1048.1928      45.5820         0.0574 
-    30                1006.9971    1051.9297      44.9326         0.4881 
-    31                1043.4229    1123.1913      79.7684         0.0039 
-    32                1045.2039    1123.5983      78.3944         0.0029 
-    33                1101.4212    1132.2381      30.8169         0.9421 
-    34                1122.1664    1153.0459      30.8795         0.7500 
-    35                1175.8590    1198.9272      23.0682         0.1096 
-    36                1177.5535    1214.3663      36.8128         0.1570 
-    37                1180.0345    1263.2069      83.1724         0.0187 
-    38                1198.0738    1265.7525      67.6787         0.0050 
-    39                1209.4283    1285.0690      75.6407         0.8708 
-    40                1213.4868    1298.9615      85.4747         0.0385 
-    41                1233.7197    1310.4870      76.7673         0.0216 
-    42                1248.6007    1408.0003     159.3996         0.0112 
-    43                1296.1008    1428.5032     132.4024         0.4320 
-    44                1311.1904    1466.5198     155.3294         0.1982 
-    45                1325.6114    1540.0955     214.4841         0.0266 
-    46                1351.5363    1609.2815     257.7452         0.0034 
-    47                1456.1390    1638.6050     182.4660         0.8862 
-    48                1461.1551    1677.1533     215.9982         0.0018 
-    49                1467.0845    1677.6594     210.5749         0.3544 
-    50                1486.3167    1731.5126     245.1959         0.3755 
-    51                1498.4933    1765.7296     267.2363         0.1308 
-    52                1571.5221    1790.0019     218.4798         0.5727 
-    53                1591.5923    1791.2539     199.6616         0.7342 
-    54                1597.5166    1822.1798     224.6632         0.0321 
-    55                1620.6702    1856.1012     235.4310         0.0287 
-    56                2881.8985    2912.3013      30.4028         0.8767 
-    57                2918.3100    2979.2651      60.9551         0.8766 
-    58                3057.8158    3066.3079       8.4921         0.3894 
-    59                3058.9610    3066.3538       7.3928         0.3597 
-    60                3076.7507    3066.4798     -10.2709         0.2818 
-    61                3076.9099    3066.5068     -10.4031         0.2873 
-    62                3093.3546    3067.1407     -26.2139         0.0508 
-    63                3093.7472    3067.1518     -26.5954         0.0304 
-    64                3108.9905    3068.3143     -40.6762         0.7263 
-    65                3109.6289    3068.4050     -41.2239         0.7320 
-----------------------------------------------------------------------------
-#===================================================================================#
-#| [94m                         Objective Function Breakdown                          [0m |#
-#| [94m  Target Name              Residual  x  Weight  =  Contribution (Current-Prev) [0m |#
-#===================================================================================#
-optgeo                         5.01374      1.000 [92m     5.01374e+00[0m ( -1.804e-01 ) 
-vibration                     17.73052      1.000 [92m     1.77305e+01[0m ( -1.944e+00 ) 
-Regularization                 0.80362      1.000 [91m     8.03624e-01[0m ( +5.026e-01 ) 
-Total                                             [92m     2.35479e+01[0m ( -1.622e+00 ) 
--------------------------------------------------------------------------------------
-Backing up result/optimize/smirnoff99Frosst.offxml -> result/optimize/smirnoff99Frosst_47.offxml
-#========================================================================#
-#|  The force field has been written to the result/optimize directory.  |#
-#|    Input file with optimization parameters saved to optimize.sav.    |#
-#========================================================================#
-
-  Step       |k|        |dk|       |grad|       -=X2=-     Delta(X2)    StepQual
-     3   8.965e-01   3.491e-01   4.011e+00[92m   2.35479e+01[0m  -1.622e+00      0.994
-
-#========================================================#
-#| [94m                   Total Gradient                   [0m |#
-#========================================================#
-   0 [  4.06625120e-01 ] : HarmonicBondForce/Bond/k/[#6X3:1]:[#6X3:2]
-   1 [  3.11261297e-01 ] : HarmonicBondForce/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [  6.19006279e-02 ] : HarmonicBondForce/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [ -7.49777994e-01 ] : HarmonicBondForce/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [  6.99179250e-02 ] : HarmonicBondForce/Bond/k/[#6X4:1]-[#1:2]
-   5 [ -2.46937111e-01 ] : HarmonicBondForce/Bond/length/[#6X4:1]-[#1:2]
-   6 [ -9.79074644e-02 ] : HarmonicBondForce/Bond/k/[#6X3:1]-[#1:2]
-   7 [ -7.07852664e-01 ] : HarmonicBondForce/Bond/length/[#6X3:1]-[#1:2]
-   8 [  4.33977275e-01 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [  3.43920398e-01 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [ -5.37757992e-01 ] : HarmonicAngleForce/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [  5.06347212e-01 ] : HarmonicAngleForce/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [  6.02472517e-01 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [  3.57114064e+00 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [  6.98479802e-01 ] : HarmonicAngleForce/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [ -3.80306586e-03 ] : HarmonicAngleForce/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [  3.71888806e-01 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
-  17 [ -4.19630376e-02 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [  4.90350728e-02 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X4]
-  19 [  6.50551441e-02 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [  1.74870438e-01 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X3]
-  21 [  2.27830935e-01 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [  2.31206003e-03 ] : NonbondedForce/Atom/epsilon/[#6X4:1]
-  23 [  1.84758537e-02 ] : NonbondedForce/Atom/rmin_half/[#6X4:1]
-  24 [  2.67027750e-03 ] : NonbondedForce/Atom/epsilon/[#8X2H0+0:1]
-  25 [  2.81136027e-02 ] : NonbondedForce/Atom/rmin_half/[#8X2H0+0:1]
-----------------------------------------------------------
-Increasing trust radius to  3.9609e-01
-Calculating nonlinear optimization step
-Finding trust radius: H+0.0000*I, length 1.2981e+00 (target 3.9609e-01)
-Finding trust radius: H+9.0000*I, length 3.2858e-01 (target 3.9609e-01)
-Finding trust radius: H+61.6869*I, length 6.1698e-02 (target 3.9609e-01)
-Finding trust radius: H+9.0000*I, length 3.2858e-01 (target 3.9609e-01)
-Finding trust radius: H+23.5623*I, length 1.4949e-01 (target 3.9609e-01)
-Finding trust radius: H+3.4377*I, length 6.0824e-01 (target 3.9609e-01)
-Finding trust radius: H+10.4568*I, length 2.9335e-01 (target 3.9609e-01)
-Finding trust radius: H+7.9888*I, length 3.5849e-01 (target 3.9609e-01)
-Finding trust radius: H+6.0272*I, length 4.3545e-01 (target 3.9609e-01)
-Finding trust radius: H+7.0018*I, length 3.9346e-01 (target 3.9609e-01)
-Finding trust radius: H+6.9959*I, length 3.9369e-01 (target 3.9609e-01)
-Finding trust radius: H+6.9256*I, length 3.9645e-01 (target 3.9609e-01)
-Finding trust radius: H+6.5751*I, length 4.1080e-01 (target 3.9609e-01)
-Finding trust radius: H+6.9345*I, length 3.9610e-01 (target 3.9609e-01)
-Finding trust radius: H+6.9347*I, length 3.9609e-01 (target 3.9609e-01)
-Finding trust radius: H+6.9347*I, length 3.9609e-01 (target 3.9609e-01)
-Finding trust radius: H+6.9347*I, length 3.9609e-01 (target 3.9609e-01)
-Trust-radius step found (length 3.9609e-01),  6.9347e+00 added to Hessian diagonal
-#========================================================#
-#| [95m  Mathematical Parameters (Current + Step = Next)   [0m |#
-#========================================================#
-   0 [ -8.3521e-02 - 4.1746e-02 = -1.2527e-01 ] : HarmonicBondForce/Bond/k/[#6X3:1]:[#6X3:2]
-   1 [ -6.3541e-02 - 3.5630e-02 = -9.9171e-02 ] : HarmonicBondForce/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [ -1.2790e-02 - 6.2334e-03 = -1.9023e-02 ] : HarmonicBondForce/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [  1.5316e-01 + 8.1420e-02 =  2.3458e-01 ] : HarmonicBondForce/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [ -1.4380e-02 - 7.7779e-03 = -2.2158e-02 ] : HarmonicBondForce/Bond/k/[#6X4:1]-[#1:2]
-   5 [  5.4428e-02 + 2.5910e-02 =  8.0338e-02 ] : HarmonicBondForce/Bond/length/[#6X4:1]-[#1:2]
-   6 [  1.9818e-02 + 1.0944e-02 =  3.0762e-02 ] : HarmonicBondForce/Bond/k/[#6X3:1]-[#1:2]
-   7 [  1.7737e-01 + 6.9601e-02 =  2.4697e-01 ] : HarmonicBondForce/Bond/length/[#6X3:1]-[#1:2]
-   8 [ -1.1014e-01 - 4.4523e-02 = -1.5466e-01 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [ -8.1421e-02 - 3.4592e-02 = -1.1601e-01 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [  9.6006e-02 + 4.8806e-02 =  1.4481e-01 ] : HarmonicAngleForce/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [ -1.0517e-01 - 4.9549e-02 = -1.5472e-01 ] : HarmonicAngleForce/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [ -1.9032e-01 - 3.2210e-02 = -2.2253e-01 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [ -7.8261e-01 - 3.5444e-01 = -1.1370e+00 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [ -1.5684e-01 - 7.5322e-02 = -2.3216e-01 ] : HarmonicAngleForce/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [  3.4930e-04 + 6.3494e-04 =  9.8423e-04 ] : HarmonicAngleForce/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [ -1.2978e-01 - 1.8397e-02 = -1.4818e-01 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
-  17 [  8.2145e-03 + 4.0960e-03 =  1.2310e-02 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [ -1.1211e-02 - 5.0648e-03 = -1.6276e-02 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X4]
-  19 [ -1.5021e-02 - 6.6944e-03 = -2.1716e-02 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [ -3.9405e-02 - 1.6448e-02 = -5.5853e-02 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X3]
-  21 [ -5.2647e-02 - 2.1336e-02 = -7.3983e-02 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [ -4.7895e-04 - 1.8680e-04 = -6.6575e-04 ] : NonbondedForce/Atom/epsilon/[#6X4:1]
-  23 [ -3.9921e-03 - 1.4643e-03 = -5.4564e-03 ] : NonbondedForce/Atom/rmin_half/[#6X4:1]
-  24 [ -4.4679e-04 - 2.3838e-04 = -6.8516e-04 ] : NonbondedForce/Atom/epsilon/[#8X2H0+0:1]
-  25 [ -5.2781e-03 - 2.2890e-03 = -7.5671e-03 ] : NonbondedForce/Atom/rmin_half/[#8X2H0+0:1]
-----------------------------------------------------------
-#========================================================#
-#| [95m    Physical Parameters (Current + Step = Next)     [0m |#
-#========================================================#
-   0 [  9.3716e+02 - 4.1746e-01 =  9.3675e+02 ] : HarmonicBondForce/Bond/k/[#6X3:1]:[#6X3:2]
-   1 [  1.3994e+00 - 3.5630e-04 =  1.3990e+00 ] : HarmonicBondForce/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [  8.9987e+02 - 6.2334e-02 =  8.9981e+02 ] : HarmonicBondForce/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [  1.3245e+00 + 8.1420e-04 =  1.3253e+00 ] : HarmonicBondForce/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [  6.7986e+02 - 7.7779e-02 =  6.7978e+02 ] : HarmonicBondForce/Bond/k/[#6X4:1]-[#1:2]
-   5 [  1.0905e+00 + 2.5910e-04 =  1.0908e+00 ] : HarmonicBondForce/Bond/length/[#6X4:1]-[#1:2]
-   6 [  7.3420e+02 + 1.0944e-01 =  7.3431e+02 ] : HarmonicBondForce/Bond/k/[#6X3:1]-[#1:2]
-   7 [  1.0818e+00 + 6.9601e-04 =  1.0825e+00 ] : HarmonicBondForce/Bond/length/[#6X3:1]-[#1:2]
-   8 [  1.0840e+02 - 4.4523e-01 =  1.0795e+02 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [  6.9186e+01 - 3.4592e-01 =  6.8840e+01 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [  1.2096e+02 + 4.8806e-01 =  1.2145e+02 ] : HarmonicAngleForce/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [  1.3895e+02 - 4.9549e-01 =  1.3845e+02 ] : HarmonicAngleForce/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [  1.1810e+02 - 3.2210e-01 =  1.1777e+02 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [  9.2174e+01 - 3.5444e+00 =  8.8630e+01 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [  1.1843e+02 - 7.5322e-01 =  1.1768e+02 ] : HarmonicAngleForce/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [  1.4000e+02 + 6.3494e-03 =  1.4001e+02 ] : HarmonicAngleForce/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [  3.4952e+00 - 1.8397e-02 =  3.4768e+00 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
-  17 [  1.0582e+00 + 4.0960e-03 =  1.0623e+00 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [  1.5588e-02 - 5.0648e-05 =  1.5537e-02 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X4]
-  19 [  1.4855e+00 - 6.6944e-04 =  1.4848e+00 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [  1.4606e-02 - 1.6448e-04 =  1.4441e-02 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X3]
-  21 [  1.4537e+00 - 2.1336e-03 =  1.4516e+00 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [  1.0940e-01 - 1.8680e-06 =  1.0939e-01 ] : NonbondedForce/Atom/epsilon/[#6X4:1]
-  23 [  1.9076e+00 - 1.4643e-04 =  1.9075e+00 ] : NonbondedForce/Atom/rmin_half/[#6X4:1]
-  24 [  1.7000e-01 - 2.3838e-06 =  1.6999e-01 ] : NonbondedForce/Atom/epsilon/[#8X2H0+0:1]
-  25 [  1.6832e+00 - 2.2890e-04 =  1.6829e+00 ] : NonbondedForce/Atom/rmin_half/[#8X2H0+0:1]
-----------------------------------------------------------
-Input file with saved parameters: optimize.sav
-#========================================================#
-#| [94m     Iteration 4: Evaluating objective function     [0m |#
-#| [94m        and derivatives through second order        [0m |#
-#========================================================#
-
-#======================================================================================================================#
-#| [92m                                  Optimized Geometries, Objective =  4.81198e+00                                  [0m |#
-#| [92m  System                       Bonds            Angles           Dihedrals         Impropers               Term.  [0m |#
-#| [92m                            RMSD   denom      RMSD   denom      RMSD   denom      RMSD   denom                    [0m |#
-#======================================================================================================================#
-9HXanthene                    0.020    0.01     0.024    0.03     0.076    0.20     0.005    0.20             4.812 
-------------------------------------------------------------------------------------------------------------------------
-
-#==========================================================================#
-#|                       Frequencies (wavenumbers)                        |#
-#|  Target: vibration  Type: Vibration_SMIRNOFF  Objective = 1.57582e+01  |#
-#|  Mode #            Reference   Calculated   Difference   Ref(dot)Calc  |#
-#==========================================================================#
-    0                   31.1817      37.0307       5.8490         0.9918 
-    1                  127.2863     135.9719       8.6856         0.9969 
-    2                  200.5311     227.2500      26.7189         0.9380 
-    3                  245.4174     234.4569     -10.9605         0.9373 
-    4                  258.8788     240.8222     -18.0566         0.9954 
-    5                  295.5887     304.2509       8.6622         0.9872 
-    6                  385.5805     342.5096     -43.0709         0.9889 
-    7                  413.3227     435.9765      22.6538         0.9685 
-    8                  461.1571     441.5072     -19.6499         0.9817 
-    9                  468.4759     453.5681     -14.9078         0.9885 
-    10                 553.9686     514.0238     -39.9448         0.9577 
-    11                 557.9183     529.6266     -28.2917         0.9529 
-    12                 559.2968     553.1456      -6.1512         0.9401 
-    13                 609.7540     618.6207       8.8667         0.0013 
-    14                 650.9588     631.0995     -19.8593         0.0038 
-    15                 691.9021     658.3180     -33.5841         0.7208 
-    16                 731.3959     694.7930     -36.6029         0.9543 
-    17                 748.6224     722.2205     -26.4019         0.9887 
-    18                 757.4865     729.0031     -28.4834         0.9586 
-    19                 793.4162     747.0250     -46.3912         0.0488 
-    20                 796.3137     750.9531     -45.3606         0.0486 
-    21                 829.9391     795.0636     -34.8755         0.9793 
-    22                 886.2937     875.4927     -10.8010         0.0059 
-    23                 898.9488     882.2635     -16.6853         0.3124 
-    24                 905.1053     887.2606     -17.8447         0.0864 
-    25                 931.8180     909.0684     -22.7496         0.0039 
-    26                 972.6908     950.8261     -21.8647         0.4946 
-    27                 981.1443    1010.8968      29.7525         0.0017 
-    28                1002.3531    1022.9318      20.5787         0.0023 
-    29                1002.6108    1041.9892      39.3784         0.0571 
-    30                1006.9971    1045.9335      38.9364         0.4961 
-    31                1043.4229    1116.7134      73.2905         0.0039 
-    32                1045.2039    1117.1552      71.9513         0.0030 
-    33                1101.4212    1123.8421      22.4209         0.9379 
-    34                1122.1664    1142.9967      20.8303         0.7531 
-    35                1175.8590    1194.2420      18.3830         0.1509 
-    36                1177.5535    1207.0548      29.5013         0.2508 
-    37                1180.0345    1247.2007      67.1662         0.0198 
-    38                1198.0738    1254.2058      56.1320         0.0075 
-    39                1209.4283    1285.1707      75.7424         0.8708 
-    40                1213.4868    1288.5897      75.1029         0.0407 
-    41                1233.7197    1302.9901      69.2704         0.0201 
-    42                1248.6007    1392.6998     144.0991         0.0128 
-    43                1296.1008    1421.8129     125.7121         0.2642 
-    44                1311.1904    1452.1987     141.0083         0.2330 
-    45                1325.6114    1525.4222     199.8108         0.0235 
-    46                1351.5363    1586.9351     235.3988         0.0028 
-    47                1456.1390    1623.6605     167.5215         0.8775 
-    48                1461.1551    1658.9504     197.7953         0.1921 
-    49                1467.0845    1665.1260     198.0415         0.0233 
-    50                1486.3167    1724.0667     237.7500         0.2615 
-    51                1498.4933    1762.2222     263.7289         0.0950 
-    52                1571.5221    1779.7052     208.1831         0.5650 
-    53                1591.5923    1781.6396     190.0473         0.7663 
-    54                1597.5166    1811.7572     214.2406         0.0331 
-    55                1620.6702    1848.2800     227.6098         0.0284 
-    56                2881.8985    2912.7450      30.8465         0.8764 
-    57                2918.3100    2978.4823      60.1723         0.8769 
-    58                3057.8158    3066.3813       8.5655         0.3861 
-    59                3058.9610    3066.4255       7.4645         0.3556 
-    60                3076.7507    3066.5911     -10.1596         0.2450 
-    61                3076.9099    3066.6170     -10.2929         0.2436 
-    62                3093.3546    3067.1580     -26.1966         0.0333 
-    63                3093.7472    3067.1702     -26.5770         0.0106 
-    64                3108.9905    3068.3849     -40.6056         0.7389 
-    65                3109.6289    3068.4764     -41.1525         0.7440 
-----------------------------------------------------------------------------
-#===================================================================================#
-#| [94m                         Objective Function Breakdown                          [0m |#
-#| [94m  Target Name              Residual  x  Weight  =  Contribution (Current-Prev) [0m |#
-#===================================================================================#
-optgeo                         4.81198      1.000 [92m     4.81198e+00[0m ( -2.018e-01 ) 
-vibration                     15.75820      1.000 [92m     1.57582e+01[0m ( -1.972e+00 ) 
-Regularization                 1.65992      1.000 [91m     1.65992e+00[0m ( +8.563e-01 ) 
-Total                                             [92m     2.22301e+01[0m ( -1.318e+00 ) 
--------------------------------------------------------------------------------------
-Backing up result/optimize/smirnoff99Frosst.offxml -> result/optimize/smirnoff99Frosst_48.offxml
-#========================================================================#
-#|  The force field has been written to the result/optimize directory.  |#
-#|    Input file with optimization parameters saved to optimize.sav.    |#
-#========================================================================#
-
-  Step       |k|        |dk|       |grad|       -=X2=-     Delta(X2)    StepQual
-     4   1.288e+00   3.961e-01   2.654e+00[92m   2.22301e+01[0m  -1.318e+00      0.987
-
-#========================================================#
-#| [94m                   Total Gradient                   [0m |#
-#========================================================#
-   0 [  2.99882504e-01 ] : HarmonicBondForce/Bond/k/[#6X3:1]:[#6X3:2]
-   1 [  2.31274310e-01 ] : HarmonicBondForce/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [  4.52617486e-02 ] : HarmonicBondForce/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [ -5.66136009e-01 ] : HarmonicBondForce/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [  5.44869395e-02 ] : HarmonicBondForce/Bond/k/[#6X4:1]-[#1:2]
-   5 [ -1.78274687e-01 ] : HarmonicBondForce/Bond/length/[#6X4:1]-[#1:2]
-   6 [ -7.64537126e-02 ] : HarmonicBondForce/Bond/k/[#6X3:1]-[#1:2]
-   7 [ -4.04457830e-01 ] : HarmonicBondForce/Bond/length/[#6X3:1]-[#1:2]
-   8 [  2.55217646e-01 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [  2.32735879e-01 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [ -2.47223998e-01 ] : HarmonicAngleForce/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [  3.51853131e-01 ] : HarmonicAngleForce/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [  1.63197830e-01 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [  2.39986518e+00 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [  4.78758003e-01 ] : HarmonicAngleForce/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [ -5.82691970e-03 ] : HarmonicAngleForce/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [  1.42842336e-01 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
-  17 [ -2.68669333e-02 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [  3.46943011e-02 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X4]
-  19 [  4.58313619e-02 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [  1.06216617e-01 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X3]
-  21 [  1.35972461e-01 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [  1.27135027e-03 ] : NonbondedForce/Atom/epsilon/[#6X4:1]
-  23 [  1.07923088e-02 ] : NonbondedForce/Atom/rmin_half/[#6X4:1]
-  24 [  1.49088400e-03 ] : NonbondedForce/Atom/epsilon/[#8X2H0+0:1]
-  25 [  1.74039988e-02 ] : NonbondedForce/Atom/rmin_half/[#8X2H0+0:1]
-----------------------------------------------------------
-Increasing trust radius to  4.4025e-01
-Calculating nonlinear optimization step
-Finding trust radius: H+0.0000*I, length 8.6843e-01 (target 4.4025e-01)
-Finding trust radius: H+9.0000*I, length 2.1901e-01 (target 4.4025e-01)
-Finding trust radius: H+61.6869*I, length 4.0938e-02 (target 4.4025e-01)
-Finding trust radius: H+9.0000*I, length 2.1901e-01 (target 4.4025e-01)
-Finding trust radius: H+23.5623*I, length 9.9418e-02 (target 4.4025e-01)
-Finding trust radius: H+3.4377*I, length 4.0596e-01 (target 4.4025e-01)
-Finding trust radius: H+1.3131*I, length 6.0389e-01 (target 4.4025e-01)
-Finding trust radius: H+3.7269*I, length 3.8867e-01 (target 4.4025e-01)
-Finding trust radius: H+3.0806*I, length 4.2957e-01 (target 4.4025e-01)
-Finding trust radius: H+2.3178*I, length 4.9057e-01 (target 4.4025e-01)
-Finding trust radius: H+2.9597*I, length 4.3820e-01 (target 4.4025e-01)
-Finding trust radius: H+2.9236*I, length 4.4084e-01 (target 4.4025e-01)
-Finding trust radius: H+2.9314*I, length 4.4027e-01 (target 4.4025e-01)
-Finding trust radius: H+2.9316*I, length 4.4025e-01 (target 4.4025e-01)
-Finding trust radius: H+2.9316*I, length 4.4025e-01 (target 4.4025e-01)
-Finding trust radius: H+2.9316*I, length 4.4025e-01 (target 4.4025e-01)
-Finding trust radius: H+2.9316*I, length 4.4025e-01 (target 4.4025e-01)
-Trust-radius step found (length 4.4025e-01),  2.9316e+00 added to Hessian diagonal
-#========================================================#
-#| [95m  Mathematical Parameters (Current + Step = Next)   [0m |#
-#========================================================#
-   0 [ -1.2527e-01 - 5.3413e-02 = -1.7868e-01 ] : HarmonicBondForce/Bond/k/[#6X3:1]:[#6X3:2]
-   1 [ -9.9171e-02 - 4.8376e-02 = -1.4755e-01 ] : HarmonicBondForce/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [ -1.9023e-02 - 7.7418e-03 = -2.6765e-02 ] : HarmonicBondForce/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [  2.3458e-01 + 1.0910e-01 =  3.4368e-01 ] : HarmonicBondForce/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [ -2.2158e-02 - 1.0932e-02 = -3.3090e-02 ] : HarmonicBondForce/Bond/k/[#6X4:1]-[#1:2]
-   5 [  8.0338e-02 + 3.2831e-02 =  1.1317e-01 ] : HarmonicBondForce/Bond/length/[#6X4:1]-[#1:2]
-   6 [  3.0762e-02 + 1.5334e-02 =  4.6096e-02 ] : HarmonicBondForce/Bond/k/[#6X3:1]-[#1:2]
-   7 [  2.4697e-01 + 6.5211e-02 =  3.1219e-01 ] : HarmonicBondForce/Bond/length/[#6X3:1]-[#1:2]
-   8 [ -1.5466e-01 - 4.5406e-02 = -2.0007e-01 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [ -1.1601e-01 - 4.0731e-02 = -1.5674e-01 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [  1.4481e-01 + 3.6905e-02 =  1.8172e-01 ] : HarmonicAngleForce/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [ -1.5472e-01 - 5.6864e-02 = -2.1159e-01 ] : HarmonicAngleForce/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [ -2.2253e-01 - 1.0024e-02 = -2.3255e-01 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [ -1.1370e+00 - 3.9156e-01 = -1.5286e+00 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [ -2.3216e-01 - 9.0899e-02 = -3.2306e-01 ] : HarmonicAngleForce/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [  9.8423e-04 + 1.5769e-03 =  2.5611e-03 ] : HarmonicAngleForce/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [ -1.4818e-01 - 1.6512e-02 = -1.6469e-01 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
-  17 [  1.2310e-02 + 5.0798e-03 =  1.7390e-02 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [ -1.6276e-02 - 6.1328e-03 = -2.2409e-02 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X4]
-  19 [ -2.1716e-02 - 8.0385e-03 = -2.9754e-02 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [ -5.5853e-02 - 1.4854e-02 = -7.0707e-02 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X3]
-  21 [ -7.3983e-02 - 1.8795e-02 = -9.2778e-02 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [ -6.6575e-04 - 1.0370e-04 = -7.6945e-04 ] : NonbondedForce/Atom/epsilon/[#6X4:1]
-  23 [ -5.4564e-03 - 8.8888e-04 = -6.3453e-03 ] : NonbondedForce/Atom/rmin_half/[#6X4:1]
-  24 [ -6.8516e-04 - 1.6880e-04 = -8.5397e-04 ] : NonbondedForce/Atom/epsilon/[#8X2H0+0:1]
-  25 [ -7.5671e-03 - 1.6337e-03 = -9.2008e-03 ] : NonbondedForce/Atom/rmin_half/[#8X2H0+0:1]
-----------------------------------------------------------
-#========================================================#
-#| [95m    Physical Parameters (Current + Step = Next)     [0m |#
-#========================================================#
-   0 [  9.3675e+02 - 5.3413e-01 =  9.3621e+02 ] : HarmonicBondForce/Bond/k/[#6X3:1]:[#6X3:2]
-   1 [  1.3990e+00 - 4.8376e-04 =  1.3985e+00 ] : HarmonicBondForce/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [  8.9981e+02 - 7.7418e-02 =  8.9973e+02 ] : HarmonicBondForce/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [  1.3253e+00 + 1.0910e-03 =  1.3264e+00 ] : HarmonicBondForce/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [  6.7978e+02 - 1.0932e-01 =  6.7967e+02 ] : HarmonicBondForce/Bond/k/[#6X4:1]-[#1:2]
-   5 [  1.0908e+00 + 3.2831e-04 =  1.0911e+00 ] : HarmonicBondForce/Bond/length/[#6X4:1]-[#1:2]
-   6 [  7.3431e+02 + 1.5334e-01 =  7.3446e+02 ] : HarmonicBondForce/Bond/k/[#6X3:1]-[#1:2]
-   7 [  1.0825e+00 + 6.5211e-04 =  1.0831e+00 ] : HarmonicBondForce/Bond/length/[#6X3:1]-[#1:2]
-   8 [  1.0795e+02 - 4.5406e-01 =  1.0750e+02 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [  6.8840e+01 - 4.0731e-01 =  6.8433e+01 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [  1.2145e+02 + 3.6905e-01 =  1.2182e+02 ] : HarmonicAngleForce/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [  1.3845e+02 - 5.6864e-01 =  1.3788e+02 ] : HarmonicAngleForce/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [  1.1777e+02 - 1.0024e-01 =  1.1767e+02 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [  8.8630e+01 - 3.9156e+00 =  8.4714e+01 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [  1.1768e+02 - 9.0899e-01 =  1.1677e+02 ] : HarmonicAngleForce/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [  1.4001e+02 + 1.5769e-02 =  1.4003e+02 ] : HarmonicAngleForce/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [  3.4768e+00 - 1.6512e-02 =  3.4603e+00 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
-  17 [  1.0623e+00 + 5.0798e-03 =  1.0674e+00 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [  1.5537e-02 - 6.1328e-05 =  1.5476e-02 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X4]
-  19 [  1.4848e+00 - 8.0385e-04 =  1.4840e+00 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [  1.4441e-02 - 1.4854e-04 =  1.4293e-02 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X3]
-  21 [  1.4516e+00 - 1.8795e-03 =  1.4497e+00 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [  1.0939e-01 - 1.0370e-06 =  1.0939e-01 ] : NonbondedForce/Atom/epsilon/[#6X4:1]
-  23 [  1.9075e+00 - 8.8888e-05 =  1.9074e+00 ] : NonbondedForce/Atom/rmin_half/[#6X4:1]
-  24 [  1.6999e-01 - 1.6880e-06 =  1.6999e-01 ] : NonbondedForce/Atom/epsilon/[#8X2H0+0:1]
-  25 [  1.6829e+00 - 1.6337e-04 =  1.6828e+00 ] : NonbondedForce/Atom/rmin_half/[#8X2H0+0:1]
-----------------------------------------------------------
-Input file with saved parameters: optimize.sav
-#========================================================#
-#| [94m     Iteration 5: Evaluating objective function     [0m |#
-#| [94m        and derivatives through second order        [0m |#
-#========================================================#
-
-#======================================================================================================================#
-#| [92m                                  Optimized Geometries, Objective =  4.56868e+00                                  [0m |#
-#| [92m  System                       Bonds            Angles           Dihedrals         Impropers               Term.  [0m |#
-#| [92m                            RMSD   denom      RMSD   denom      RMSD   denom      RMSD   denom                    [0m |#
-#======================================================================================================================#
-9HXanthene                    0.020    0.01     0.023    0.03     0.076    0.20     0.005    0.20             4.569 
-------------------------------------------------------------------------------------------------------------------------
-
-#==========================================================================#
-#|                       Frequencies (wavenumbers)                        |#
-#|  Target: vibration  Type: Vibration_SMIRNOFF  Objective = 1.38473e+01  |#
-#|  Mode #            Reference   Calculated   Difference   Ref(dot)Calc  |#
-#==========================================================================#
-    0                   31.1817      35.7145       4.5328         0.9919 
-    1                  127.2863     135.8907       8.6044         0.9969 
-    2                  200.5311     227.2535      26.7224         0.9382 
-    3                  245.4174     234.2897     -11.1277         0.9373 
-    4                  258.8788     241.8322     -17.0466         0.9955 
-    5                  295.5887     303.6477       8.0590         0.9873 
-    6                  385.5805     341.9728     -43.6077         0.9888 
-    7                  413.3227     435.4772      22.1545         0.9686 
-    8                  461.1571     444.1308     -17.0263         0.9818 
-    9                  468.4759     456.4048     -12.0711         0.9887 
-    10                 553.9686     516.7264     -37.2422         0.9574 
-    11                 557.9183     531.3905     -26.5278         0.9528 
-    12                 559.2968     551.5787      -7.7181         0.9404 
-    13                 609.7540     616.8423       7.0883         0.0013 
-    14                 650.9588     629.7645     -21.1943         0.0039 
-    15                 691.9021     656.6716     -35.2305         0.7102 
-    16                 731.3959     696.8697     -34.5262         0.9506 
-    17                 748.6224     725.9485     -22.6739         0.9811 
-    18                 757.4865     727.4758     -30.0107         0.9604 
-    19                 793.4162     745.4930     -47.9232         0.0481 
-    20                 796.3137     749.7865     -46.5272         0.0485 
-    21                 829.9391     793.7938     -36.1453         0.9801 
-    22                 886.2937     871.9356     -14.3581         0.0060 
-    23                 898.9488     878.7676     -20.1812         0.3123 
-    24                 905.1053     885.2295     -19.8758         0.0868 
-    25                 931.8180     907.2645     -24.5535         0.0039 
-    26                 972.6908     950.9623     -21.7285         0.5017 
-    27                 981.1443    1007.1806      26.0363         0.0017 
-    28                1002.3531    1018.0309      15.6778         0.0024 
-    29                1002.6108    1039.3586      36.7478         0.0569 
-    30                1006.9971    1043.4067      36.4096         0.5000 
-    31                1043.4229    1113.8299      70.4070         0.0021 
-    32                1045.2039    1114.0837      68.8798         0.0007 
-    33                1101.4212    1114.5532      13.1320         0.0015 
-    34                1122.1664    1130.9910       8.8246         0.7557 
-    35                1175.8590    1188.4036      12.5446         0.2293 
-    36                1177.5535    1196.9054      19.3519         0.3801 
-    37                1180.0345    1228.6233      48.5888         0.0204 
-    38                1198.0738    1240.6285      42.5547         0.0102 
-    39                1209.4283    1276.7259      67.2976         0.4391 
-    40                1213.4868    1285.3225      71.8357         0.0123 
-    41                1233.7197    1295.8955      62.1758         0.0176 
-    42                1248.6007    1373.1100     124.5093         0.0133 
-    43                1296.1008    1415.4376     119.3368         0.1583 
-    44                1311.1904    1434.3811     123.1907         0.2637 
-    45                1325.6114    1508.8691     183.2577         0.0197 
-    46                1351.5363    1563.1251     211.5888         0.0021 
-    47                1456.1390    1608.4986     152.3596         0.8557 
-    48                1461.1551    1638.4250     177.2699         0.1941 
-    49                1467.0845    1651.2218     184.1373         0.0241 
-    50                1486.3167    1718.1517     231.8350         0.1599 
-    51                1498.4933    1757.8043     259.3110         0.0766 
-    52                1571.5221    1768.9093     197.3872         0.5564 
-    53                1591.5923    1772.7286     181.1363         0.7997 
-    54                1597.5166    1800.8148     203.2982         0.0345 
-    55                1620.6702    1840.1705     219.5003         0.0281 
-    56                2881.8985    2913.1388      31.2403         0.8761 
-    57                2918.3100    2977.6120      59.3020         0.8772 
-    58                3057.8158    3066.5483       8.7325         0.3731 
-    59                3058.9610    3066.5902       7.6292         0.3400 
-    60                3076.7507    3066.7897      -9.9610         0.2172 
-    61                3076.9099    3066.8146     -10.0953         0.2110 
-    62                3093.3546    3067.2524     -26.1022         0.0071 
-    63                3093.7472    3067.2663     -26.4809         0.0195 
-    64                3108.9905    3068.5485     -40.4420         0.7541 
-    65                3109.6289    3068.6409     -40.9880         0.7586 
-----------------------------------------------------------------------------
-#===================================================================================#
-#| [94m                         Objective Function Breakdown                          [0m |#
-#| [94m  Target Name              Residual  x  Weight  =  Contribution (Current-Prev) [0m |#
-#===================================================================================#
-optgeo                         4.56868      1.000 [92m     4.56868e+00[0m ( -2.433e-01 ) 
-vibration                     13.84730      1.000 [92m     1.38473e+01[0m ( -1.911e+00 ) 
-Regularization                 2.96606      1.000 [91m     2.96606e+00[0m ( +1.306e+00 ) 
-Total                                             [92m     2.13820e+01[0m ( -8.481e-01 ) 
--------------------------------------------------------------------------------------
-Backing up result/optimize/smirnoff99Frosst.offxml -> result/optimize/smirnoff99Frosst_49.offxml
-#========================================================================#
-#|  The force field has been written to the result/optimize directory.  |#
-#|    Input file with optimization parameters saved to optimize.sav.    |#
-#========================================================================#
-
-  Step       |k|        |dk|       |grad|       -=X2=-     Delta(X2)    StepQual
-     5   1.722e+00   4.403e-01   1.399e+00[92m   2.13820e+01[0m  -8.481e-01      0.978
-
-#========================================================#
-#| [94m                   Total Gradient                   [0m |#
-#========================================================#
-   0 [  1.76285380e-01 ] : HarmonicBondForce/Bond/k/[#6X3:1]:[#6X3:2]
-   1 [  1.17682885e-01 ] : HarmonicBondForce/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [  2.53130031e-02 ] : HarmonicBondForce/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [ -3.22033774e-01 ] : HarmonicBondForce/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [  3.18420932e-02 ] : HarmonicBondForce/Bond/k/[#6X4:1]-[#1:2]
-   5 [ -9.54662565e-02 ] : HarmonicBondForce/Bond/length/[#6X4:1]-[#1:2]
-   6 [ -4.48739950e-02 ] : HarmonicBondForce/Bond/k/[#6X3:1]-[#1:2]
-   7 [ -1.00834164e-01 ] : HarmonicBondForce/Bond/length/[#6X3:1]-[#1:2]
-   8 [  8.61497648e-02 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [  1.21925207e-01 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [ -9.51179526e-02 ] : HarmonicAngleForce/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [  1.91978270e-01 ] : HarmonicAngleForce/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [ -4.20697213e-01 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [  1.15383380e+00 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [  2.12607628e-01 ] : HarmonicAngleForce/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [ -7.13113082e-03 ] : HarmonicAngleForce/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [ -3.94836047e-01 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
-  17 [ -1.46377171e-02 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [  1.65003022e-02 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X4]
-  19 [  2.22039924e-02 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [  4.90177541e-02 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X3]
-  21 [  5.81477046e-02 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [  2.49041521e-04 ] : NonbondedForce/Atom/epsilon/[#6X4:1]
-  23 [  4.07444993e-03 ] : NonbondedForce/Atom/rmin_half/[#6X4:1]
-  24 [ -1.66938014e-04 ] : NonbondedForce/Atom/epsilon/[#8X2H0+0:1]
-  25 [  6.94899539e-03 ] : NonbondedForce/Atom/rmin_half/[#8X2H0+0:1]
-----------------------------------------------------------
-Increasing trust radius to  4.8139e-01
-Calculating nonlinear optimization step
-Newton-Raphson step found (length 4.1741e-01)
-#========================================================#
-#| [95m  Mathematical Parameters (Current + Step = Next)   [0m |#
-#========================================================#
-   0 [ -1.7868e-01 - 7.1897e-02 = -2.5058e-01 ] : HarmonicBondForce/Bond/k/[#6X3:1]:[#6X3:2]
-   1 [ -1.4755e-01 - 5.9340e-02 = -2.0689e-01 ] : HarmonicBondForce/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [ -2.6765e-02 - 9.3834e-03 = -3.6148e-02 ] : HarmonicBondForce/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [  3.4368e-01 + 1.4452e-01 =  4.8821e-01 ] : HarmonicBondForce/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [ -3.3090e-02 - 1.5537e-02 = -4.8627e-02 ] : HarmonicBondForce/Bond/k/[#6X4:1]-[#1:2]
-   5 [  1.1317e-01 + 4.0240e-02 =  1.5341e-01 ] : HarmonicBondForce/Bond/length/[#6X4:1]-[#1:2]
-   6 [  4.6096e-02 + 2.1344e-02 =  6.7440e-02 ] : HarmonicBondForce/Bond/k/[#6X3:1]-[#1:2]
-   7 [  3.1219e-01 + 2.6374e-02 =  3.3856e-01 ] : HarmonicBondForce/Bond/length/[#6X3:1]-[#1:2]
-   8 [ -2.0007e-01 - 3.2891e-02 = -2.3296e-01 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [ -1.5674e-01 - 4.7130e-02 = -2.0388e-01 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [  1.8172e-01 + 9.4989e-03 =  1.9122e-01 ] : HarmonicAngleForce/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [ -2.1159e-01 - 6.3646e-02 = -2.7523e-01 ] : HarmonicAngleForce/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [ -2.3255e-01 + 3.7185e-02 = -1.9537e-01 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [ -1.5286e+00 - 3.5242e-01 = -1.8810e+00 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [ -3.2306e-01 - 9.0163e-02 = -4.1322e-01 ] : HarmonicAngleForce/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [  2.5611e-03 + 4.3249e-03 =  6.8860e-03 ] : HarmonicAngleForce/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [ -1.6469e-01 + 8.7356e-03 = -1.5596e-01 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
-  17 [  1.7390e-02 + 6.4145e-03 =  2.3805e-02 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [ -2.2409e-02 - 6.1941e-03 = -2.8603e-02 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X4]
-  19 [ -2.9754e-02 - 8.2618e-03 = -3.8016e-02 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [ -7.0707e-02 - 8.7263e-03 = -7.9433e-02 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X3]
-  21 [ -9.2778e-02 - 8.7989e-03 = -1.0158e-01 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [ -7.6945e-04 + 2.3927e-04 = -5.3018e-04 ] : NonbondedForce/Atom/epsilon/[#6X4:1]
-  23 [ -6.3453e-03 + 1.0125e-03 = -5.3328e-03 ] : NonbondedForce/Atom/rmin_half/[#6X4:1]
-  24 [ -8.5397e-04 + 4.0096e-04 = -4.5301e-04 ] : NonbondedForce/Atom/epsilon/[#8X2H0+0:1]
-  25 [ -9.2008e-03 + 1.0170e-03 = -8.1838e-03 ] : NonbondedForce/Atom/rmin_half/[#8X2H0+0:1]
-----------------------------------------------------------
-#========================================================#
-#| [95m    Physical Parameters (Current + Step = Next)     [0m |#
-#========================================================#
-   0 [  9.3621e+02 - 7.1897e-01 =  9.3549e+02 ] : HarmonicBondForce/Bond/k/[#6X3:1]:[#6X3:2]
-   1 [  1.3985e+00 - 5.9340e-04 =  1.3979e+00 ] : HarmonicBondForce/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [  8.9973e+02 - 9.3834e-02 =  8.9964e+02 ] : HarmonicBondForce/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [  1.3264e+00 + 1.4452e-03 =  1.3279e+00 ] : HarmonicBondForce/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [  6.7967e+02 - 1.5537e-01 =  6.7951e+02 ] : HarmonicBondForce/Bond/k/[#6X4:1]-[#1:2]
-   5 [  1.0911e+00 + 4.0240e-04 =  1.0915e+00 ] : HarmonicBondForce/Bond/length/[#6X4:1]-[#1:2]
-   6 [  7.3446e+02 + 2.1344e-01 =  7.3467e+02 ] : HarmonicBondForce/Bond/k/[#6X3:1]-[#1:2]
-   7 [  1.0831e+00 + 2.6374e-04 =  1.0834e+00 ] : HarmonicBondForce/Bond/length/[#6X3:1]-[#1:2]
-   8 [  1.0750e+02 - 3.2891e-01 =  1.0717e+02 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [  6.8433e+01 - 4.7130e-01 =  6.7961e+01 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [  1.2182e+02 + 9.4989e-02 =  1.2191e+02 ] : HarmonicAngleForce/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [  1.3788e+02 - 6.3646e-01 =  1.3725e+02 ] : HarmonicAngleForce/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [  1.1767e+02 + 3.7185e-01 =  1.1805e+02 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [  8.4714e+01 - 3.5242e+00 =  8.1190e+01 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [  1.1677e+02 - 9.0163e-01 =  1.1587e+02 ] : HarmonicAngleForce/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [  1.4003e+02 + 4.3249e-02 =  1.4007e+02 ] : HarmonicAngleForce/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [  3.4603e+00 + 8.7356e-03 =  3.4690e+00 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
-  17 [  1.0674e+00 + 6.4145e-03 =  1.0738e+00 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [  1.5476e-02 - 6.1941e-05 =  1.5414e-02 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X4]
-  19 [  1.4840e+00 - 8.2618e-04 =  1.4832e+00 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [  1.4293e-02 - 8.7263e-05 =  1.4206e-02 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X3]
-  21 [  1.4497e+00 - 8.7989e-04 =  1.4488e+00 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [  1.0939e-01 + 2.3927e-06 =  1.0939e-01 ] : NonbondedForce/Atom/epsilon/[#6X4:1]
-  23 [  1.9074e+00 + 1.0125e-04 =  1.9075e+00 ] : NonbondedForce/Atom/rmin_half/[#6X4:1]
-  24 [  1.6999e-01 + 4.0096e-06 =  1.7000e-01 ] : NonbondedForce/Atom/epsilon/[#8X2H0+0:1]
-  25 [  1.6828e+00 + 1.0170e-04 =  1.6829e+00 ] : NonbondedForce/Atom/rmin_half/[#8X2H0+0:1]
-----------------------------------------------------------
-Input file with saved parameters: optimize.sav
-#========================================================#
-#| [94m     Iteration 6: Evaluating objective function     [0m |#
-#| [94m        and derivatives through second order        [0m |#
-#========================================================#
-
-#======================================================================================================================#
-#| [92m                                  Optimized Geometries, Objective =  4.29049e+00                                  [0m |#
-#| [92m  System                       Bonds            Angles           Dihedrals         Impropers               Term.  [0m |#
-#| [92m                            RMSD   denom      RMSD   denom      RMSD   denom      RMSD   denom                    [0m |#
-#======================================================================================================================#
-9HXanthene                    0.019    0.01     0.022    0.03     0.076    0.20     0.005    0.20             4.290 
-------------------------------------------------------------------------------------------------------------------------
-
-#==========================================================================#
-#|                       Frequencies (wavenumbers)                        |#
-#|  Target: vibration  Type: Vibration_SMIRNOFF  Objective = 1.23345e+01  |#
-#|  Mode #            Reference   Calculated   Difference   Ref(dot)Calc  |#
-#==========================================================================#
-    0                   31.1817      34.1423       2.9606         0.9920 
-    1                  127.2863     135.9181       8.6318         0.9969 
-    2                  200.5311     227.3766      26.8455         0.9384 
-    3                  245.4174     234.1208     -11.2966         0.9373 
-    4                  258.8788     242.7866     -16.0922         0.9956 
-    5                  295.5887     302.8959       7.3072         0.9873 
-    6                  385.5805     341.4104     -44.1701         0.9888 
-    7                  413.3227     434.8851      21.5624         0.9689 
-    8                  461.1571     444.9444     -16.2127         0.9819 
-    9                  468.4759     457.4701     -11.0058         0.9890 
-    10                 553.9686     517.8090     -36.1596         0.9574 
-    11                 557.9183     531.7903     -26.1280         0.9530 
-    12                 559.2968     550.2673      -9.0295         0.9408 
-    13                 609.7540     614.8242       5.0702         0.0013 
-    14                 650.9588     628.4984     -22.4604         0.0039 
-    15                 691.9021     655.1196     -36.7825         0.7050 
-    16                 731.3959     698.5622     -32.8337         0.9530 
-    17                 748.6224     725.8898     -22.7326         0.0139 
-    18                 757.4865     728.1530     -29.3335         0.0118 
-    19                 793.4162     751.8192     -41.5970         0.0486 
-    20                 796.3137     755.4654     -40.8483         0.0486 
-    21                 829.9391     792.6634     -37.2757         0.9809 
-    22                 886.2937     868.5672     -17.7265         0.0060 
-    23                 898.9488     875.5148     -23.4340         0.3122 
-    24                 905.1053     889.0934     -16.0119         0.0848 
-    25                 931.8180     913.7884     -18.0296         0.0039 
-    26                 972.6908     953.3873     -19.3035         0.4828 
-    27                 981.1443    1003.3147      22.1704         0.0017 
-    28                1002.3531    1012.9996      10.6465         0.0024 
-    29                1002.6108    1046.3640      43.7532         0.0570 
-    30                1006.9971    1050.2456      43.2485         0.4930 
-    31                1043.4229    1104.1381      60.7152         0.0025 
-    32                1045.2039    1119.3947      74.1908         0.0157 
-    33                1101.4212    1121.7408      20.3196         0.0174 
-    34                1122.1664    1122.2106       0.0442         0.0230 
-    35                1175.8590    1182.0006       6.1416         0.3582 
-    36                1177.5535    1185.4336       7.8801         0.5051 
-    37                1180.0345    1211.9902      31.9557         0.0201 
-    38                1198.0738    1228.5131      30.4393         0.0122 
-    39                1209.4283    1265.6203      56.1920         0.4324 
-    40                1213.4868    1285.4923      72.0055         0.0123 
-    41                1233.7197    1290.2472      56.5275         0.0149 
-    42                1248.6007    1353.8471     105.2464         0.0133 
-    43                1296.1008    1409.3835     113.2827         0.1020 
-    44                1311.1904    1416.8770     105.6866         0.2812 
-    45                1325.6114    1494.0095     168.3981         0.0164 
-    46                1351.5363    1542.6982     191.1619         0.0014 
-    47                1456.1390    1595.8833     139.7443         0.8298 
-    48                1461.1551    1620.2829     159.1278         0.1962 
-    49                1467.0845    1638.8986     171.8141         0.0242 
-    50                1486.3167    1714.1968     227.8801         0.0913 
-    51                1498.4933    1752.1764     253.6831         0.0734 
-    52                1571.5221    1759.5657     188.0436         0.5488 
-    53                1591.5923    1767.0148     175.4225         0.7824 
-    54                1597.5166    1791.2094     193.6928         0.0364 
-    55                1620.6702    1833.0357     212.3655         0.0278 
-    56                2881.8985    2913.2663      31.3678         0.8759 
-    57                2918.3100    2976.8104      58.5004         0.8774 
-    58                3057.8158    3066.8817       9.0659         0.3529 
-    59                3058.9610    3066.9207       7.9597         0.3154 
-    60                3076.7507    3067.1323      -9.6184         0.1914 
-    61                3076.9099    3067.1560      -9.7539         0.1808 
-    62                3093.3546    3067.4977     -25.8569         0.0306 
-    63                3093.7472    3067.5138     -26.2334         0.0635 
-    64                3108.9905    3068.8722     -40.1183         0.7702 
-    65                3109.6289    3068.9657     -40.6632         0.7738 
-----------------------------------------------------------------------------
-#===================================================================================#
-#| [94m                         Objective Function Breakdown                          [0m |#
-#| [94m  Target Name              Residual  x  Weight  =  Contribution (Current-Prev) [0m |#
-#===================================================================================#
-optgeo                         4.29049      1.000 [92m     4.29049e+00[0m ( -2.782e-01 ) 
-vibration                     12.33454      1.000 [92m     1.23345e+01[0m ( -1.513e+00 ) 
-Regularization                 4.48959      1.000 [91m     4.48959e+00[0m ( +1.524e+00 ) 
-Total                                             [92m     2.11146e+01[0m ( -2.674e-01 ) 
--------------------------------------------------------------------------------------
-Backing up result/optimize/smirnoff99Frosst.offxml -> result/optimize/smirnoff99Frosst_50.offxml
-#========================================================================#
-#|  The force field has been written to the result/optimize directory.  |#
-#|    Input file with optimization parameters saved to optimize.sav.    |#
-#========================================================================#
-
-  Step       |k|        |dk|       |grad|       -=X2=-     Delta(X2)    StepQual
-     6   2.119e+00   4.174e-01   8.642e-01[92m   2.11146e+01[0m  -2.674e-01      0.986
-
-#========================================================#
-#| [94m                   Total Gradient                   [0m |#
-#========================================================#
-   0 [  1.84152934e-02 ] : HarmonicBondForce/Bond/k/[#6X3:1]:[#6X3:2]
-   1 [ -3.01817222e-02 ] : HarmonicBondForce/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [  2.06912627e-03 ] : HarmonicBondForce/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [ -2.15381757e-03 ] : HarmonicBondForce/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [ -7.27648804e-05 ] : HarmonicBondForce/Bond/k/[#6X4:1]-[#1:2]
-   5 [  1.59633396e-03 ] : HarmonicBondForce/Bond/length/[#6X4:1]-[#1:2]
-   6 [ -1.02683094e-04 ] : HarmonicBondForce/Bond/k/[#6X3:1]-[#1:2]
-   7 [  6.03138946e-02 ] : HarmonicBondForce/Bond/length/[#6X3:1]-[#1:2]
-   8 [ -3.58344954e-02 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [  3.18558518e-03 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [ -8.93367501e-02 ] : HarmonicAngleForce/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [  2.37156527e-02 ] : HarmonicAngleForce/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [ -5.55924828e-01 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [  7.04456358e-02 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [ -5.20583247e-02 ] : HarmonicAngleForce/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [ -1.02318247e-03 ] : HarmonicAngleForce/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [ -6.43969394e-01 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
-  17 [ -2.01473953e-03 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [  1.08132510e-03 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X4]
-  19 [  1.95510485e-04 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [  1.59369478e-02 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X3]
-  21 [  2.02581310e-02 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [ -6.68514996e-06 ] : NonbondedForce/Atom/epsilon/[#6X4:1]
-  23 [  3.13595566e-03 ] : NonbondedForce/Atom/rmin_half/[#6X4:1]
-  24 [  8.30052185e-04 ] : NonbondedForce/Atom/epsilon/[#8X2H0+0:1]
-  25 [  6.43857143e-03 ] : NonbondedForce/Atom/rmin_half/[#8X2H0+0:1]
-----------------------------------------------------------
-Calculating nonlinear optimization step
-Newton-Raphson step found (length 7.4033e-02)
-#========================================================#
-#| [95m  Mathematical Parameters (Current + Step = Next)   [0m |#
-#========================================================#
-   0 [ -2.5058e-01 - 8.2358e-03 = -2.5881e-01 ] : HarmonicBondForce/Bond/k/[#6X3:1]:[#6X3:2]
-   1 [ -2.0689e-01 + 1.6328e-02 = -1.9056e-01 ] : HarmonicBondForce/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [ -3.6148e-02 - 8.6682e-04 = -3.7015e-02 ] : HarmonicBondForce/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [  4.8821e-01 + 2.4592e-03 =  4.9067e-01 ] : HarmonicBondForce/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [ -4.8627e-02 + 2.8415e-05 = -4.8598e-02 ] : HarmonicBondForce/Bond/k/[#6X4:1]-[#1:2]
-   5 [  1.5341e-01 - 1.8487e-04 =  1.5322e-01 ] : HarmonicBondForce/Bond/length/[#6X4:1]-[#1:2]
-   6 [  6.7440e-02 + 1.2698e-04 =  6.7567e-02 ] : HarmonicBondForce/Bond/k/[#6X3:1]-[#1:2]
-   7 [  3.3856e-01 - 1.6196e-02 =  3.2236e-01 ] : HarmonicBondForce/Bond/length/[#6X3:1]-[#1:2]
-   8 [ -2.3296e-01 + 1.2413e-02 = -2.2054e-01 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [ -2.0388e-01 - 1.4626e-03 = -2.0534e-01 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [  1.9122e-01 - 1.3109e-02 =  1.7811e-01 ] : HarmonicAngleForce/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [ -2.7523e-01 - 1.0167e-02 = -2.8540e-01 ] : HarmonicAngleForce/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [ -1.9537e-01 + 3.6799e-02 = -1.5857e-01 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [ -1.8810e+00 - 1.7892e-02 = -1.8989e+00 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [ -4.1322e-01 + 2.3993e-02 = -3.8923e-01 ] : HarmonicAngleForce/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [  6.8860e-03 + 6.9559e-04 =  7.5816e-03 ] : HarmonicAngleForce/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [ -1.5596e-01 + 4.5179e-02 = -1.1078e-01 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
-  17 [  2.3805e-02 - 3.1364e-03 =  2.0668e-02 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [ -2.8603e-02 - 6.0803e-04 = -2.9211e-02 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X4]
-  19 [ -3.8016e-02 - 2.1413e-04 = -3.8230e-02 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [ -7.9433e-02 - 6.9701e-03 = -8.6403e-02 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X3]
-  21 [ -1.0158e-01 - 9.1424e-03 = -1.1072e-01 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [ -5.3018e-04 + 2.0630e-05 = -5.0955e-04 ] : NonbondedForce/Atom/epsilon/[#6X4:1]
-  23 [ -5.3328e-03 - 1.4526e-03 = -6.7854e-03 ] : NonbondedForce/Atom/rmin_half/[#6X4:1]
-  24 [ -4.5301e-04 - 4.0405e-04 = -8.5706e-04 ] : NonbondedForce/Atom/epsilon/[#8X2H0+0:1]
-  25 [ -8.1838e-03 - 3.0951e-03 = -1.1279e-02 ] : NonbondedForce/Atom/rmin_half/[#8X2H0+0:1]
-----------------------------------------------------------
-#========================================================#
-#| [95m    Physical Parameters (Current + Step = Next)     [0m |#
-#========================================================#
-   0 [  9.3549e+02 - 8.2358e-02 =  9.3541e+02 ] : HarmonicBondForce/Bond/k/[#6X3:1]:[#6X3:2]
-   1 [  1.3979e+00 + 1.6328e-04 =  1.3981e+00 ] : HarmonicBondForce/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [  8.9964e+02 - 8.6682e-03 =  8.9963e+02 ] : HarmonicBondForce/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [  1.3279e+00 + 2.4592e-05 =  1.3279e+00 ] : HarmonicBondForce/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [  6.7951e+02 + 2.8415e-04 =  6.7951e+02 ] : HarmonicBondForce/Bond/k/[#6X4:1]-[#1:2]
-   5 [  1.0915e+00 - 1.8487e-06 =  1.0915e+00 ] : HarmonicBondForce/Bond/length/[#6X4:1]-[#1:2]
-   6 [  7.3467e+02 + 1.2698e-03 =  7.3468e+02 ] : HarmonicBondForce/Bond/k/[#6X3:1]-[#1:2]
-   7 [  1.0834e+00 - 1.6196e-04 =  1.0832e+00 ] : HarmonicBondForce/Bond/length/[#6X3:1]-[#1:2]
-   8 [  1.0717e+02 + 1.2413e-01 =  1.0729e+02 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [  6.7961e+01 - 1.4626e-02 =  6.7947e+01 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [  1.2191e+02 - 1.3109e-01 =  1.2178e+02 ] : HarmonicAngleForce/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [  1.3725e+02 - 1.0167e-01 =  1.3715e+02 ] : HarmonicAngleForce/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [  1.1805e+02 + 3.6799e-01 =  1.1841e+02 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [  8.1190e+01 - 1.7892e-01 =  8.1011e+01 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [  1.1587e+02 + 2.3993e-01 =  1.1611e+02 ] : HarmonicAngleForce/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [  1.4007e+02 + 6.9559e-03 =  1.4008e+02 ] : HarmonicAngleForce/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [  3.4690e+00 + 4.5179e-02 =  3.5142e+00 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
-  17 [  1.0738e+00 - 3.1364e-03 =  1.0707e+00 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [  1.5414e-02 - 6.0803e-06 =  1.5408e-02 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X4]
-  19 [  1.4832e+00 - 2.1413e-05 =  1.4832e+00 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [  1.4206e-02 - 6.9701e-05 =  1.4136e-02 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X3]
-  21 [  1.4488e+00 - 9.1424e-04 =  1.4479e+00 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [  1.0939e-01 + 2.0630e-07 =  1.0939e-01 ] : NonbondedForce/Atom/epsilon/[#6X4:1]
-  23 [  1.9075e+00 - 1.4526e-04 =  1.9073e+00 ] : NonbondedForce/Atom/rmin_half/[#6X4:1]
-  24 [  1.7000e-01 - 4.0405e-06 =  1.6999e-01 ] : NonbondedForce/Atom/epsilon/[#8X2H0+0:1]
-  25 [  1.6829e+00 - 3.0951e-04 =  1.6826e+00 ] : NonbondedForce/Atom/rmin_half/[#8X2H0+0:1]
-----------------------------------------------------------
-Input file with saved parameters: optimize.sav
-#========================================================#
-#| [94m     Iteration 7: Evaluating objective function     [0m |#
-#| [94m        and derivatives through second order        [0m |#
-#========================================================#
-
-#======================================================================================================================#
-#| [92m                                  Optimized Geometries, Objective =  4.31002e+00                                  [0m |#
+#| [92m                                         optgeo, Objective =  4.31049e+00                                         [0m |#
 #| [92m  System                       Bonds            Angles           Dihedrals         Impropers               Term.  [0m |#
 #| [92m                            RMSD   denom      RMSD   denom      RMSD   denom      RMSD   denom                    [0m |#
 #======================================================================================================================#
@@ -1669,192 +748,2075 @@ Input file with saved parameters: optimize.sav
 
 #==========================================================================#
 #|                       Frequencies (wavenumbers)                        |#
-#|  Target: vibration  Type: Vibration_SMIRNOFF  Objective = 1.22776e+01  |#
+#|  Target: vibration  Type: Vibration_SMIRNOFF  Objective = 7.62565e+00  |#
 #|  Mode #            Reference   Calculated   Difference   Ref(dot)Calc  |#
 #==========================================================================#
-    0                   31.1817      34.3862       3.2045         0.9920 
-    1                  127.2863     136.5856       9.2993         0.9969 
-    2                  200.5311     228.4496      27.9185         0.9383 
-    3                  245.4174     233.9764     -11.4410         0.9373 
-    4                  258.8788     243.6902     -15.1886         0.9956 
-    5                  295.5887     304.2910       8.7023         0.9874 
-    6                  385.5805     341.3309     -44.2496         0.9888 
-    7                  413.3227     434.5774      21.2547         0.9690 
-    8                  461.1571     445.4418     -15.7153         0.9819 
-    9                  468.4759     457.9855     -10.4904         0.9889 
-    10                 553.9686     518.8035     -35.1651         0.9576 
-    11                 557.9183     533.1012     -24.8171         0.9532 
-    12                 559.2968     550.2047      -9.0921         0.9409 
-    13                 609.7540     614.2581       4.5041         0.0013 
-    14                 650.9588     628.2965     -22.6623         0.0039 
-    15                 691.9021     654.9702     -36.9319         0.7078 
-    16                 731.3959     700.7006     -30.6953         0.9550 
-    17                 748.6224     725.5363     -23.0861         0.0139 
-    18                 757.4865     729.9142     -27.5723         0.0118 
-    19                 793.4162     760.6058     -32.8104         0.0490 
-    20                 796.3137     763.6123     -32.7014         0.0486 
-    21                 829.9391     792.6048     -37.3343         0.9810 
-    22                 886.2937     868.2146     -18.0791         0.0060 
-    23                 898.9488     875.0977     -23.8511         0.3123 
-    24                 905.1053     895.2650      -9.8403         0.0816 
-    25                 931.8180     923.4271      -8.3909         0.0038 
-    26                 972.6908     957.7669     -14.9239         0.4550 
-    27                 981.1443    1002.9628      21.8185         0.0017 
-    28                1002.3531    1012.5372      10.1841         0.0024 
-    29                1002.6108    1057.4440      54.8332         0.0571 
-    30                1006.9971    1061.1218      54.1247         0.4837 
-    31                1043.4229    1103.7112      60.2883         0.0026 
-    32                1045.2039    1118.7601      73.5562         0.0157 
-    33                1101.4212    1133.6188      32.1976         0.0174 
-    34                1122.1664    1134.0714      11.9050         0.0229 
-    35                1175.8590    1181.7196       5.8606         0.3666 
-    36                1177.5535    1184.8154       7.2619         0.5106 
-    37                1180.0345    1211.0727      31.0382         0.0200 
-    38                1198.0738    1227.7112      29.6374         0.0122 
-    39                1209.4283    1265.0678      55.6395         0.4317 
-    40                1213.4868    1285.5197      72.0329         0.0123 
-    41                1233.7197    1289.7131      55.9934         0.0148 
-    42                1248.6007    1352.8136     104.2129         0.0133 
-    43                1296.1008    1409.4218     113.3210         0.0980 
-    44                1311.1904    1416.1986     105.0082         0.2817 
-    45                1325.6114    1493.4611     167.8497         0.0162 
-    46                1351.5363    1541.7606     190.2243         0.0014 
-    47                1456.1390    1595.3320     139.1930         0.8283 
-    48                1461.1551    1619.2302     158.0751         0.1968 
-    49                1467.0845    1638.2104     171.1259         0.0242 
-    50                1486.3167    1714.1248     227.8081         0.0888 
-    51                1498.4933    1751.7790     253.2857         0.0729 
-    52                1571.5221    1758.9783     187.4562         0.5487 
-    53                1591.5923    1766.7641     175.1718         0.7800 
-    54                1597.5166    1790.4338     192.9172         0.0364 
-    55                1620.6702    1832.4257     211.7555         0.0278 
-    56                2881.8985    2913.0969      31.1984         0.8760 
-    57                2918.3100    2976.9845      58.6745         0.8773 
-    58                3057.8158    3066.8724       9.0566         0.3492 
-    59                3058.9610    3066.9110       7.9500         0.3114 
-    60                3076.7507    3067.1059      -9.6448         0.1913 
-    61                3076.9099    3067.1296      -9.7803         0.1801 
-    62                3093.3546    3067.4847     -25.8699         0.0340 
-    63                3093.7472    3067.5011     -26.2461         0.0669 
-    64                3108.9905    3068.8537     -40.1368         0.7706 
-    65                3109.6289    3068.9473     -40.6816         0.7743 
+    0                   31.1817      54.4059      23.2242         0.9908 
+    1                  127.2863     137.3924      10.1061         0.9950 
+    2                  200.5311     224.2878      23.7567         0.9326 
+    3                  245.4174     230.9935     -14.4239         0.9373 
+    4                  258.8788     240.1857     -18.6931         0.9939 
+    5                  295.5887     320.8013      25.2126         0.9750 
+    6                  385.5805     329.6971     -55.8834         0.9893 
+    7                  413.3227     417.0504       3.7277         0.9725 
+    8                  461.1571     434.3372     -26.8199         0.9809 
+    9                  468.4759     452.0916     -16.3843         0.9884 
+    10                 553.9686     508.3788     -45.5898         0.9583 
+    11                 557.9183     539.6872     -18.2311         0.9410 
+    12                 559.2968     543.5809     -15.7159         0.9438 
+    13                 609.7540     604.0198      -5.7342         0.0013 
+    14                 650.9588     617.3847     -33.5741         0.0034 
+    15                 691.9021     624.5236     -67.3785         0.8418 
+    16                 731.3959     692.7602     -38.6357         0.9332 
+    17                 748.6224     698.6893     -49.9331         0.0139 
+    18                 757.4865     718.1322     -39.3543         0.0118 
+    19                 793.4162     746.6266     -46.7896         0.0488 
+    20                 796.3137     753.0862     -43.2275         0.0030 
+    21                 829.9391     754.4044     -75.5347         0.0015 
+    22                 886.2937     861.5715     -24.7222         0.0056 
+    23                 898.9488     869.1707     -29.7781         0.3109 
+    24                 905.1053     870.6315     -34.4738         0.0757 
+    25                 931.8180     905.2251     -26.5929         0.0036 
+    26                 972.6908     933.9343     -38.7565         0.4112 
+    27                 981.1443     942.5691     -38.5752         0.0016 
+    28                1002.3531     958.7992     -43.5539         0.0022 
+    29                1002.6108    1037.5971      34.9863         0.0569 
+    30                1006.9971    1041.1976      34.2005         0.4725 
+    31                1043.4229    1070.7683      27.3454         0.0002 
+    32                1045.2039    1089.3537      44.1498         0.0083 
+    33                1101.4212    1111.5878      10.1666         0.0176 
+    34                1122.1664    1112.0192     -10.1472         0.0229 
+    35                1175.8590    1159.5639     -16.2951         0.0350 
+    36                1177.5535    1160.3693     -17.1842         0.0572 
+    37                1180.0345    1205.7586      25.7241         0.0173 
+    38                1198.0738    1219.4080      21.3342         0.0088 
+    39                1209.4283    1237.5135      28.0852         0.4323 
+    40                1213.4868    1252.0453      38.5585         0.0123 
+    41                1233.7197    1269.3490      35.6293         0.0130 
+    42                1248.6007    1351.4168     102.8161         0.0073 
+    43                1296.1008    1375.9352      79.8344         0.5759 
+    44                1311.1904    1425.2156     114.0252         0.2577 
+    45                1325.6114    1500.9794     175.3680         0.0237 
+    46                1351.5363    1544.4939     192.9576         0.0038 
+    47                1456.1390    1571.2096     115.0706         0.6497 
+    48                1461.1551    1592.6695     131.5144         0.0170 
+    49                1467.0845    1606.1842     139.0997         0.3368 
+    50                1486.3167    1634.0750     147.7583         0.6889 
+    51                1498.4933    1637.9373     139.4440         0.2620 
+    52                1571.5221    1685.1330     113.6109         0.5822 
+    53                1591.5923    1689.4322      97.8399         0.7225 
+    54                1597.5166    1726.0614     128.5448         0.0400 
+    55                1620.6702    1772.5415     151.8713         0.0269 
+    56                2881.8985    2896.1354      14.2369         0.8761 
+    57                2918.3100    2960.4448      42.1348         0.8770 
+    58                3057.8158    3077.2774      19.4616         0.2966 
+    59                3058.9610    3077.4265      18.4655         0.2556 
+    60                3076.7507    3077.8930       1.1423         0.2804 
+    61                3076.9099    3077.9690       1.0591         0.3035 
+    62                3093.3546    3078.9512     -14.4034         0.0793 
+    63                3093.7472    3079.0002     -14.7470         0.1113 
+    64                3108.9905    3079.5171     -29.4734         0.7609 
+    65                3109.6289    3079.8394     -29.7895         0.7846 
 ----------------------------------------------------------------------------
 #===================================================================================#
 #| [94m                         Objective Function Breakdown                          [0m |#
 #| [94m  Target Name              Residual  x  Weight  =  Contribution (Current-Prev) [0m |#
 #===================================================================================#
-optgeo                         4.31002      1.000 [91m     4.31002e+00[0m ( +1.953e-02 ) 
-vibration                     12.27757      1.000 [92m     1.22776e+01[0m ( -5.697e-02 ) 
-Regularization                 4.50125      1.000 [91m     4.50125e+00[0m ( +1.166e-02 ) 
-Total                                             [92m     2.10888e+01[0m ( -2.578e-02 ) 
+optgeo                         4.31049      1.000 [92m     4.31049e+00[0m ( -7.718e-01 ) 
+vibration                      7.62565      1.000 [92m     7.62565e+00[0m ( -5.066e+00 ) 
+Regularization                 0.01249      1.000 [91m     1.24910e-02[0m ( +1.149e-02 ) 
+Total                                             [92m     1.19486e+01[0m ( -5.827e+00 ) 
 -------------------------------------------------------------------------------------
-Backing up result/optimize/smirnoff99Frosst.offxml -> result/optimize/smirnoff99Frosst_51.offxml
+Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_27.offxml
 #========================================================================#
 #|  The force field has been written to the result/optimize directory.  |#
 #|    Input file with optimization parameters saved to optimize.sav.    |#
 #========================================================================#
 
   Step       |k|        |dk|       |grad|       -=X2=-     Delta(X2)    StepQual
-     7   2.122e+00   7.403e-02   5.152e-02[92m   2.10888e+01[0m  -2.578e-02      0.963
+     2   1.118e-01   8.941e-02   2.337e+02[92m   1.19486e+01[0m  -5.827e+00      1.000
 
 #========================================================#
 #| [94m                   Total Gradient                   [0m |#
 #========================================================#
-   0 [  2.96680316e-04 ] : HarmonicBondForce/Bond/k/[#6X3:1]:[#6X3:2]
-   1 [  1.18164761e-02 ] : HarmonicBondForce/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [  7.03954171e-05 ] : HarmonicBondForce/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [ -3.26746398e-04 ] : HarmonicBondForce/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [  5.55886464e-05 ] : HarmonicBondForce/Bond/k/[#6X4:1]-[#1:2]
-   5 [  7.67051235e-05 ] : HarmonicBondForce/Bond/length/[#6X4:1]-[#1:2]
-   6 [  5.39568308e-04 ] : HarmonicBondForce/Bond/k/[#6X3:1]-[#1:2]
-   7 [ -8.23095540e-03 ] : HarmonicBondForce/Bond/length/[#6X3:1]-[#1:2]
-   8 [  1.74120414e-02 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [  1.31832997e-04 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [ -3.72679762e-02 ] : HarmonicAngleForce/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [  1.71107789e-03 ] : HarmonicAngleForce/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [  1.56758545e-02 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [  1.36268564e-03 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [  2.09133704e-02 ] : HarmonicAngleForce/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [ -5.51664077e-04 ] : HarmonicAngleForce/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [ -7.37792431e-03 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
-  17 [  7.10235996e-04 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [ -9.61510687e-04 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X4]
-  19 [ -6.15755597e-04 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [ -1.76874355e-03 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X3]
-  21 [ -1.62041289e-03 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [  5.02306617e-04 ] : NonbondedForce/Atom/epsilon/[#6X4:1]
-  23 [ -1.20969856e-03 ] : NonbondedForce/Atom/rmin_half/[#6X4:1]
-  24 [  3.07768350e-04 ] : NonbondedForce/Atom/epsilon/[#8X2H0+0:1]
-  25 [ -1.44669631e-03 ] : NonbondedForce/Atom/rmin_half/[#8X2H0+0:1]
+   0 [  2.48602534e+01 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [  1.71407377e+02 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [  4.43669620e+00 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  2.47923945e+01 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [  5.50757730e+00 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  5.12513029e+01 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [ -4.28845595e+00 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  1.37517532e+02 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [  5.52756502e+00 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [  4.34970489e+00 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [ -1.13979119e+01 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [  4.21440930e+00 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [ -8.60261075e+00 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [  4.55726324e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [  3.04873593e+00 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [ -4.18517350e-02 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [ -3.83221743e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  3.63297700e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [  6.26253871e-01 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [  1.07191483e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [  2.23090075e+00 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [  3.76861106e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  6.39773193e-02 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  7.01975461e-01 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [  5.18935724e-02 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [  1.11487602e+00 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
 ----------------------------------------------------------
-Convergence criterion reached for gradient norm (1.00e-01)
-Convergence criterion reached in step size (1.00e-01)
-Convergence criterion reached for objective function (1.00e-01)
+Calculating nonlinear optimization step
+Finding trust radius: H+0.0000*I, length 5.8346e-01 (target 8.9413e-02)
+Finding trust radius: H+9.0000*I, length 2.9552e-01 (target 8.9413e-02)
+Finding trust radius: H+61.6869*I, length 1.8406e-01 (target 8.9413e-02)
+Finding trust radius: H+34.5372*I, length 2.1006e-01 (target 8.9413e-02)
+Finding trust radius: H+246.7477*I, length 1.2025e-01 (target 8.9413e-02)
+Finding trust radius: H+165.9323*I, length 1.3964e-01 (target 8.9413e-02)
+Finding trust radius: H+807.4923*I, length 6.4304e-02 (target 8.9413e-02)
+Finding trust radius: H+498.3300*I, length 8.5646e-02 (target 8.9413e-02)
+Finding trust radius: H+498.3300*I, length 8.5646e-02 (target 8.9413e-02)
+Finding trust radius: H+391.9039*I, length 9.7246e-02 (target 8.9413e-02)
+Finding trust radius: H+607.6552*I, length 7.6491e-02 (target 8.9413e-02)
+Finding trust radius: H+466.4347*I, length 8.8793e-02 (target 8.9413e-02)
+Finding trust radius: H+462.4993*I, length 8.9199e-02 (target 8.9413e-02)
+Finding trust radius: H+460.1970*I, length 8.9438e-02 (target 8.9413e-02)
+Finding trust radius: H+460.4260*I, length 8.9414e-02 (target 8.9413e-02)
+Finding trust radius: H+460.5224*I, length 8.9404e-02 (target 8.9413e-02)
+Finding trust radius: H+460.3297*I, length 8.9424e-02 (target 8.9413e-02)
+Starting Hessian diagonal search with step size 8.9414e-02
+Hessian diagonal search: H+460.4260*I, length 8.9414e-02, result  7.8970e+00
+Hessian diagonal search: H+7890.7973*I, length 1.4513e-02, result -2.0240e+00
+Hessian diagonal search: H+39141.1996*I, length 4.7579e-03, result -9.6077e-01
+Hessian diagonal search: H+7890.7973*I, length 1.4513e-02, result -2.0240e+00
+Hessian diagonal search: H+17022.0890*I, length 8.8532e-03, result -1.5492e+00
+Hessian diagonal search: H+3981.1191*I, length 2.2188e-02, result -2.1655e+00
+Hessian diagonal search: H+1988.1027*I, length 3.5168e-02, result -1.5485e+00
+Hessian diagonal search: H+5318.1493*I, length 1.8499e-02, result -2.1579e+00
+Hessian diagonal search: H+4449.0544*I, length 2.0679e-02, result -2.1744e+00
+Hessian diagonal search: H+4524.4081*I, length 2.0462e-02, result -2.1744e+00
+Hessian diagonal search: H+4478.5247*I, length 2.0593e-02, result -2.1744e+00
+Hessian diagonal search: H+4477.5008*I, length 2.0596e-02, result -2.1744e+00
+Hessian diagonal search: H+4476.5920*I, length 2.0599e-02, result -2.1744e+00
+Hessian diagonal search: H+4466.0635*I, length 2.0629e-02, result -2.1744e+00
+Hessian diagonal search: H+4472.5690*I, length 2.0610e-02, result -2.1744e+00
+Hessian diagonal search: H+4475.0552*I, length 2.0603e-02, result -2.1744e+00
+Optimization step found (length 2.0599e-02)
+#========================================================#
+#| [95m  Mathematical Parameters (Current + Step = Next)   [0m |#
+#========================================================#
+   0 [ -3.7489e-02 - 5.7872e-03 = -4.3276e-02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [  4.8934e-03 - 1.5267e-02 = -1.0373e-02 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [ -6.9146e-03 - 1.0213e-03 = -7.9359e-03 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  6.4117e-02 - 2.5637e-03 =  6.1553e-02 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [ -8.8487e-03 - 1.1446e-03 = -9.9932e-03 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  2.9592e-02 - 2.9518e-03 =  2.6641e-02 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [  7.7018e-03 + 6.8164e-04 =  8.3834e-03 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  1.9997e-02 - 5.0403e-03 =  1.4957e-02 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [ -1.0468e-02 - 1.2598e-03 = -1.1728e-02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [ -6.8087e-03 - 1.0072e-03 = -7.8159e-03 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [  1.5455e-02 + 1.6805e-03 =  1.7135e-02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [ -6.1495e-03 - 1.0876e-03 = -7.2372e-03 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [ -1.0623e-03 + 6.5122e-04 = -4.1113e-04 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [ -6.9907e-02 - 1.0271e-02 = -8.0178e-02 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [ -1.1411e-02 - 8.6583e-04 = -1.2276e-02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [  2.7614e-04 + 6.6131e-06 =  2.8276e-04 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [  1.4680e-03 + 3.3925e-04 =  1.8073e-03 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  1.8165e-19 + 1.8779e-20 =  2.0043e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [ -8.3085e-04 - 1.3406e-04 = -9.6491e-04 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [ -1.2376e-03 - 2.1189e-04 = -1.4495e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [ -3.1799e-03 - 4.5807e-04 = -3.6379e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [ -4.9069e-03 - 7.3038e-04 = -5.6373e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  1.9567e-05 - 8.9357e-06 =  1.0631e-05 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  2.0557e-04 - 9.0709e-05 =  1.1486e-04 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [ -1.7546e-05 - 8.4536e-06 = -2.5999e-05 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [ -3.3358e-04 - 1.7648e-04 = -5.1006e-04 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+----------------------------------------------------------
+#========================================================#
+#| [95m    Physical Parameters (Current + Step = Next)     [0m |#
+#========================================================#
+   0 [  7.8626e+02 - 5.2085e+00 =  7.8105e+02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [  1.4069e+00 - 2.1373e-02 =  1.3855e+00 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [  8.9378e+02 - 9.1919e-01 =  8.9286e+02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  1.4128e+00 - 3.5892e-03 =  1.4092e+00 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [  6.7204e+02 - 1.0301e+00 =  6.7101e+02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  1.1314e+00 - 4.1325e-03 =  1.1273e+00 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [  7.4093e+02 + 6.1348e-01 =  7.4155e+02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  1.1080e+00 - 7.0565e-03 =  1.1009e+00 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [  1.0824e+02 - 1.5117e-01 =  1.0809e+02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [  6.9047e+01 - 1.4101e-01 =  6.8906e+01 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [  1.2185e+02 + 2.0166e-01 =  1.2206e+02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [  1.3914e+02 - 1.5227e-01 =  1.3899e+02 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [  1.1987e+02 + 7.8147e-02 =  1.1995e+02 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [  9.0213e+01 - 1.4380e+00 =  8.8775e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [  1.1863e+02 - 1.0390e-01 =  1.1853e+02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [  1.4004e+02 + 9.2583e-04 =  1.4004e+02 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [  3.6303e+00 + 1.2298e-03 =  3.6316e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  1.0500e+00 + 0.0000e+00 =  1.0500e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [  1.5559e-02 - 2.2790e-05 =  1.5536e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [  1.4846e+00 - 4.0428e-04 =  1.4842e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [  1.4459e-02 - 7.7872e-05 =  1.4382e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [  1.4496e+00 - 1.3936e-03 =  1.4482e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  1.0940e-01 - 1.5191e-06 =  1.0940e-01 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  1.9084e+00 - 1.7307e-04 =  1.9082e+00 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [  1.7000e-01 - 1.4371e-06 =  1.7000e-01 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [  1.6831e+00 - 3.3672e-04 =  1.6827e+00 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+----------------------------------------------------------
+Input file with saved parameters: optimize.sav
+#========================================================#
+#| [94m     Iteration 3: Evaluating objective function     [0m |#
+#| [94m        and derivatives through second order        [0m |#
+#========================================================#
+
+#======================================================================================================================#
+#| [92m                                         optgeo, Objective =  2.28173e+00                                         [0m |#
+#| [92m  System                       Bonds            Angles           Dihedrals         Impropers               Term.  [0m |#
+#| [92m                            RMSD   denom      RMSD   denom      RMSD   denom      RMSD   denom                    [0m |#
+#======================================================================================================================#
+9HXanthene                    0.013    0.01     0.022    0.03     0.076    0.20     0.005    0.20             2.282 
+------------------------------------------------------------------------------------------------------------------------
+
+#==========================================================================#
+#|                       Frequencies (wavenumbers)                        |#
+#|  Target: vibration  Type: Vibration_SMIRNOFF  Objective = 7.47835e+00  |#
+#|  Mode #            Reference   Calculated   Difference   Ref(dot)Calc  |#
+#==========================================================================#
+    0                   31.1817      55.4953      24.3136         0.9910 
+    1                  127.2863     139.1899      11.9036         0.9952 
+    2                  200.5311     226.8030      26.2719         0.9330 
+    3                  245.4174     233.9492     -11.4682         0.9372 
+    4                  258.8788     243.2052     -15.6736         0.9939 
+    5                  295.5887     324.9577      29.3690         0.9760 
+    6                  385.5805     331.8073     -53.7732         0.9895 
+    7                  413.3227     419.9563       6.6336         0.9745 
+    8                  461.1571     443.5460     -17.6111         0.9808 
+    9                  468.4759     461.2716      -7.2043         0.9886 
+    10                 553.9686     518.5241     -35.4445         0.9584 
+    11                 557.9183     548.4081      -9.5102         0.9435 
+    12                 559.2968     552.5137      -6.7831         0.9445 
+    13                 609.7540     614.5353       4.7813         0.0013 
+    14                 650.9588     622.0496     -28.9092         0.0031 
+    15                 691.9021     630.5136     -61.3885         0.8953 
+    16                 731.3959     702.4504     -28.9455         0.9268 
+    17                 748.6224     708.4081     -40.2143         0.0138 
+    18                 757.4865     731.0577     -26.4288         0.0119 
+    19                 793.4162     753.6286     -39.7876         0.0482 
+    20                 796.3137     758.1689     -38.1448         0.0032 
+    21                 829.9391     762.1466     -67.7925         0.0015 
+    22                 886.2937     870.0492     -16.2445         0.0055 
+    23                 898.9488     876.1578     -22.7910         0.7297 
+    24                 905.1053     877.0796     -28.0257         0.0157 
+    25                 931.8180     913.7413     -18.0767         0.0036 
+    26                 972.6908     942.0902     -30.6006         0.4024 
+    27                 981.1443     944.0398     -37.1045         0.0015 
+    28                1002.3531     959.6652     -42.6879         0.0022 
+    29                1002.6108    1046.7674      44.1566         0.0562 
+    30                1006.9971    1050.3320      43.3349         0.4705 
+    31                1043.4229    1071.7269      28.3040         0.0006 
+    32                1045.2039    1089.6763      44.4724         0.0078 
+    33                1101.4212    1121.2860      19.8648         0.0176 
+    34                1122.1664    1121.7353      -0.4311         0.0228 
+    35                1175.8590    1160.3160     -15.5430         0.0409 
+    36                1177.5535    1164.2126     -13.3409         0.0655 
+    37                1180.0345    1206.6208      26.5863         0.0174 
+    38                1198.0738    1221.5909      23.5171         0.0094 
+    39                1209.4283    1238.9027      29.4744         0.4329 
+    40                1213.4868    1258.0253      44.5385         0.0123 
+    41                1233.7197    1272.3706      38.6509         0.0115 
+    42                1248.6007    1354.2880     105.6873         0.0073 
+    43                1296.1008    1379.8384      83.7376         0.5666 
+    44                1311.1904    1426.5265     115.3361         0.2655 
+    45                1325.6114    1502.0128     176.4014         0.0232 
+    46                1351.5363    1544.0308     192.4945         0.0037 
+    47                1456.1390    1570.5837     114.4447         0.6143 
+    48                1461.1551    1591.8563     130.7012         0.0180 
+    49                1467.0845    1605.9160     138.8315         0.3339 
+    50                1486.3167    1633.4223     147.1056         0.6948 
+    51                1498.4933    1634.6772     136.1839         0.2816 
+    52                1571.5221    1684.5994     113.0773         0.5885 
+    53                1591.5923    1689.9059      98.3136         0.7268 
+    54                1597.5166    1727.7638     130.2472         0.0399 
+    55                1620.6702    1775.9468     155.2766         0.0268 
+    56                2881.8985    2894.3383      12.4398         0.8761 
+    57                2918.3100    2958.1985      39.8885         0.8771 
+    58                3057.8158    3078.7901      20.9743         0.3066 
+    59                3058.9610    3078.9456      19.9846         0.2691 
+    60                3076.7507    3079.4617       2.7110         0.2670 
+    61                3076.9099    3079.5445       2.6346         0.2894 
+    62                3093.3546    3080.6484     -12.7062         0.0695 
+    63                3093.7472    3080.6954     -13.0518         0.0988 
+    64                3108.9905    3081.2803     -27.7102         0.7496 
+    65                3109.6289    3081.6052     -28.0237         0.7735 
+----------------------------------------------------------------------------
+#===================================================================================#
+#| [94m                         Objective Function Breakdown                          [0m |#
+#| [94m  Target Name              Residual  x  Weight  =  Contribution (Current-Prev) [0m |#
+#===================================================================================#
+optgeo                         2.28173      1.000 [92m     2.28173e+00[0m ( -2.029e+00 ) 
+vibration                      7.47835      1.000 [92m     7.47835e+00[0m ( -1.473e-01 ) 
+Regularization                 0.01411      1.000 [91m     1.41115e-02[0m ( +1.620e-03 ) 
+Total                                             [92m     9.77419e+00[0m ( -2.174e+00 ) 
+-------------------------------------------------------------------------------------
+Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_28.offxml
+#========================================================================#
+#|  The force field has been written to the result/optimize directory.  |#
+#|    Input file with optimization parameters saved to optimize.sav.    |#
+#========================================================================#
+
+  Step       |k|        |dk|       |grad|       -=X2=-     Delta(X2)    StepQual
+     3   1.188e-01   2.060e-02   1.226e+02[92m   9.77419e+00[0m  -2.174e+00      1.000
+
+#========================================================#
+#| [94m                   Total Gradient                   [0m |#
+#========================================================#
+   0 [  2.67235427e+01 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [ -6.82502365e+01 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [  4.53991148e+00 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  1.84574160e+01 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [  5.11771412e+00 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  4.10491099e+01 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [ -3.04554973e+00 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  7.24162582e+01 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [  5.50689681e+00 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [  4.53981329e+00 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [ -6.35991637e+00 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [  5.04386162e+00 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [ -3.14381266e+00 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [  4.66606381e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [  3.57271935e+00 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [ -2.45165342e-02 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [ -1.42739193e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  4.00855963e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [  6.85373482e-01 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [  1.07093820e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [  2.26086573e+00 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [  3.44841517e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  3.19962872e-02 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  2.67304002e-01 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [  3.93304642e-02 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [  7.65891233e-01 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+----------------------------------------------------------
+Calculating nonlinear optimization step
+Finding trust radius: H+0.0000*I, length 5.9657e-01 (target 2.0599e-02)
+Finding trust radius: H+9.0000*I, length 3.4209e-01 (target 2.0599e-02)
+Finding trust radius: H+61.6869*I, length 1.9104e-01 (target 2.0599e-02)
+Finding trust radius: H+41.1586*I, length 2.2129e-01 (target 2.0599e-02)
+Finding trust radius: H+246.7477*I, length 1.0540e-01 (target 2.0599e-02)
+Finding trust radius: H+174.0510*I, length 1.2379e-01 (target 2.0599e-02)
+Finding trust radius: H+807.4923*I, length 5.5416e-02 (target 2.0599e-02)
+Finding trust radius: H+583.4375*I, length 6.7364e-02 (target 2.0599e-02)
+Finding trust radius: H+2398.9145*I, length 2.5989e-02 (target 2.0599e-02)
+Finding trust radius: H+1682.2481*I, length 3.3747e-02 (target 2.0599e-02)
+Finding trust radius: H+6764.9351*I, length 1.1711e-02 (target 2.0599e-02)
+Finding trust radius: H+2398.9145*I, length 2.5989e-02 (target 2.0599e-02)
+Finding trust radius: H+3805.2759*I, length 1.8294e-02 (target 2.0599e-02)
+Finding trust radius: H+4835.9536*I, length 1.5203e-02 (target 2.0599e-02)
+Finding trust radius: H+3510.9837*I, length 1.9461e-02 (target 2.0599e-02)
+Finding trust radius: H+3370.9447*I, length 2.0078e-02 (target 2.0599e-02)
+Finding trust radius: H+2980.1944*I, length 2.2059e-02 (target 2.0599e-02)
+Finding trust radius: H+3274.4253*I, length 2.0529e-02 (target 2.0599e-02)
+Finding trust radius: H+3253.6853*I, length 2.0629e-02 (target 2.0599e-02)
+Finding trust radius: H+3259.8399*I, length 2.0600e-02 (target 2.0599e-02)
+Finding trust radius: H+3260.5033*I, length 2.0596e-02 (target 2.0599e-02)
+Finding trust radius: H+3259.1765*I, length 2.0603e-02 (target 2.0599e-02)
+Starting Hessian diagonal search with step size 2.0600e-02
+Hessian diagonal search: H+3259.8399*I, length 2.0600e-02, result -9.5299e-01
+Hessian diagonal search: H+53536.7182*I, length 2.0731e-03, result -2.3433e-01
+Hessian diagonal search: H+50581.8472*I, length 2.1830e-03, result -2.4566e-01
+Hessian diagonal search: H+3259.8399*I, length 2.0600e-02, result -9.5299e-01
+Hessian diagonal search: H+2562.2890*I, length 2.4734e-02, result -8.8493e-01
+Hessian diagonal search: H+15293.2697*I, length 6.1228e-03, result -5.8293e-01
+Hessian diagonal search: H+147.1722*I, length 1.3336e-01, result -9.2386e-01
+Hessian diagonal search: H+6810.0204*I, length 1.1650e-02, result -8.6037e-01
+Hessian diagonal search: H+1593.6431*I, length 3.5083e-02, result -5.0817e-01
+Hessian diagonal search: H+4463.2525*I, length 1.6176e-02, result -9.5383e-01
+Hessian diagonal search: H+4382.9252*I, length 1.6405e-02, result -9.5586e-01
+Hessian diagonal search: H+3852.2520*I, length 1.8122e-02, result -9.6360e-01
+Hessian diagonal search: H+3620.1361*I, length 1.9009e-02, result -9.6263e-01
+Hessian diagonal search: H+3814.3680*I, length 1.8260e-02, result -9.6366e-01
+Hessian diagonal search: H+3803.9249*I, length 1.8299e-02, result -9.6367e-01
+Hessian diagonal search: H+3801.5361*I, length 1.8308e-02, result -9.6367e-01
+Hessian diagonal search: H+3802.3088*I, length 1.8305e-02, result -9.6367e-01
+Hessian diagonal search: H+3731.7241*I, length 1.8571e-02, result -9.6352e-01
+Hessian diagonal search: H+3774.7939*I, length 1.8407e-02, result -9.6364e-01
+Hessian diagonal search: H+3791.3104*I, length 1.8346e-02, result -9.6366e-01
+Hessian diagonal search: H+3797.6286*I, length 1.8322e-02, result -9.6367e-01
+Hessian diagonal search: H+3800.0434*I, length 1.8313e-02, result -9.6367e-01
+Optimization step found (length 1.8308e-02)
+#========================================================#
+#| [95m  Mathematical Parameters (Current + Step = Next)   [0m |#
+#========================================================#
+   0 [ -4.3276e-02 - 6.3050e-03 = -4.9581e-02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [ -1.0373e-02 + 1.0520e-02 =  1.4637e-04 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [ -7.9359e-03 - 1.1015e-03 = -9.0374e-03 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  6.1553e-02 - 2.8974e-03 =  5.8656e-02 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [ -9.9932e-03 - 1.2213e-03 = -1.1215e-02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  2.6641e-02 - 4.1593e-03 =  2.2481e-02 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [  8.3834e-03 + 6.4980e-04 =  9.0332e-03 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  1.4957e-02 - 3.7088e-03 =  1.1248e-02 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [ -1.1728e-02 - 1.4339e-03 = -1.3162e-02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [ -7.8159e-03 - 1.1661e-03 = -8.9820e-03 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [  1.7135e-02 + 1.9925e-03 =  1.9128e-02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [ -7.2372e-03 - 1.0636e-03 = -8.3008e-03 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [ -4.1113e-04 + 1.3762e-04 = -2.7351e-04 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [ -8.0178e-02 - 1.1468e-02 = -9.1646e-02 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [ -1.2276e-02 - 1.0465e-03 = -1.3323e-02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [  2.8276e-04 + 1.9781e-05 =  3.0254e-04 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [  1.8073e-03 + 2.4935e-04 =  2.0566e-03 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  2.0043e-19 + 2.3141e-20 =  2.2357e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [ -9.6491e-04 - 1.5446e-04 = -1.1194e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [ -1.4495e-03 - 2.3493e-04 = -1.6844e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [ -3.6379e-03 - 5.0964e-04 = -4.1476e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [ -5.6373e-03 - 7.7116e-04 = -6.4085e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  1.0631e-05 - 3.9833e-06 =  6.6478e-06 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  1.1486e-04 - 2.8626e-05 =  8.6232e-05 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [ -2.5999e-05 - 7.4842e-06 = -3.3483e-05 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [ -5.1006e-04 - 1.5194e-04 = -6.6200e-04 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+----------------------------------------------------------
+#========================================================#
+#| [95m    Physical Parameters (Current + Step = Next)     [0m |#
+#========================================================#
+   0 [  7.8105e+02 - 5.6745e+00 =  7.7538e+02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [  1.3855e+00 + 1.4727e-02 =  1.4002e+00 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [  8.9286e+02 - 9.9138e-01 =  8.9187e+02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  1.4092e+00 - 4.0563e-03 =  1.4051e+00 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [  6.7101e+02 - 1.0992e+00 =  6.6991e+02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  1.1273e+00 - 5.8231e-03 =  1.1215e+00 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [  7.4155e+02 + 5.8482e-01 =  7.4213e+02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  1.1009e+00 - 5.1923e-03 =  1.0957e+00 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [  1.0809e+02 - 1.7207e-01 =  1.0792e+02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [  6.8906e+01 - 1.6326e-01 =  6.8743e+01 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [  1.2206e+02 + 2.3910e-01 =  1.2230e+02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [  1.3899e+02 - 1.4891e-01 =  1.3884e+02 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [  1.1995e+02 + 1.6514e-02 =  1.1997e+02 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [  8.8775e+01 - 1.6056e+00 =  8.7169e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [  1.1853e+02 - 1.2558e-01 =  1.1840e+02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [  1.4004e+02 + 2.7693e-03 =  1.4004e+02 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [  3.6316e+00 + 9.0389e-04 =  3.6325e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  1.0500e+00 + 0.0000e+00 =  1.0500e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [  1.5536e-02 - 2.6259e-05 =  1.5510e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [  1.4842e+00 - 4.4824e-04 =  1.4838e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [  1.4382e-02 - 8.6638e-05 =  1.4295e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [  1.4482e+00 - 1.4714e-03 =  1.4468e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  1.0940e-01 - 6.7716e-07 =  1.0940e-01 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  1.9082e+00 - 5.4619e-05 =  1.9082e+00 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [  1.7000e-01 - 1.2723e-06 =  1.6999e-01 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [  1.6827e+00 - 2.8991e-04 =  1.6824e+00 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+----------------------------------------------------------
+Input file with saved parameters: optimize.sav
+#========================================================#
+#| [94m     Iteration 4: Evaluating objective function     [0m |#
+#| [94m        and derivatives through second order        [0m |#
+#========================================================#
+
+#======================================================================================================================#
+#| [92m                                         optgeo, Objective =  1.84704e+00                                         [0m |#
+#| [92m  System                       Bonds            Angles           Dihedrals         Impropers               Term.  [0m |#
+#| [92m                            RMSD   denom      RMSD   denom      RMSD   denom      RMSD   denom                    [0m |#
+#======================================================================================================================#
+9HXanthene                    0.011    0.01     0.022    0.03     0.076    0.20     0.005    0.20             1.847 
+------------------------------------------------------------------------------------------------------------------------
+
+#==========================================================================#
+#|                       Frequencies (wavenumbers)                        |#
+#|  Target: vibration  Type: Vibration_SMIRNOFF  Objective = 6.94733e+00  |#
+#|  Mode #            Reference   Calculated   Difference   Ref(dot)Calc  |#
+#==========================================================================#
+    0                   31.1817      55.0701      23.8884         0.9909 
+    1                  127.2863     138.4970      11.2107         0.9952 
+    2                  200.5311     226.7262      26.1951         0.9337 
+    3                  245.4174     231.7614     -13.6560         0.9373 
+    4                  258.8788     242.9387     -15.9401         0.9941 
+    5                  295.5887     324.2852      28.6965         0.9766 
+    6                  385.5805     330.0879     -55.4926         0.9893 
+    7                  413.3227     418.1638       4.8411         0.9725 
+    8                  461.1571     441.2076     -19.9495         0.9812 
+    9                  468.4759     458.8973      -9.5786         0.9885 
+    10                 553.9686     515.7862     -38.1824         0.9579 
+    11                 557.9183     545.2488     -12.6695         0.1064 
+    12                 559.2968     546.5318     -12.7650         0.1396 
+    13                 609.7540     605.3114      -4.4426         0.0013 
+    14                 650.9588     617.5928     -33.3660         0.0035 
+    15                 691.9021     625.5990     -66.3031         0.8076 
+    16                 731.3959     699.0976     -32.2983         0.1080 
+    17                 748.6224     701.7527     -46.8697         0.0300 
+    18                 757.4865     728.5729     -28.9136         0.0118 
+    19                 793.4162     751.7447     -41.6715         0.0011 
+    20                 796.3137     756.3240     -39.9897         0.9912 
+    21                 829.9391     764.2074     -65.7317         0.0015 
+    22                 886.2937     861.5266     -24.7671         0.0056 
+    23                 898.9488     869.3797     -29.5691         0.3103 
+    24                 905.1053     879.2275     -25.8778         0.0740 
+    25                 931.8180     916.7189     -15.0991         0.0036 
+    26                 972.6908     938.6899     -34.0009         0.0097 
+    27                 981.1443     944.4012     -36.7431         0.0218 
+    28                1002.3531     955.1698     -47.1833         0.0022 
+    29                1002.6108    1050.4586      47.8478         0.0563 
+    30                1006.9971    1053.9923      46.9952         0.4691 
+    31                1043.4229    1066.6914      23.2685         0.0007 
+    32                1045.2039    1084.9755      39.7716         0.0088 
+    33                1101.4212    1125.6299      24.2087         0.0177 
+    34                1122.1664    1126.0701       3.9037         0.0229 
+    35                1175.8590    1156.0643     -19.7947         0.0430 
+    36                1177.5535    1160.1384     -17.4151         0.0658 
+    37                1180.0345    1200.5891      20.5546         0.0171 
+    38                1198.0738    1216.4881      18.4143         0.0096 
+    39                1209.4283    1234.1208      24.6925         0.4301 
+    40                1213.4868    1262.5832      49.0964         0.0123 
+    41                1233.7197    1266.6749      32.9552         0.0115 
+    42                1248.6007    1351.6513     103.0506         0.0092 
+    43                1296.1008    1379.5389      83.4381         0.4244 
+    44                1311.1904    1421.1526     109.9622         0.2831 
+    45                1325.6114    1497.9134     172.3020         0.0213 
+    46                1351.5363    1534.9776     183.4413         0.0037 
+    47                1456.1390    1564.8002     108.6612         0.6062 
+    48                1461.1551    1585.0206     123.8655         0.0171 
+    49                1467.0845    1597.2314     130.1469         0.3403 
+    50                1486.3167    1625.6214     139.3047         0.6722 
+    51                1498.4933    1628.4883     129.9950         0.2392 
+    52                1571.5221    1676.5062     104.9841         0.5761 
+    53                1591.5923    1681.2694      89.6771         0.7246 
+    54                1597.5166    1717.8432     120.3266         0.0402 
+    55                1620.6702    1767.5262     146.8560         0.0266 
+    56                2881.8985    2892.0982      10.1997         0.8759 
+    57                2918.3100    2955.5115      37.2015         0.8772 
+    58                3057.8158    3079.6678      21.8520         0.2988 
+    59                3058.9610    3079.8177      20.8567         0.2589 
+    60                3076.7507    3080.3114       3.5607         0.2773 
+    61                3076.9099    3080.3861       3.4762         0.2965 
+    62                3093.3546    3081.3664     -11.9882         0.0843 
+    63                3093.7472    3081.4160     -12.3312         0.1175 
+    64                3108.9905    3081.9989     -26.9916         0.7705 
+    65                3109.6289    3082.3269     -27.3020         0.7921 
+----------------------------------------------------------------------------
+#===================================================================================#
+#| [94m                         Objective Function Breakdown                          [0m |#
+#| [94m  Target Name              Residual  x  Weight  =  Contribution (Current-Prev) [0m |#
+#===================================================================================#
+optgeo                         1.84704      1.000 [92m     1.84704e+00[0m ( -4.347e-01 ) 
+vibration                      6.94733      1.000 [92m     6.94733e+00[0m ( -5.310e-01 ) 
+Regularization                 0.01615      1.000 [91m     1.61522e-02[0m ( +2.041e-03 ) 
+Total                                             [92m     8.81052e+00[0m ( -9.637e-01 ) 
+-------------------------------------------------------------------------------------
+Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_29.offxml
+#========================================================================#
+#|  The force field has been written to the result/optimize directory.  |#
+#|    Input file with optimization parameters saved to optimize.sav.    |#
+#========================================================================#
+
+  Step       |k|        |dk|       |grad|       -=X2=-     Delta(X2)    StepQual
+     4   1.271e-01   1.831e-02   1.186e+02[92m   8.81052e+00[0m  -9.637e-01      1.000
+
+#========================================================#
+#| [94m                   Total Gradient                   [0m |#
+#========================================================#
+   0 [  2.34867310e+01 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [  9.72589162e+01 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [  4.27471247e+00 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  1.02877936e+01 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [  4.64170765e+00 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  2.88536941e+01 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [ -2.47133393e+00 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  3.08470534e+01 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [  4.95488382e+00 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [  4.31527204e+00 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [ -7.57424266e+00 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [  4.17492522e+00 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [ -2.33162554e+00 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [  4.43361831e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [  3.76505266e+00 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [ -7.85280823e-02 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [ -1.39082620e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  4.47138443e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [  6.57035442e-01 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [  1.06436432e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [  2.05874345e+00 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [  3.28137632e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  4.37813789e-02 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  4.61013771e-01 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [  4.31178039e-02 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [  8.98260269e-01 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+----------------------------------------------------------
+Calculating nonlinear optimization step
+Finding trust radius: H+0.0000*I, length 5.7944e-01 (target 1.8308e-02)
+Finding trust radius: H+9.0000*I, length 2.8386e-01 (target 1.8308e-02)
+Finding trust radius: H+61.6869*I, length 1.6138e-01 (target 1.8308e-02)
+Finding trust radius: H+35.9545*I, length 1.8586e-01 (target 1.8308e-02)
+Finding trust radius: H+246.7477*I, length 1.0499e-01 (target 1.8308e-02)
+Finding trust radius: H+168.7764*I, length 1.2081e-01 (target 1.8308e-02)
+Finding trust radius: H+807.4923*I, length 5.6651e-02 (target 1.8308e-02)
+Finding trust radius: H+687.8426*I, length 6.2611e-02 (target 1.8308e-02)
+Finding trust radius: H+2398.9145*I, length 2.5842e-02 (target 1.8308e-02)
+Finding trust radius: H+1722.9545*I, length 3.3318e-02 (target 1.8308e-02)
+Finding trust radius: H+6764.9351*I, length 1.1295e-02 (target 1.8308e-02)
+Finding trust radius: H+4316.9631*I, length 1.6203e-02 (target 1.8308e-02)
+Finding trust radius: H+4316.9631*I, length 1.6203e-02 (target 1.8308e-02)
+Finding trust radius: H+3518.3004*I, length 1.9087e-02 (target 1.8308e-02)
+Finding trust radius: H+3065.5106*I, length 2.1300e-02 (target 1.8308e-02)
+Finding trust radius: H+3766.1951*I, length 1.8075e-02 (target 1.8308e-02)
+Finding trust radius: H+3722.7779*I, length 1.8244e-02 (target 1.8308e-02)
+Finding trust radius: H+3708.8760*I, length 1.8299e-02 (target 1.8308e-02)
+Finding trust radius: H+3706.3922*I, length 1.8308e-02 (target 1.8308e-02)
+Finding trust radius: H+3707.1457*I, length 1.8305e-02 (target 1.8308e-02)
+Finding trust radius: H+3705.6388*I, length 1.8311e-02 (target 1.8308e-02)
+Starting Hessian diagonal search with step size 1.8308e-02
+Hessian diagonal search: H+3706.3922*I, length 1.8308e-02, result -6.2710e-01
+Hessian diagonal search: H+60772.3988*I, length 1.7695e-03, result -1.9222e-01
+Hessian diagonal search: H+57356.6074*I, length 1.8654e-03, result -2.0162e-01
+Hessian diagonal search: H+3706.3922*I, length 1.8308e-02, result -6.2710e-01
+Hessian diagonal search: H+2900.0327*I, length 2.2259e-02, result -4.6323e-01
+Hessian diagonal search: H+17368.2040*I, length 5.2601e-03, result -4.7161e-01
+Hessian diagonal search: H+1609.9839*I, length 3.5053e-02, result  6.1285e-01
+Hessian diagonal search: H+7737.7919*I, length 1.0139e-02, result -6.7266e-01
+Hessian diagonal search: H+7044.9505*I, length 1.0933e-02, result -6.8756e-01
+Hessian diagonal search: H+6088.1911*I, length 1.2293e-02, result -7.0272e-01
+Hessian diagonal search: H+5109.0186*I, length 1.4153e-02, result -7.0329e-01
+Hessian diagonal search: H+5555.2892*I, length 1.3232e-02, result -7.0584e-01
+Hessian diagonal search: H+5563.2672*I, length 1.3217e-02, result -7.0583e-01
+Hessian diagonal search: H+5542.7925*I, length 1.3256e-02, result -7.0584e-01
+Hessian diagonal search: H+5375.0197*I, length 1.3587e-02, result -7.0550e-01
+Hessian diagonal search: H+5533.0406*I, length 1.3275e-02, result -7.0584e-01
+Hessian diagonal search: H+5535.8627*I, length 1.3269e-02, result -7.0584e-01
+Hessian diagonal search: H+5536.9848*I, length 1.3267e-02, result -7.0584e-01
+Hessian diagonal search: H+5539.2028*I, length 1.3263e-02, result -7.0584e-01
+Hessian diagonal search: H+5540.5738*I, length 1.3260e-02, result -7.0584e-01
+Optimization step found (length 1.3263e-02)
+#========================================================#
+#| [95m  Mathematical Parameters (Current + Step = Next)   [0m |#
+#========================================================#
+   0 [ -4.9581e-02 - 4.1539e-03 = -5.3735e-02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [  1.4637e-04 - 9.3574e-03 = -9.2110e-03 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [ -9.0374e-03 - 7.5788e-04 = -9.7953e-03 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  5.8656e-02 - 1.1469e-03 =  5.7509e-02 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [ -1.1215e-02 - 7.8897e-04 = -1.2004e-02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  2.2481e-02 - 1.7872e-03 =  2.0694e-02 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [  9.0332e-03 + 3.3655e-04 =  9.3698e-03 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  1.1248e-02 + 1.1724e-03 =  1.2421e-02 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [ -1.3162e-02 - 8.8904e-04 = -1.4051e-02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [ -8.9820e-03 - 7.7430e-04 = -9.7563e-03 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [  1.9128e-02 + 1.0853e-03 =  2.0213e-02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [ -8.3008e-03 - 7.7905e-04 = -9.0799e-03 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [ -2.7351e-04 + 2.7789e-04 =  4.3807e-06 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [ -9.1646e-02 - 7.7221e-03 = -9.9369e-02 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [ -1.3323e-02 - 7.3526e-04 = -1.4058e-02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [  3.0254e-04 + 1.4131e-05 =  3.1667e-04 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [  2.0566e-03 + 1.5146e-04 =  2.2081e-03 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  2.2357e-19 - 8.6934e-21 =  2.1488e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [ -1.1194e-03 - 1.1260e-04 = -1.2320e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [ -1.6844e-03 - 1.7497e-04 = -1.8594e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [ -4.1476e-03 - 3.3690e-04 = -4.4845e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [ -6.4085e-03 - 5.2379e-04 = -6.9323e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  6.6478e-06 - 5.2325e-06 =  1.4153e-06 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  8.6232e-05 - 5.2036e-05 =  3.4196e-05 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [ -3.3483e-05 - 6.1423e-06 = -3.9626e-05 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [ -6.6200e-04 - 1.2795e-04 = -7.8995e-04 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+----------------------------------------------------------
+#========================================================#
+#| [95m    Physical Parameters (Current + Step = Next)     [0m |#
+#========================================================#
+   0 [  7.7538e+02 - 3.7385e+00 =  7.7164e+02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [  1.4002e+00 - 1.3100e-02 =  1.3871e+00 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [  8.9187e+02 - 6.8209e-01 =  8.9118e+02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  1.4051e+00 - 1.6057e-03 =  1.4035e+00 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [  6.6991e+02 - 7.1007e-01 =  6.6920e+02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  1.1215e+00 - 2.5021e-03 =  1.1190e+00 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [  7.4213e+02 + 3.0290e-01 =  7.4243e+02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  1.0957e+00 + 1.6413e-03 =  1.0974e+00 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [  1.0792e+02 - 1.0669e-01 =  1.0781e+02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [  6.8743e+01 - 1.0840e-01 =  6.8634e+01 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [  1.2230e+02 + 1.3023e-01 =  1.2243e+02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [  1.3884e+02 - 1.0907e-01 =  1.3873e+02 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [  1.1997e+02 + 3.3347e-02 =  1.2000e+02 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [  8.7169e+01 - 1.0811e+00 =  8.6088e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [  1.1840e+02 - 8.8232e-02 =  1.1831e+02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [  1.4004e+02 + 1.9783e-03 =  1.4004e+02 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [  3.6325e+00 + 5.4904e-04 =  3.6330e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  1.0500e+00 + 0.0000e+00 =  1.0500e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [  1.5510e-02 - 1.9142e-05 =  1.5491e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [  1.4838e+00 - 3.3384e-04 =  1.4835e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [  1.4295e-02 - 5.7274e-05 =  1.4238e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [  1.4468e+00 - 9.9939e-04 =  1.4458e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  1.0940e-01 - 8.8952e-07 =  1.0940e-01 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  1.9082e+00 - 9.9285e-05 =  1.9081e+00 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [  1.6999e-01 - 1.0442e-06 =  1.6999e-01 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [  1.6824e+00 - 2.4413e-04 =  1.6822e+00 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+----------------------------------------------------------
+Input file with saved parameters: optimize.sav
+#========================================================#
+#| [94m     Iteration 5: Evaluating objective function     [0m |#
+#| [94m        and derivatives through second order        [0m |#
+#========================================================#
+
+#======================================================================================================================#
+#| [92m                                         optgeo, Objective =  1.55358e+00                                         [0m |#
+#| [92m  System                       Bonds            Angles           Dihedrals         Impropers               Term.  [0m |#
+#| [92m                            RMSD   denom      RMSD   denom      RMSD   denom      RMSD   denom                    [0m |#
+#======================================================================================================================#
+9HXanthene                    0.009    0.01     0.022    0.03     0.076    0.20     0.005    0.20             1.554 
+------------------------------------------------------------------------------------------------------------------------
+
+#==========================================================================#
+#|                       Frequencies (wavenumbers)                        |#
+#|  Target: vibration  Type: Vibration_SMIRNOFF  Objective = 6.53297e+00  |#
+#|  Mode #            Reference   Calculated   Difference   Ref(dot)Calc  |#
+#==========================================================================#
+    0                   31.1817      55.6921      24.5104         0.9910 
+    1                  127.2863     139.5473      12.2610         0.9953 
+    2                  200.5311     228.2130      27.6819         0.9339 
+    3                  245.4174     233.4499     -11.9675         0.9372 
+    4                  258.8788     244.7044     -14.1744         0.9941 
+    5                  295.5887     326.6768      31.0881         0.9772 
+    6                  385.5805     331.2863     -54.2942         0.9894 
+    7                  413.3227     419.6700       6.3473         0.9739 
+    8                  461.1571     446.6665     -14.4906         0.9812 
+    9                  468.4759     464.2868      -4.1891         0.9887 
+    10                 553.9686     521.8708     -32.0978         0.9580 
+    11                 557.9183     550.6040      -7.3143         0.1065 
+    12                 559.2968     551.6414      -7.6554         0.1398 
+    13                 609.7540     611.6537       1.8997         0.0013 
+    14                 650.9588     620.4280     -30.5308         0.0034 
+    15                 691.9021     628.8386     -63.0635         0.8496 
+    16                 731.3959     704.9695     -26.4264         0.1071 
+    17                 748.6224     706.6819     -41.9405         0.0300 
+    18                 757.4865     735.8737     -21.6128         0.0119 
+    19                 793.4162     754.6613     -38.7549         0.0011 
+    20                 796.3137     756.9183     -39.3954         0.9830 
+    21                 829.9391     765.7701     -64.1690         0.0015 
+    22                 886.2937     866.4824     -19.8113         0.0055 
+    23                 898.9488     873.9310     -25.0178         0.3097 
+    24                 905.1053     880.2477     -24.8576         0.0753 
+    25                 931.8180     917.5760     -14.2420         0.0037 
+    26                 972.6908     938.2875     -34.4033         0.0094 
+    27                 981.1443     947.0362     -34.1081         0.0223 
+    28                1002.3531     953.9430     -48.4101         0.0022 
+    29                1002.6108    1050.8274      48.2166         0.0558 
+    30                1006.9971    1054.4269      47.4298         0.4717 
+    31                1043.4229    1064.5831      21.1602         0.0008 
+    32                1045.2039    1081.9608      36.7569         0.0082 
+    33                1101.4212    1125.8641      24.4429         0.0176 
+    34                1122.1664    1126.3292       4.1628         0.0227 
+    35                1175.8590    1153.6270     -22.2320         0.0516 
+    36                1177.5535    1160.7259     -16.8276         0.0792 
+    37                1180.0345    1196.9799      16.9454         0.0172 
+    38                1198.0738    1213.9811      15.9073         0.0105 
+    39                1209.4283    1231.7738      22.3455         0.4314 
+    40                1213.4868    1266.2901      52.8033         0.0123 
+    41                1233.7197    1266.9933      33.2736         0.0097 
+    42                1248.6007    1349.5879     100.9872         0.0096 
+    43                1296.1008    1380.2004      84.0996         0.3695 
+    44                1311.1904    1417.3846     106.1942         0.2934 
+    45                1325.6114    1493.1273     167.5159         0.0198 
+    46                1351.5363    1527.7607     176.2244         0.0035 
+    47                1456.1390    1561.6744     105.5354         0.6215 
+    48                1461.1551    1581.1897     120.0346         0.0153 
+    49                1467.0845    1591.5318     124.4473         0.3422 
+    50                1486.3167    1620.8415     134.5248         0.6537 
+    51                1498.4933    1623.9404     125.4471         0.2090 
+    52                1571.5221    1672.7372     101.2151         0.5796 
+    53                1591.5923    1678.7294      87.1371         0.7271 
+    54                1597.5166    1715.5378     118.0212         0.0408 
+    55                1620.6702    1767.6435     146.9733         0.0264 
+    56                2881.8985    2890.8484       8.9499         0.8759 
+    57                2918.3100    2953.9350      35.6250         0.8772 
+    58                3057.8158    3080.3979      22.5821         0.3017 
+    59                3058.9610    3080.5510      21.5900         0.2640 
+    60                3076.7507    3081.0678       4.3171         0.2705 
+    61                3076.9099    3081.1481       4.2382         0.2905 
+    62                3093.3546    3082.2496     -11.1050         0.0768 
+    63                3093.7472    3082.2984     -11.4488         0.1075 
+    64                3108.9905    3082.8945     -26.0960         0.7590 
+    65                3109.6289    3083.2224     -26.4065         0.7816 
+----------------------------------------------------------------------------
+#===================================================================================#
+#| [94m                         Objective Function Breakdown                          [0m |#
+#| [94m  Target Name              Residual  x  Weight  =  Contribution (Current-Prev) [0m |#
+#===================================================================================#
+optgeo                         1.55358      1.000 [92m     1.55358e+00[0m ( -2.935e-01 ) 
+vibration                      6.53297      1.000 [92m     6.53297e+00[0m ( -4.144e-01 ) 
+Regularization                 0.01812      1.000 [91m     1.81240e-02[0m ( +1.972e-03 ) 
+Total                                             [92m     8.10468e+00[0m ( -7.058e-01 ) 
+-------------------------------------------------------------------------------------
+Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_30.offxml
+#========================================================================#
+#|  The force field has been written to the result/optimize directory.  |#
+#|    Input file with optimization parameters saved to optimize.sav.    |#
+#========================================================================#
+
+  Step       |k|        |dk|       |grad|       -=X2=-     Delta(X2)    StepQual
+     5   1.346e-01   1.326e-02   8.817e+01[92m   8.10468e+00[0m  -7.058e-01      1.000
+
+#========================================================#
+#| [94m                   Total Gradient                   [0m |#
+#========================================================#
+   0 [  2.38755306e+01 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [ -4.74890477e+01 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [  4.22141032e+00 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  7.84516851e+00 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [  4.36730313e+00 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  2.36886005e+01 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [ -1.87443863e+00 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  4.85042706e+01 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [  4.77168818e+00 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [  4.27686958e+00 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [ -5.07768294e+00 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [  4.51008729e+00 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [ -1.89753809e+00 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [  4.25723042e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [  4.00753299e+00 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [ -7.51841346e-02 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [ -8.30030909e-01 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  4.29751543e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [  6.62201311e-01 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [  1.01273175e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [  1.89257455e+00 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [  2.86370390e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  1.94931802e-02 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  1.57370858e-01 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [  3.19248797e-02 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [  6.34128704e-01 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+----------------------------------------------------------
+Calculating nonlinear optimization step
+Finding trust radius: H+0.0000*I, length 5.9537e-01 (target 1.3263e-02)
+Finding trust radius: H+9.0000*I, length 3.2753e-01 (target 1.3263e-02)
+Finding trust radius: H+61.6869*I, length 1.7457e-01 (target 1.3263e-02)
+Finding trust radius: H+40.0923*I, length 2.0541e-01 (target 1.3263e-02)
+Finding trust radius: H+246.7477*I, length 9.4223e-02 (target 1.3263e-02)
+Finding trust radius: H+170.0511*I, length 1.1260e-01 (target 1.3263e-02)
+Finding trust radius: H+807.4923*I, length 4.8271e-02 (target 1.3263e-02)
+Finding trust radius: H+583.5072*I, length 5.9123e-02 (target 1.3263e-02)
+Finding trust radius: H+2398.9145*I, length 2.1892e-02 (target 1.3263e-02)
+Finding trust radius: H+1702.4300*I, length 2.8540e-02 (target 1.3263e-02)
+Finding trust radius: H+6764.9351*I, length 9.3585e-03 (target 1.3263e-02)
+Finding trust radius: H+4421.9657*I, length 1.3335e-02 (target 1.3263e-02)
+Finding trust radius: H+4421.9657*I, length 1.3335e-02 (target 1.3263e-02)
+Finding trust radius: H+3576.7748*I, length 1.5875e-02 (target 1.3263e-02)
+Finding trust radius: H+5258.3306*I, length 1.1551e-02 (target 1.3263e-02)
+Finding trust radius: H+4549.8408*I, length 1.3024e-02 (target 1.3263e-02)
+Finding trust radius: H+4443.2750*I, length 1.3282e-02 (target 1.3263e-02)
+Finding trust radius: H+4451.5426*I, length 1.3262e-02 (target 1.3263e-02)
+Finding trust radius: H+4450.6390*I, length 1.3264e-02 (target 1.3263e-02)
+Finding trust radius: H+4449.7356*I, length 1.3266e-02 (target 1.3263e-02)
+Starting Hessian diagonal search with step size 1.3264e-02
+Hessian diagonal search: H+4450.6390*I, length 1.3264e-02, result -6.0637e-01
+Hessian diagonal search: H+72820.3388*I, length 1.1396e-03, result -9.5111e-02
+Hessian diagonal search: H+68629.9741*I, length 1.2052e-03, result -1.0026e-01
+Hessian diagonal search: H+4450.6390*I, length 1.3264e-02, result -6.0637e-01
+Hessian diagonal search: H+3461.4275*I, length 1.6305e-02, result -6.3194e-01
+Hessian diagonal search: H+18612.1125*I, length 3.9457e-03, result -2.8806e-01
+Hessian diagonal search: H+0.2733*I, length 5.7096e-01, result  1.0520e+02
+Hessian diagonal search: H+7827.2107*I, length 8.2791e-03, result -4.8832e-01
+Hessian diagonal search: H+1336.7083*I, length 3.4132e-02, result -3.4662e-01
+Hessian diagonal search: H+4921.6487*I, length 1.2204e-02, result -5.8976e-01
+Hessian diagonal search: H+2532.7482*I, length 2.0971e-02, result -6.1711e-01
+Hessian diagonal search: H+3988.9290*I, length 1.4517e-02, result -6.2071e-01
+Hessian diagonal search: H+3267.0095*I, length 1.7091e-02, result -6.3366e-01
+Hessian diagonal search: H+3140.0139*I, length 1.7649e-02, result -6.3375e-01
+Hessian diagonal search: H+3189.2041*I, length 1.7428e-02, result -6.3382e-01
+Hessian diagonal search: H+3190.3015*I, length 1.7423e-02, result -6.3382e-01
+Hessian diagonal search: H+3193.9013*I, length 1.7407e-02, result -6.3382e-01
+Hessian diagonal search: H+3191.6763*I, length 1.7417e-02, result -6.3382e-01
+Hessian diagonal search: H+3190.9283*I, length 1.7421e-02, result -6.3382e-01
+Optimization step found (length 1.7423e-02)
+#========================================================#
+#| [95m  Mathematical Parameters (Current + Step = Next)   [0m |#
+#========================================================#
+   0 [ -5.3735e-02 - 6.5662e-03 = -6.0301e-02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [ -9.2110e-03 + 9.0144e-03 = -1.9663e-04 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [ -9.7953e-03 - 1.1985e-03 = -1.0994e-02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  5.7509e-02 - 1.6632e-03 =  5.5846e-02 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [ -1.2004e-02 - 1.2188e-03 = -1.3222e-02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  2.0694e-02 - 2.5285e-03 =  1.8166e-02 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [  9.3698e-03 + 4.7525e-04 =  9.8450e-03 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  1.2421e-02 - 2.5857e-03 =  9.8349e-03 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [ -1.4051e-02 - 1.4758e-03 = -1.5526e-02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [ -9.7563e-03 - 1.2973e-03 = -1.1054e-02 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [  2.0213e-02 + 1.9780e-03 =  2.2191e-02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [ -9.0799e-03 - 1.0893e-03 = -1.0169e-02 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [  4.3807e-06 + 2.7385e-05 =  3.1765e-05 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [ -9.9369e-02 - 1.2191e-02 = -1.1156e-01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [ -1.4058e-02 - 1.3088e-03 = -1.5367e-02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [  3.1667e-04 + 3.8226e-05 =  3.5489e-04 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [  2.2081e-03 + 1.7376e-04 =  2.3818e-03 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  2.1488e-19 + 1.8071e-20 =  2.3295e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [ -1.2320e-03 - 1.7335e-04 = -1.4053e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [ -1.8594e-03 - 2.5915e-04 = -2.1186e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [ -4.4845e-03 - 4.8264e-04 = -4.9671e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [ -6.9323e-03 - 7.2639e-04 = -7.6587e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  1.4153e-06 - 8.9124e-07 =  5.2408e-07 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  3.4196e-05 + 4.4764e-07 =  3.4644e-05 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [ -3.9626e-05 - 6.6191e-06 = -4.6245e-05 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [ -7.8995e-04 - 1.4167e-04 = -9.3163e-04 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+----------------------------------------------------------
+#========================================================#
+#| [95m    Physical Parameters (Current + Step = Next)     [0m |#
+#========================================================#
+   0 [  7.7164e+02 - 5.9096e+00 =  7.6573e+02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [  1.3871e+00 + 1.2620e-02 =  1.3997e+00 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [  8.9118e+02 - 1.0786e+00 =  8.9011e+02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  1.4035e+00 - 2.3284e-03 =  1.4012e+00 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [  6.6920e+02 - 1.0969e+00 =  6.6810e+02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  1.1190e+00 - 3.5399e-03 =  1.1154e+00 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [  7.4243e+02 + 4.2772e-01 =  7.4286e+02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  1.0974e+00 - 3.6200e-03 =  1.0938e+00 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [  1.0781e+02 - 1.7709e-01 =  1.0764e+02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [  6.8634e+01 - 1.8162e-01 =  6.8452e+01 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [  1.2243e+02 + 2.3736e-01 =  1.2266e+02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [  1.3873e+02 - 1.5251e-01 =  1.3858e+02 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [  1.2000e+02 + 3.2862e-03 =  1.2000e+02 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [  8.6088e+01 - 1.7067e+00 =  8.4382e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [  1.1831e+02 - 1.5705e-01 =  1.1816e+02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [  1.4004e+02 + 5.3516e-03 =  1.4005e+02 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [  3.6330e+00 + 6.2988e-04 =  3.6336e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  1.0500e+00 + 0.0000e+00 =  1.0500e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [  1.5491e-02 - 2.9470e-05 =  1.5461e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [  1.4835e+00 - 4.9445e-04 =  1.4830e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [  1.4238e-02 - 8.2049e-05 =  1.4156e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [  1.4458e+00 - 1.3860e-03 =  1.4444e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  1.0940e-01 - 1.5151e-07 =  1.0940e-01 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  1.9081e+00 + 8.5411e-07 =  1.9081e+00 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [  1.6999e-01 - 1.1252e-06 =  1.6999e-01 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [  1.6822e+00 - 2.7031e-04 =  1.6819e+00 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+----------------------------------------------------------
+Input file with saved parameters: optimize.sav
+#========================================================#
+#| [94m     Iteration 6: Evaluating objective function     [0m |#
+#| [94m        and derivatives through second order        [0m |#
+#========================================================#
+
+#======================================================================================================================#
+#| [92m                                         optgeo, Objective =  1.50254e+00                                         [0m |#
+#| [92m  System                       Bonds            Angles           Dihedrals         Impropers               Term.  [0m |#
+#| [92m                            RMSD   denom      RMSD   denom      RMSD   denom      RMSD   denom                    [0m |#
+#======================================================================================================================#
+9HXanthene                    0.009    0.01     0.021    0.03     0.076    0.20     0.005    0.20             1.503 
+------------------------------------------------------------------------------------------------------------------------
+
+#==========================================================================#
+#|                       Frequencies (wavenumbers)                        |#
+#|  Target: vibration  Type: Vibration_SMIRNOFF  Objective = 5.94701e+00  |#
+#|  Mode #            Reference   Calculated   Difference   Ref(dot)Calc  |#
+#==========================================================================#
+    0                   31.1817      55.2436      24.0619         0.9909 
+    1                  127.2863     138.9480      11.6617         0.9953 
+    2                  200.5311     228.0662      27.5351         0.9344 
+    3                  245.4174     231.5263     -13.8911         0.9373 
+    4                  258.8788     244.5161     -14.3627         0.9943 
+    5                  295.5887     325.9690      30.3803         0.9777 
+    6                  385.5805     329.6318     -55.9487         0.9892 
+    7                  413.3227     417.8966       4.5739         0.9721 
+    8                  461.1571     444.8661     -16.2910         0.9815 
+    9                  468.4759     462.4916      -5.9843         0.9887 
+    10                 553.9686     519.7282     -34.2404         0.9575 
+    11                 557.9183     544.1868     -13.7315         0.1063 
+    12                 559.2968     550.0503      -9.2465         0.1395 
+    13                 609.7540     603.5299      -6.2241         0.0013 
+    14                 650.9588     616.1266     -34.8322         0.0037 
+    15                 691.9021     624.4802     -67.4219         0.7616 
+    16                 731.3959     696.6215     -34.7744         0.1075 
+    17                 748.6224     705.9790     -42.6434         0.0300 
+    18                 757.4865     734.0609     -23.4256         0.0119 
+    19                 793.4162     748.6770     -44.7392         0.0011 
+    20                 796.3137     758.5534     -37.7603         0.9883 
+    21                 829.9391     766.9868     -62.9523         0.0015 
+    22                 886.2937     858.8046     -27.4891         0.0056 
+    23                 898.9488     866.9427     -32.0061         0.3101 
+    24                 905.1053     882.1138     -22.9915         0.0749 
+    25                 931.8180     919.4048     -12.4132         0.0037 
+    26                 972.6908     932.8491     -39.8417         0.0095 
+    27                 981.1443     948.4330     -32.7113         0.0221 
+    28                1002.3531     949.1002     -53.2529         0.0022 
+    29                1002.6108    1053.1268      50.5160         0.0558 
+    30                1006.9971    1056.7092      49.7121         0.4708 
+    31                1043.4229    1058.8718      15.4489         0.0008 
+    32                1045.2039    1076.3341      31.1302         0.0089 
+    33                1101.4212    1128.6808      27.2596         0.0176 
+    34                1122.1664    1129.1404       6.9740         0.0228 
+    35                1175.8590    1148.3666     -27.4924         0.0556 
+    36                1177.5535    1155.8710     -21.6825         0.0829 
+    37                1180.0345    1189.7968       9.7623         0.0170 
+    38                1198.0738    1207.7379       9.6641         0.0108 
+    39                1209.4283    1225.9259      16.4976         0.4288 
+    40                1213.4868    1261.1899      47.7031         0.3800 
+    41                1233.7197    1268.8443      35.1246         0.4276 
+    42                1248.6007    1342.9018      94.3011         0.0104 
+    43                1296.1008    1380.0027      83.9019         0.2798 
+    44                1311.1904    1410.1336      98.9432         0.3072 
+    45                1325.6114    1486.2218     160.6104         0.0177 
+    46                1351.5363    1516.7193     165.1830         0.0034 
+    47                1456.1390    1555.1680      99.0290         0.6267 
+    48                1461.1551    1573.4434     112.2883         0.0133 
+    49                1467.0845    1581.0447     113.9602         0.3468 
+    50                1486.3167    1612.1121     125.7954         0.6217 
+    51                1498.4933    1617.1151     118.6218         0.1704 
+    52                1571.5221    1663.9036      92.3815         0.5674 
+    53                1591.5923    1669.5822      77.9899         0.7242 
+    54                1597.5166    1705.0756     107.5590         0.0415 
+    55                1620.6702    1759.2012     138.5310         0.0262 
+    56                2881.8985    2888.6327       6.7342         0.8757 
+    57                2918.3100    2951.2274      32.9174         0.8773 
+    58                3057.8158    3080.9735      23.1577         0.2938 
+    59                3058.9610    3081.1215      22.1605         0.2541 
+    60                3076.7507    3081.6190       4.8683         0.2794 
+    61                3076.9099    3081.6927       4.7828         0.2967 
+    62                3093.3546    3082.7000     -10.6546         0.0902 
+    63                3093.7472    3082.7513     -10.9959         0.1239 
+    64                3108.9905    3083.3399     -25.6506         0.7757 
+    65                3109.6289    3083.6698     -25.9591         0.7963 
+----------------------------------------------------------------------------
+#===================================================================================#
+#| [94m                         Objective Function Breakdown                          [0m |#
+#| [94m  Target Name              Residual  x  Weight  =  Contribution (Current-Prev) [0m |#
+#===================================================================================#
+optgeo                         1.50254      1.000 [92m     1.50254e+00[0m ( -5.105e-02 ) 
+vibration                      5.94701      1.000 [92m     5.94701e+00[0m ( -5.860e-01 ) 
+Regularization                 0.02131      1.000 [91m     2.13116e-02[0m ( +3.188e-03 ) 
+Total                                             [92m     7.47086e+00[0m ( -6.338e-01 ) 
+-------------------------------------------------------------------------------------
+Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_31.offxml
+#========================================================================#
+#|  The force field has been written to the result/optimize directory.  |#
+#|    Input file with optimization parameters saved to optimize.sav.    |#
+#========================================================================#
+
+  Step       |k|        |dk|       |grad|       -=X2=-     Delta(X2)    StepQual
+     6   1.460e-01   1.742e-02   1.092e+02[92m   7.47086e+00[0m  -6.338e-01      1.000
+
+#========================================================#
+#| [94m                   Total Gradient                   [0m |#
+#========================================================#
+   0 [  2.04046723e+01 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [  9.50186385e+01 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [  4.02362853e+00 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  2.81173432e+00 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [  3.88853243e+00 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  1.75093602e+01 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [ -1.51712431e+00 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  2.16728508e+01 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [  4.65105522e+00 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [  4.16300819e+00 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [ -4.99577587e+00 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [  3.59882734e+00 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [ -1.05605855e+00 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [  3.93429836e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [  3.86393127e+00 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [ -1.09311901e-01 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [ -5.37874379e-01 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  4.65893270e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [  4.91203884e-01 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [  8.02694837e-01 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [  1.62663564e+00 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [  2.59300954e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  3.18680966e-02 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  3.50441455e-01 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [  3.47225503e-02 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [  7.52218171e-01 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+----------------------------------------------------------
+Calculating nonlinear optimization step
+Finding trust radius: H+0.0000*I, length 6.0002e-01 (target 1.7423e-02)
+Finding trust radius: H+9.0000*I, length 2.7741e-01 (target 1.7423e-02)
+Finding trust radius: H+61.6869*I, length 1.4125e-01 (target 1.7423e-02)
+Finding trust radius: H+35.4808*I, length 1.6709e-01 (target 1.7423e-02)
+Finding trust radius: H+246.7477*I, length 9.1119e-02 (target 1.7423e-02)
+Finding trust radius: H+159.3607*I, length 1.0657e-01 (target 1.7423e-02)
+Finding trust radius: H+807.4923*I, length 5.0020e-02 (target 1.7423e-02)
+Finding trust radius: H+671.6884*I, length 5.5919e-02 (target 1.7423e-02)
+Finding trust radius: H+2398.9145*I, length 2.3153e-02 (target 1.7423e-02)
+Finding trust radius: H+1725.1005*I, length 2.9716e-02 (target 1.7423e-02)
+Finding trust radius: H+6764.9351*I, length 1.0186e-02 (target 1.7423e-02)
+Finding trust radius: H+2398.9145*I, length 2.3153e-02 (target 1.7423e-02)
+Finding trust radius: H+3805.2759*I, length 1.6120e-02 (target 1.7423e-02)
+Finding trust radius: H+4835.9536*I, length 1.3319e-02 (target 1.7423e-02)
+Finding trust radius: H+3731.3880*I, length 1.6373e-02 (target 1.7423e-02)
+Finding trust radius: H+3187.8293*I, length 1.8545e-02 (target 1.7423e-02)
+Finding trust radius: H+3464.4280*I, length 1.7366e-02 (target 1.7423e-02)
+Finding trust radius: H+3463.3046*I, length 1.7370e-02 (target 1.7423e-02)
+Finding trust radius: H+3448.4657*I, length 1.7429e-02 (target 1.7423e-02)
+Finding trust radius: H+3347.7027*I, length 1.7843e-02 (target 1.7423e-02)
+Finding trust radius: H+3449.9132*I, length 1.7423e-02 (target 1.7423e-02)
+Finding trust radius: H+3450.6149*I, length 1.7421e-02 (target 1.7423e-02)
+Finding trust radius: H+3449.2115*I, length 1.7426e-02 (target 1.7423e-02)
+Starting Hessian diagonal search with step size 1.7423e-02
+Hessian diagonal search: H+3449.9132*I, length 1.7423e-02, result -4.0633e-01
+Hessian diagonal search: H+56617.2738*I, length 1.7238e-03, result -1.7023e-01
+Hessian diagonal search: H+53466.6139*I, length 1.8151e-03, result -1.7824e-01
+Hessian diagonal search: H+3449.9132*I, length 1.7423e-02, result -4.0633e-01
+Hessian diagonal search: H+2706.1428*I, length 2.1087e-02, result -2.1257e-01
+Hessian diagonal search: H+16176.6043*I, length 5.0516e-03, result -4.0114e-01
+Hessian diagonal search: H+7962.5476*I, length 8.9413e-03, result -5.2984e-01
+Hessian diagonal search: H+8577.0286*I, length 8.4251e-03, result -5.2045e-01
+Hessian diagonal search: H+7060.5519*I, length 9.8433e-03, result -5.4110e-01
+Hessian diagonal search: H+5530.4119*I, length 1.1965e-02, result -5.4311e-01
+Hessian diagonal search: H+6147.7685*I, length 1.0995e-02, result -5.4633e-01
+Hessian diagonal search: H+6180.4480*I, length 1.0948e-02, result -5.4631e-01
+Hessian diagonal search: H+6131.4429*I, length 1.1018e-02, result -5.4633e-01
+Hessian diagonal search: H+6125.3564*I, length 1.1027e-02, result -5.4633e-01
+Hessian diagonal search: H+5894.5210*I, length 1.1371e-02, result -5.4589e-01
+Hessian diagonal search: H+6113.5055*I, length 1.1044e-02, result -5.4633e-01
+Hessian diagonal search: H+6124.1157*I, length 1.1029e-02, result -5.4633e-01
+Hessian diagonal search: H+6127.6490*I, length 1.1024e-02, result -5.4633e-01
+Optimization step found (length 1.1027e-02)
+#========================================================#
+#| [95m  Mathematical Parameters (Current + Step = Next)   [0m |#
+#========================================================#
+   0 [ -6.0301e-02 - 3.2710e-03 = -6.3572e-02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [ -1.9663e-04 - 8.1514e-03 = -8.3480e-03 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [ -1.0994e-02 - 6.4396e-04 = -1.1638e-02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  5.5846e-02 - 3.0935e-04 =  5.5536e-02 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [ -1.3222e-02 - 6.0104e-04 = -1.3823e-02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  1.8166e-02 - 5.9166e-04 =  1.7574e-02 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [  9.8450e-03 + 1.8534e-04 =  1.0030e-02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  9.8349e-03 + 1.5735e-03 =  1.1408e-02 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [ -1.5526e-02 - 7.5089e-04 = -1.6277e-02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [ -1.1054e-02 - 6.7151e-04 = -1.1725e-02 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [  2.2191e-02 + 6.8639e-04 =  2.2877e-02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [ -1.0169e-02 - 6.0416e-04 = -1.0773e-02 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [  3.1765e-05 + 1.2170e-04 =  1.5346e-04 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [ -1.1156e-01 - 6.1806e-03 = -1.1774e-01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [ -1.5367e-02 - 6.6014e-04 = -1.6027e-02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [  3.5489e-04 + 1.7636e-05 =  3.7253e-04 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [  2.3818e-03 + 4.2710e-05 =  2.4245e-03 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  2.3295e-19 + 1.7437e-20 =  2.5038e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [ -1.4053e-03 - 7.3189e-05 = -1.4785e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [ -2.1186e-03 - 1.1402e-04 = -2.2326e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [ -4.9671e-03 - 2.3543e-04 = -5.2025e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [ -7.6587e-03 - 3.6475e-04 = -8.0234e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  5.2408e-07 - 2.8060e-06 = -2.2820e-06 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  3.4644e-05 - 2.9258e-05 =  5.3863e-06 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [ -4.6245e-05 - 4.2079e-06 = -5.0453e-05 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [ -9.3163e-04 - 9.2983e-05 = -1.0246e-03 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+----------------------------------------------------------
+#========================================================#
+#| [95m    Physical Parameters (Current + Step = Next)     [0m |#
+#========================================================#
+   0 [  7.6573e+02 - 2.9439e+00 =  7.6278e+02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [  1.3997e+00 - 1.1412e-02 =  1.3883e+00 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [  8.9011e+02 - 5.7956e-01 =  8.8953e+02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  1.4012e+00 - 4.3309e-04 =  1.4008e+00 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [  6.6810e+02 - 5.4094e-01 =  6.6756e+02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  1.1154e+00 - 8.2832e-04 =  1.1146e+00 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [  7.4286e+02 + 1.6680e-01 =  7.4303e+02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  1.0938e+00 + 2.2030e-03 =  1.0960e+00 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [  1.0764e+02 - 9.0107e-02 =  1.0755e+02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [  6.8452e+01 - 9.4012e-02 =  6.8358e+01 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [  1.2266e+02 + 8.2367e-02 =  1.2275e+02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [  1.3858e+02 - 8.4582e-02 =  1.3849e+02 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [  1.2000e+02 + 1.4604e-02 =  1.2002e+02 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [  8.4382e+01 - 8.6528e-01 =  8.3516e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [  1.1816e+02 - 7.9217e-02 =  1.1808e+02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [  1.4005e+02 + 2.4690e-03 =  1.4005e+02 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [  3.6336e+00 + 1.5482e-04 =  3.6338e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  1.0500e+00 + 0.0000e+00 =  1.0500e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [  1.5461e-02 - 1.2442e-05 =  1.5449e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [  1.4830e+00 - 2.1754e-04 =  1.4827e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [  1.4156e-02 - 4.0023e-05 =  1.4116e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [  1.4444e+00 - 6.9593e-04 =  1.4437e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  1.0940e-01 - 4.7703e-07 =  1.0940e-01 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  1.9081e+00 - 5.5823e-05 =  1.9080e+00 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [  1.6999e-01 - 7.1534e-07 =  1.6999e-01 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [  1.6819e+00 - 1.7741e-04 =  1.6817e+00 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+----------------------------------------------------------
+Input file with saved parameters: optimize.sav
+#========================================================#
+#| [94m     Iteration 7: Evaluating objective function     [0m |#
+#| [94m        and derivatives through second order        [0m |#
+#========================================================#
+
+#======================================================================================================================#
+#| [92m                                         optgeo, Objective =  1.29323e+00                                         [0m |#
+#| [92m  System                       Bonds            Angles           Dihedrals         Impropers               Term.  [0m |#
+#| [92m                            RMSD   denom      RMSD   denom      RMSD   denom      RMSD   denom                    [0m |#
+#======================================================================================================================#
+9HXanthene                    0.008    0.01     0.021    0.03     0.076    0.20     0.005    0.20             1.293 
+------------------------------------------------------------------------------------------------------------------------
+
+#==========================================================================#
+#|                       Frequencies (wavenumbers)                        |#
+#|  Target: vibration  Type: Vibration_SMIRNOFF  Objective = 5.60797e+00  |#
+#|  Mode #            Reference   Calculated   Difference   Ref(dot)Calc  |#
+#==========================================================================#
+    0                   31.1817      55.7221      24.5404         0.9910 
+    1                  127.2863     139.8083      12.5220         0.9954 
+    2                  200.5311     229.1666      28.6355         0.9346 
+    3                  245.4174     232.9895     -12.4279         0.9372 
+    4                  258.8788     245.8812     -12.9976         0.9942 
+    5                  295.5887     327.7660      32.1773         0.9782 
+    6                  385.5805     330.6327     -54.9478         0.9893 
+    7                  413.3227     419.1024       5.7797         0.9734 
+    8                  461.1571     449.2510     -11.9061         0.9815 
+    9                  468.4759     466.8455      -1.6304         0.9888 
+    10                 553.9686     524.6481     -29.3205         0.9577 
+    11                 557.9183     548.8364      -9.0819         0.1064 
+    12                 559.2968     554.0938      -5.2030         0.1398 
+    13                 609.7540     609.0839      -0.6701         0.0013 
+    14                 650.9588     618.7161     -32.2427         0.0035 
+    15                 691.9021     627.0514     -64.8507         0.8093 
+    16                 731.3959     701.8030     -29.5929         0.1068 
+    17                 748.6224     709.5152     -39.1072         0.0300 
+    18                 757.4865     739.6851     -17.8014         0.0119 
+    19                 793.4162     751.2688     -42.1474         0.0011 
+    20                 796.3137     758.4729     -37.8408         0.9759 
+    21                 829.9391     767.7038     -62.2353         0.0015 
+    22                 886.2937     863.1591     -23.1346         0.0055 
+    23                 898.9488     870.9013     -28.0475         0.3095 
+    24                 905.1053     882.1413     -22.9640         0.0760 
+    25                 931.8180     919.3363     -12.4817         0.0037 
+    26                 972.6908     932.5001     -40.1907         0.0092 
+    27                 981.1443     947.9577     -33.1866         0.0092 
+    28                1002.3531     949.9343     -52.4188         0.2273 
+    29                1002.6108    1052.5069      49.8961         0.0554 
+    30                1006.9971    1056.1497      49.1526         0.4732 
+    31                1043.4229    1056.8674      13.4445         0.0007 
+    32                1045.2039    1073.5344      28.3305         0.0083 
+    33                1101.4212    1127.8691      26.4479         0.0175 
+    34                1122.1664    1128.3512       6.1848         0.0227 
+    35                1175.8590    1145.7641     -30.0949         0.0631 
+    36                1177.5535    1155.5331     -22.0204         0.0979 
+    37                1180.0345    1186.8593       6.8248         0.0167 
+    38                1198.0738    1205.1922       7.1184         0.0115 
+    39                1209.4283    1223.6235      14.1952         0.4293 
+    40                1213.4868    1261.5766      48.0898         0.3603 
+    41                1233.7197    1270.7510      37.0313         0.4276 
+    42                1248.6007    1340.1187      91.5180         0.0104 
+    43                1296.1008    1379.6551      83.5543         0.2572 
+    44                1311.1904    1406.1928      95.0024         0.3134 
+    45                1325.6114    1481.3145     155.7031         0.0165 
+    46                1351.5363    1510.3591     158.8228         0.0031 
+    47                1456.1390    1552.1557      96.0167         0.6414 
+    48                1461.1551    1570.2114     109.0563         0.0115 
+    49                1467.0845    1575.7950     108.7105         0.3475 
+    50                1486.3167    1608.2028     121.8861         0.6025 
+    51                1498.4933    1613.2053     114.7120         0.1525 
+    52                1571.5221    1660.8974      89.3753         0.5703 
+    53                1591.5923    1667.7712      76.1789         0.7234 
+    54                1597.5166    1703.3073     105.7907         0.0422 
+    55                1620.6702    1759.4945     138.8243         0.0259 
+    56                2881.8985    2887.7050       5.8065         0.8757 
+    57                2918.3100    2950.0071      31.6971         0.8774 
+    58                3057.8158    3081.4113      23.5955         0.2963 
+    59                3058.9610    3081.5623      22.6013         0.2585 
+    60                3076.7507    3082.0791       5.3284         0.2737 
+    61                3076.9099    3082.1576       5.2477         0.2922 
+    62                3093.3546    3083.2723     -10.0823         0.0829 
+    63                3093.7472    3083.3229     -10.4243         0.1143 
+    64                3108.9905    3083.9198     -25.0707         0.7649 
+    65                3109.6289    3084.2492     -25.3797         0.7866 
+----------------------------------------------------------------------------
+#===================================================================================#
+#| [94m                         Objective Function Breakdown                          [0m |#
+#| [94m  Target Name              Residual  x  Weight  =  Contribution (Current-Prev) [0m |#
+#===================================================================================#
+optgeo                         1.29323      1.000 [92m     1.29323e+00[0m ( -2.093e-01 ) 
+vibration                      5.60797      1.000 [92m     5.60797e+00[0m ( -3.390e-01 ) 
+Regularization                 0.02333      1.000 [91m     2.33287e-02[0m ( +2.017e-03 ) 
+Total                                             [92m     6.92452e+00[0m ( -5.463e-01 ) 
+-------------------------------------------------------------------------------------
+Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_32.offxml
+#========================================================================#
+#|  The force field has been written to the result/optimize directory.  |#
+#|    Input file with optimization parameters saved to optimize.sav.    |#
+#========================================================================#
+
+  Step       |k|        |dk|       |grad|       -=X2=-     Delta(X2)    StepQual
+     7   1.527e-01   1.103e-02   7.200e+01[92m   6.92452e+00[0m  -5.463e-01      1.000
+
+#========================================================#
+#| [94m                   Total Gradient                   [0m |#
+#========================================================#
+   0 [  2.11455777e+01 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [ -3.06965123e+01 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [  3.96458726e+00 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  2.74455057e+00 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [  3.67728346e+00 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  1.59829405e+01 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [ -1.14437805e+00 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  4.45431594e+01 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [  4.32441415e+00 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [  4.12520421e+00 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [ -3.96663965e+00 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [  3.91353344e+00 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [ -2.57157224e+00 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [  3.76717628e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [  3.97852541e+00 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [ -1.03652547e-01 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [ -5.72281041e-01 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  5.00767215e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [  4.89611446e-01 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [  7.51514870e-01 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [  1.50700858e+00 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [  2.27536207e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  1.25997929e-02 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  1.01796106e-01 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [  2.61797863e-02 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [  5.35732093e-01 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+----------------------------------------------------------
+Calculating nonlinear optimization step
+Finding trust radius: H+0.0000*I, length 6.0680e-01 (target 1.1027e-02)
+Finding trust radius: H+9.0000*I, length 3.1768e-01 (target 1.1027e-02)
+Finding trust radius: H+61.6869*I, length 1.6007e-01 (target 1.1027e-02)
+Finding trust radius: H+38.8398*I, length 1.9125e-01 (target 1.1027e-02)
+Finding trust radius: H+246.7477*I, length 8.4886e-02 (target 1.1027e-02)
+Finding trust radius: H+165.1674*I, length 1.0371e-01 (target 1.1027e-02)
+Finding trust radius: H+807.4923*I, length 4.2014e-02 (target 1.1027e-02)
+Finding trust radius: H+581.0699*I, length 5.2095e-02 (target 1.1027e-02)
+Finding trust radius: H+2398.9145*I, length 1.8532e-02 (target 1.1027e-02)
+Finding trust radius: H+1685.7881*I, length 2.4537e-02 (target 1.1027e-02)
+Finding trust radius: H+6764.9351*I, length 7.7770e-03 (target 1.1027e-02)
+Finding trust radius: H+4420.0446*I, length 1.1159e-02 (target 1.1027e-02)
+Finding trust radius: H+4420.0446*I, length 1.1159e-02 (target 1.1027e-02)
+Finding trust radius: H+3575.7069*I, length 1.3334e-02 (target 1.1027e-02)
+Finding trust radius: H+5257.0358*I, length 9.6370e-03 (target 1.1027e-02)
+Finding trust radius: H+4580.1059*I, length 1.0829e-02 (target 1.1027e-02)
+Finding trust radius: H+4480.2311*I, length 1.1033e-02 (target 1.1027e-02)
+Finding trust radius: H+4483.9170*I, length 1.1025e-02 (target 1.1027e-02)
+Finding trust radius: H+4482.9935*I, length 1.1027e-02 (target 1.1027e-02)
+Finding trust radius: H+4482.0836*I, length 1.1029e-02 (target 1.1027e-02)
+Starting Hessian diagonal search with step size 1.1027e-02
+Hessian diagonal search: H+4482.9935*I, length 1.1027e-02, result -4.8711e-01
+Hessian diagonal search: H+73343.8206*I, length 9.2586e-04, result -6.3555e-02
+Hessian diagonal search: H+69119.6284*I, length 9.7933e-04, result -6.7035e-02
+Hessian diagonal search: H+4482.9935*I, length 1.1027e-02, result -4.8711e-01
+Hessian diagonal search: H+3485.7964*I, length 1.3621e-02, result -5.4335e-01
+Hessian diagonal search: H+18744.4353*I, length 3.2245e-03, result -1.9939e-01
+Hessian diagonal search: H+29.1327*I, length 2.1227e-01, result  4.4311e+00
+Hessian diagonal search: H+7882.6352*I, length 6.8252e-03, result -3.5866e-01
+Hessian diagonal search: H+1486.1617*I, length 2.7040e-02, result -6.6302e-01
+Hessian diagonal search: H+670.1541*I, length 4.7553e-02, result -7.7444e-01
+Hessian diagonal search: H+326.1962*I, length 7.3141e-02, result -1.4816e+00
+Hessian diagonal search: H+174.8715*I, length 1.0089e-01, result -2.6501e+00
+Hessian diagonal search: H+104.7444*I, length 1.2800e-01, result -3.0274e+00
+Hessian diagonal search: H+55.4621*I, length 1.6697e-01, result -9.8323e-01
+Hessian diagonal search: H+129.4209*I, length 1.1633e-01, result -3.0238e+00
+Hessian diagonal search: H+116.2498*I, length 1.2217e-01, result -3.0590e+00
+Hessian diagonal search: H+116.4262*I, length 1.2208e-01, result -3.0589e+00
+Hessian diagonal search: H+115.9493*I, length 1.2231e-01, result -3.0590e+00
+Hessian diagonal search: H+115.9283*I, length 1.2232e-01, result -3.0590e+00
+Hessian diagonal search: H+115.9703*I, length 1.2230e-01, result -3.0590e+00
+Optimization step found (length 1.2231e-01)
+#========================================================#
+#| [95m  Mathematical Parameters (Current + Step = Next)   [0m |#
+#========================================================#
+   0 [ -6.3572e-02 - 4.0883e-02 = -1.0445e-01 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [ -8.3480e-03 + 2.6363e-03 = -5.7117e-03 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [ -1.1638e-02 - 1.3674e-02 = -2.5311e-02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  5.5536e-02 - 1.7565e-02 =  3.7971e-02 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [ -1.3823e-02 - 7.3349e-03 = -2.1158e-02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  1.7574e-02 + 5.2864e-03 =  2.2860e-02 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [  1.0030e-02 + 1.1482e-03 =  1.1179e-02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  1.1408e-02 - 1.1631e-02 = -2.2229e-04 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [ -1.6277e-02 - 2.5537e-02 = -4.1814e-02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [ -1.1725e-02 - 1.7587e-02 = -2.9312e-02 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [  2.2877e-02 + 1.1636e-02 =  3.4513e-02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [ -1.0773e-02 + 2.3226e-03 = -8.4507e-03 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [  1.5346e-04 - 3.6635e-03 = -3.5101e-03 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [ -1.1774e-01 - 1.0200e-01 = -2.1974e-01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [ -1.6027e-02 - 2.9860e-02 = -4.5887e-02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [  3.7253e-04 + 2.0710e-03 =  2.4435e-03 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [  2.4245e-03 - 9.2630e-03 = -6.8385e-03 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  2.5038e-19 + 1.1082e-19 =  3.6120e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [ -1.4785e-03 - 2.0820e-04 = -1.6867e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [ -2.2326e-03 - 1.4625e-04 = -2.3788e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [ -5.2025e-03 + 3.9468e-03 = -1.2557e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [ -8.0234e-03 + 5.5054e-03 = -2.5180e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [ -2.2820e-06 + 4.2171e-04 =  4.1943e-04 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  5.3863e-06 + 4.1345e-03 =  4.1399e-03 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [ -5.0453e-05 + 1.4058e-04 =  9.0130e-05 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [ -1.0246e-03 + 1.5707e-03 =  5.4611e-04 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+----------------------------------------------------------
+#========================================================#
+#| [95m    Physical Parameters (Current + Step = Next)     [0m |#
+#========================================================#
+   0 [  7.6278e+02 - 3.6794e+01 =  7.2599e+02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [  1.3883e+00 + 3.6908e-03 =  1.3920e+00 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [  8.8953e+02 - 1.2306e+01 =  8.7722e+02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  1.4008e+00 - 2.4591e-02 =  1.3762e+00 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [  6.6756e+02 - 6.6014e+00 =  6.6096e+02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  1.1146e+00 + 7.4010e-03 =  1.1220e+00 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [  7.4303e+02 + 1.0334e+00 =  7.4406e+02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  1.0960e+00 - 1.6283e-02 =  1.0797e+00 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [  1.0755e+02 - 3.0644e+00 =  1.0448e+02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [  6.8358e+01 - 2.4622e+00 =  6.5896e+01 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [  1.2275e+02 + 1.3963e+00 =  1.2414e+02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [  1.3849e+02 + 3.2516e-01 =  1.3882e+02 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [  1.2002e+02 - 4.3962e-01 =  1.1958e+02 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [  8.3516e+01 - 1.4280e+01 =  6.9236e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [  1.1808e+02 - 3.5832e+00 =  1.1449e+02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [  1.4005e+02 + 2.8994e-01 =  1.4034e+02 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [  3.6338e+00 - 3.3578e-02 =  3.6002e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  1.0500e+00 + 0.0000e+00 =  1.0500e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [  1.5449e-02 - 3.5394e-05 =  1.5413e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [  1.4827e+00 - 2.7904e-04 =  1.4825e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [  1.4116e-02 + 6.7096e-04 =  1.4787e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [  1.4437e+00 + 1.0504e-02 =  1.4542e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  1.0940e-01 + 7.1691e-05 =  1.0947e-01 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  1.9080e+00 + 7.8887e-03 =  1.9159e+00 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [  1.6999e-01 + 2.3899e-05 =  1.7002e-01 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [  1.6817e+00 + 2.9969e-03 =  1.6847e+00 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+----------------------------------------------------------
+Input file with saved parameters: optimize.sav
+#========================================================#
+#| [94m     Iteration 8: Evaluating objective function     [0m |#
+#| [94m        and derivatives through second order        [0m |#
+#========================================================#
+
+#======================================================================================================================#
+#| [92m                                         optgeo, Objective =  1.47662e+00                                         [0m |#
+#| [92m  System                       Bonds            Angles           Dihedrals         Impropers               Term.  [0m |#
+#| [92m                            RMSD   denom      RMSD   denom      RMSD   denom      RMSD   denom                    [0m |#
+#======================================================================================================================#
+9HXanthene                    0.009    0.01     0.020    0.03     0.076    0.20     0.005    0.20             1.477 
+------------------------------------------------------------------------------------------------------------------------
+
+#==========================================================================#
+#|                       Frequencies (wavenumbers)                        |#
+#|  Target: vibration  Type: Vibration_SMIRNOFF  Objective = 2.32045e+00  |#
+#|  Mode #            Reference   Calculated   Difference   Ref(dot)Calc  |#
+#==========================================================================#
+    0                   31.1817      54.4408      23.2591         0.9915 
+    1                  127.2863     140.4399      13.1536         0.9960 
+    2                  200.5311     231.3739      30.8428         0.9370 
+    3                  245.4174     232.7053     -12.7121         0.9370 
+    4                  258.8788     251.0979      -7.7809         0.9951 
+    5                  295.5887     329.1513      33.5626         0.0300 
+    6                  385.5805     329.2290     -56.3515         0.0192 
+    7                  413.3227     421.3164       7.9937         0.9692 
+    8                  461.1571     459.9517      -1.2054         0.9817 
+    9                  468.4759     478.4757       9.9998         0.9894 
+    10                 553.9686     536.3937     -17.5749         0.9560 
+    11                 557.9183     542.4938     -15.4245         0.1058 
+    12                 559.2968     562.5964       3.2996         0.1397 
+    13                 609.7540     599.4021     -10.3519         0.0013 
+    14                 650.9588     611.5542     -39.4046         0.0039 
+    15                 691.9021     624.5629     -67.3392         0.5931 
+    16                 731.3959     689.7888     -41.6071         0.1041 
+    17                 748.6224     716.1265     -32.4959         0.0297 
+    18                 757.4865     736.9463     -20.5402         0.0017 
+    19                 793.4162     752.6970     -40.7192         0.0334 
+    20                 796.3137     765.9190     -30.3947         0.8073 
+    21                 829.9391     774.0307     -55.9084         0.0015 
+    22                 886.2937     849.0638     -37.2299         0.0056 
+    23                 898.9488     859.4488     -39.5000         0.3072 
+    24                 905.1053     882.5378     -22.5675         0.0752 
+    25                 931.8180     907.6878     -24.1302         0.0016 
+    26                 972.6908     921.9506     -50.7402         0.0018 
+    27                 981.1443     924.4704     -56.6739         0.0849 
+    28                1002.3531     956.2097     -46.1434         0.2269 
+    29                1002.6108    1019.8740      17.2632         0.0180 
+    30                1006.9971    1033.2925      26.2954         0.0259 
+    31                1043.4229    1057.1959      13.7730         0.0109 
+    32                1045.2039    1060.8552      15.6513         0.0182 
+    33                1101.4212    1099.2962      -2.1250         0.0029 
+    34                1122.1664    1110.6110     -11.5554         0.0009 
+    35                1175.8590    1134.3856     -41.4734         0.0170 
+    36                1177.5535    1134.9226     -42.6309         0.0164 
+    37                1180.0345    1148.1020     -31.9325         0.0098 
+    38                1198.0738    1161.9999     -36.0739         0.0147 
+    39                1209.4283    1179.3389     -30.0894         0.4164 
+    40                1213.4868    1237.6864      24.1996         0.2206 
+    41                1233.7197    1263.8429      30.1232         0.4278 
+    42                1248.6007    1280.4527      31.8520         0.0075 
+    43                1296.1008    1334.7561      38.6553         0.0316 
+    44                1311.1904    1343.6976      32.5072         0.0098 
+    45                1325.6114    1407.4147      81.8033         0.0060 
+    46                1351.5363    1423.9809      72.4446         0.0008 
+    47                1456.1390    1490.1134      33.9744         0.6133 
+    48                1461.1551    1494.1485      32.9934         0.1887 
+    49                1467.0845    1525.0383      57.9538         0.0139 
+    50                1486.3167    1553.0295      66.7128         0.3169 
+    51                1498.4933    1563.3096      64.8163         0.0669 
+    52                1571.5221    1610.7718      39.2497         0.5326 
+    53                1591.5923    1626.4832      34.8909         0.6207 
+    54                1597.5166    1650.2412      52.7246         0.0541 
+    55                1620.6702    1725.3408     104.6706         0.0240 
+    56                2881.8985    2877.5841      -4.3144         0.8738 
+    57                2918.3100    2931.4168      13.1068         0.8790 
+    58                3057.8158    3083.0127      25.1969         0.2672 
+    59                3058.9610    3083.1485      24.1875         0.2230 
+    60                3076.7507    3083.6474       6.8967         0.2742 
+    61                3076.9099    3083.7113       6.8014         0.2764 
+    62                3093.3546    3084.5733      -8.7813         0.1544 
+    63                3093.7472    3084.6391      -9.1081         0.1980 
+    64                3108.9905    3085.6275     -23.3630         0.8150 
+    65                3109.6289    3085.9775     -23.6514         0.8282 
+----------------------------------------------------------------------------
+#===================================================================================#
+#| [94m                         Objective Function Breakdown                          [0m |#
+#| [94m  Target Name              Residual  x  Weight  =  Contribution (Current-Prev) [0m |#
+#===================================================================================#
+optgeo                         1.47662      1.000 [91m     1.47662e+00[0m ( +1.834e-01 ) 
+vibration                      2.32045      1.000 [92m     2.32045e+00[0m ( -3.288e+00 ) 
+Regularization                 0.06848      1.000 [91m     6.84827e-02[0m ( +4.515e-02 ) 
+Total                                             [92m     3.86555e+00[0m ( -3.059e+00 ) 
+-------------------------------------------------------------------------------------
+Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_33.offxml
+#========================================================================#
+#|  The force field has been written to the result/optimize directory.  |#
+#|    Input file with optimization parameters saved to optimize.sav.    |#
+#========================================================================#
+
+  Step       |k|        |dk|       |grad|       -=X2=-     Delta(X2)    StepQual
+     8   2.617e-01   1.223e-01   8.216e+01[92m   3.86555e+00[0m  -3.059e+00      1.000
+
+#========================================================#
+#| [94m                   Total Gradient                   [0m |#
+#========================================================#
+   0 [  9.42865008e+00 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [  2.98670165e+01 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [  2.16693914e+00 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [ -3.90208049e+01 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [  8.28733396e-01 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  4.02923823e+01 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [ -7.32745469e-02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [ -4.52598802e+01 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [ -1.68378233e+00 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [  1.48108822e+00 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [ -1.89937396e+00 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [  8.56641589e-01 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [ -1.79560463e+01 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [  1.37687849e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [  2.60923155e+00 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [ -2.04872706e-01 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [ -6.43456976e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  7.22399390e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [  2.52455120e-01 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [  4.32475276e-01 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [  9.72539261e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [  1.04603238e-01 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [ -3.81963426e-02 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [ -3.75680105e-01 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [ -4.87981478e-03 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [ -1.93623505e-02 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+----------------------------------------------------------
+Calculating nonlinear optimization step
+Finding trust radius: H+0.0000*I, length 4.7654e-01 (target 1.2231e-01)
+Finding trust radius: H+9.0000*I, length 2.1798e-01 (target 1.2231e-01)
+Finding trust radius: H+61.6869*I, length 8.7751e-02 (target 1.2231e-01)
+Finding trust radius: H+31.3650*I, length 1.2015e-01 (target 1.2231e-01)
+Finding trust radius: H+31.3650*I, length 1.2015e-01 (target 1.2231e-01)
+Finding trust radius: H+21.2260*I, length 1.4521e-01 (target 1.2231e-01)
+Finding trust radius: H+41.7480*I, length 1.0493e-01 (target 1.2231e-01)
+Finding trust radius: H+32.0617*I, length 1.1889e-01 (target 1.2231e-01)
+Finding trust radius: H+29.5526*I, length 1.2364e-01 (target 1.2231e-01)
+Finding trust radius: H+26.2099*I, length 1.3103e-01 (target 1.2231e-01)
+Finding trust radius: H+30.2244*I, length 1.2231e-01 (target 1.2231e-01)
+Finding trust radius: H+30.2382*I, length 1.2228e-01 (target 1.2231e-01)
+Finding trust radius: H+30.2172*I, length 1.2232e-01 (target 1.2231e-01)
+Starting Hessian diagonal search with step size 1.2231e-01
+Hessian diagonal search: H+30.2244*I, length 1.2231e-01, result  2.0089e+01
+Hessian diagonal search: H+624.5340*I, length 3.1701e-02, result  4.3158e-01
+Hessian diagonal search: H+3195.7571*I, length 1.3529e-02, result -4.8642e-01
+Hessian diagonal search: H+1723.8446*I, length 1.9107e-02, result -3.7683e-01
+Hessian diagonal search: H+11570.0974*I, length 5.5563e-03, result -3.4636e-01
+Hessian diagonal search: H+3195.7571*I, length 1.3529e-02, result -4.8642e-01
+Hessian diagonal search: H+5779.6541*I, length 9.2767e-03, result -4.6018e-01
+Hessian diagonal search: H+1978.7984*I, length 1.7746e-02, result -4.1733e-01
+Hessian diagonal search: H+4004.2522*I, length 1.1792e-02, result -4.8820e-01
+Hessian diagonal search: H+3714.9651*I, length 1.2353e-02, result -4.8945e-01
+Hessian diagonal search: H+3676.6908*I, length 1.2432e-02, result -4.8948e-01
+Hessian diagonal search: H+3654.4909*I, length 1.2478e-02, result -4.8949e-01
+Hessian diagonal search: H+3657.9304*I, length 1.2471e-02, result -4.8949e-01
+Hessian diagonal search: H+3658.6741*I, length 1.2469e-02, result -4.8949e-01
+Hessian diagonal search: H+3665.5507*I, length 1.2455e-02, result -4.8949e-01
+Hessian diagonal search: H+3661.3000*I, length 1.2464e-02, result -4.8949e-01
+Hessian diagonal search: H+3659.6770*I, length 1.2467e-02, result -4.8949e-01
+Optimization step found (length 1.2469e-02)
+#========================================================#
+#| [95m  Mathematical Parameters (Current + Step = Next)   [0m |#
+#========================================================#
+   0 [ -1.0445e-01 - 2.3121e-03 = -1.0677e-01 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [ -5.7117e-03 - 4.8454e-03 = -1.0557e-02 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [ -2.5311e-02 - 5.2194e-04 = -2.5833e-02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  3.7971e-02 + 5.4651e-03 =  4.3436e-02 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [ -2.1158e-02 - 2.1092e-04 = -2.1369e-02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  2.2860e-02 - 4.8735e-03 =  1.7987e-02 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [  1.1179e-02 + 7.4608e-06 =  1.1186e-02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [ -2.2229e-04 + 6.1944e-03 =  5.9721e-03 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [ -4.1814e-02 + 4.8838e-04 = -4.1326e-02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [ -2.9312e-02 - 4.4526e-04 = -2.9758e-02 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [  3.4513e-02 + 7.7614e-04 =  3.5289e-02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [ -8.4507e-03 - 1.9217e-04 = -8.6429e-03 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [ -3.5101e-03 + 4.5607e-03 =  1.0507e-03 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [ -2.1974e-01 - 3.0508e-03 = -2.2279e-01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [ -4.5887e-02 - 5.5713e-04 = -4.6445e-02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [  2.4435e-03 + 5.1347e-05 =  2.4949e-03 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [ -6.8385e-03 + 1.6801e-03 = -5.1584e-03 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  3.6120e-19 - 1.0471e-20 =  3.5073e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [ -1.6867e-03 - 6.0888e-05 = -1.7476e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [ -2.3788e-03 - 9.5179e-05 = -2.4740e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [ -1.2557e-03 + 2.6338e-05 = -1.2294e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [ -2.5180e-03 + 4.4997e-05 = -2.4730e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  4.1943e-04 + 1.2353e-05 =  4.3178e-04 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  4.1399e-03 + 1.2174e-04 =  4.2617e-03 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [  9.0130e-05 + 2.3114e-06 =  9.2441e-05 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [  5.4611e-04 + 1.6937e-05 =  5.6304e-04 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+----------------------------------------------------------
+#========================================================#
+#| [95m    Physical Parameters (Current + Step = Next)     [0m |#
+#========================================================#
+   0 [  7.2599e+02 - 2.0809e+00 =  7.2391e+02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [  1.3920e+00 - 6.7835e-03 =  1.3852e+00 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [  8.7722e+02 - 4.6974e-01 =  8.7675e+02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  1.3762e+00 + 7.6512e-03 =  1.3838e+00 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [  6.6096e+02 - 1.8983e-01 =  6.6077e+02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  1.1220e+00 - 6.8229e-03 =  1.1152e+00 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [  7.4406e+02 + 6.7147e-03 =  7.4407e+02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  1.0797e+00 + 8.6721e-03 =  1.0884e+00 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [  1.0448e+02 + 5.8606e-02 =  1.0454e+02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [  6.5896e+01 - 6.2336e-02 =  6.5834e+01 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [  1.2414e+02 + 9.3137e-02 =  1.2423e+02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [  1.3882e+02 - 2.6904e-02 =  1.3879e+02 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [  1.1958e+02 + 5.4728e-01 =  1.2013e+02 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [  6.9236e+01 - 4.2711e-01 =  6.8809e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [  1.1449e+02 - 6.6856e-02 =  1.1443e+02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [  1.4034e+02 + 7.1886e-03 =  1.4035e+02 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [  3.6002e+00 + 6.0904e-03 =  3.6063e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  1.0500e+00 + 0.0000e+00 =  1.0500e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [  1.5413e-02 - 1.0351e-05 =  1.5403e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [  1.4825e+00 - 1.8160e-04 =  1.4823e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [  1.4787e-02 + 4.4775e-06 =  1.4791e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [  1.4542e+00 + 8.5854e-05 =  1.4543e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  1.0947e-01 + 2.1000e-06 =  1.0947e-01 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  1.9159e+00 + 2.3228e-04 =  1.9161e+00 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [  1.7002e-01 + 3.9293e-07 =  1.7002e-01 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [  1.6847e+00 + 3.2315e-05 =  1.6848e+00 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+----------------------------------------------------------
+Input file with saved parameters: optimize.sav
+#========================================================#
+#| [94m     Iteration 9: Evaluating objective function     [0m |#
+#| [94m        and derivatives through second order        [0m |#
+#========================================================#
+
+#======================================================================================================================#
+#| [92m                                         optgeo, Objective =  1.11306e+00                                         [0m |#
+#| [92m  System                       Bonds            Angles           Dihedrals         Impropers               Term.  [0m |#
+#| [92m                            RMSD   denom      RMSD   denom      RMSD   denom      RMSD   denom                    [0m |#
+#======================================================================================================================#
+9HXanthene                    0.007    0.01     0.020    0.03     0.076    0.20     0.005    0.20             1.113 
+------------------------------------------------------------------------------------------------------------------------
+
+#==========================================================================#
+#|                       Frequencies (wavenumbers)                        |#
+#|  Target: vibration  Type: Vibration_SMIRNOFF  Objective = 2.19222e+00  |#
+#|  Mode #            Reference   Calculated   Difference   Ref(dot)Calc  |#
+#==========================================================================#
+    0                   31.1817      54.3070      23.1253         0.9916 
+    1                  127.2863     140.7489      13.4626         0.9959 
+    2                  200.5311     232.0617      31.5306         0.9374 
+    3                  245.4174     233.5015     -11.9159         0.9370 
+    4                  258.8788     252.0595      -6.8193         0.9950 
+    5                  295.5887     329.2408      33.6521         0.0304 
+    6                  385.5805     329.5500     -56.0305         0.0194 
+    7                  413.3227     420.9492       7.6265         0.9705 
+    8                  461.1571     462.3325       1.1754         0.9819 
+    9                  468.4759     480.7671      12.2912         0.9896 
+    10                 553.9686     539.0822     -14.8864         0.9562 
+    11                 557.9183     545.3380     -12.5803         0.1060 
+    12                 559.2968     564.4417       5.1449         0.1399 
+    13                 609.7540     602.6686      -7.0854         0.0013 
+    14                 650.9588     613.3100     -37.6488         0.0039 
+    15                 691.9021     624.2351     -67.6670         0.6267 
+    16                 731.3959     692.7276     -38.6683         0.1041 
+    17                 748.6224     718.6456     -29.9768         0.0296 
+    18                 757.4865     738.5547     -18.9318         0.0017 
+    19                 793.4162     755.0669     -38.3493         0.0366 
+    20                 796.3137     768.0311     -28.2826         0.7502 
+    21                 829.9391     775.3618     -54.5773         0.0015 
+    22                 886.2937     851.7119     -34.5818         0.0055 
+    23                 898.9488     861.3291     -37.6197         0.3067 
+    24                 905.1053     883.3428     -21.7625         0.0761 
+    25                 931.8180     905.7281     -26.0899         0.0015 
+    26                 972.6908     918.9560     -53.7348         0.0018 
+    27                 981.1443     925.4664     -55.6779         0.0847 
+    28                1002.3531     958.5347     -43.8184         0.2335 
+    29                1002.6108    1015.0174      12.4066         0.0186 
+    30                1006.9971    1027.5252      20.5281         0.0255 
+    31                1043.4229    1057.1786      13.7557         0.0108 
+    32                1045.2039    1060.9008      15.6969         0.0182 
+    33                1101.4212    1092.4018      -9.0194         0.0027 
+    34                1122.1664    1103.3298     -18.8366         0.0000 
+    35                1175.8590    1134.1404     -41.7186         0.0167 
+    36                1177.5535    1134.7185     -42.8350         0.0161 
+    37                1180.0345    1147.6067     -32.4278         0.0079 
+    38                1198.0738    1157.1966     -40.8772         0.0150 
+    39                1209.4283    1175.7682     -33.6601         0.4067 
+    40                1213.4868    1234.5341      21.0473         0.1844 
+    41                1233.7197    1272.7057      38.9860         0.4277 
+    42                1248.6007    1275.5509      26.9502         0.0059 
+    43                1296.1008    1326.2541      30.1533         0.0320 
+    44                1311.1904    1348.4358      37.2454         0.0063 
+    45                1325.6114    1402.3464      76.7350         0.0045 
+    46                1351.5363    1416.4094      64.8731         0.0004 
+    47                1456.1390    1485.0672      28.9282         0.5883 
+    48                1461.1551    1487.0537      25.8986         0.1919 
+    49                1467.0845    1521.8633      54.7788         0.0130 
+    50                1486.3167    1551.7826      65.4659         0.2813 
+    51                1498.4933    1558.2013      59.7080         0.0656 
+    52                1571.5221    1608.9196      37.3975         0.5262 
+    53                1591.5923    1624.6815      33.0892         0.5989 
+    54                1597.5166    1648.2125      50.6959         0.0563 
+    55                1620.6702    1725.7658     105.0956         0.0237 
+    56                2881.8985    2877.2819      -4.6166         0.8737 
+    57                2918.3100    2931.0608      12.7508         0.8789 
+    58                3057.8158    3083.0460      25.2302         0.2660 
+    59                3058.9610    3083.1843      24.2233         0.2238 
+    60                3076.7507    3083.6924       6.9417         0.2791 
+    61                3076.9099    3083.7596       6.8497         0.2852 
+    62                3093.3546    3084.7357      -8.6189         0.1389 
+    63                3093.7472    3084.7999      -8.9473         0.1782 
+    64                3108.9905    3085.7331     -23.2574         0.8031 
+    65                3109.6289    3086.0796     -23.5493         0.8177 
+----------------------------------------------------------------------------
+#===================================================================================#
+#| [94m                         Objective Function Breakdown                          [0m |#
+#| [94m  Target Name              Residual  x  Weight  =  Contribution (Current-Prev) [0m |#
+#===================================================================================#
+optgeo                         1.11306      1.000 [92m     1.11306e+00[0m ( -3.636e-01 ) 
+vibration                      2.19222      1.000 [92m     2.19222e+00[0m ( -1.282e-01 ) 
+Regularization                 0.07078      1.000 [91m     7.07822e-02[0m ( +2.299e-03 ) 
+Total                                             [92m     3.37606e+00[0m ( -4.895e-01 ) 
+-------------------------------------------------------------------------------------
+Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_34.offxml
+#========================================================================#
+#|  The force field has been written to the result/optimize directory.  |#
+#|    Input file with optimization parameters saved to optimize.sav.    |#
+#========================================================================#
+
+  Step       |k|        |dk|       |grad|       -=X2=-     Delta(X2)    StepQual
+     9   2.660e-01   1.247e-02   6.808e+01[92m   3.37606e+00[0m  -4.895e-01      1.000
+
+#========================================================#
+#| [94m                   Total Gradient                   [0m |#
+#========================================================#
+   0 [  9.05709042e+00 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [ -4.31091737e+01 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [  1.91467412e+00 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [ -2.33831723e+01 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [  7.69434636e-01 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  2.46344433e+01 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [ -4.77954960e-02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  3.28383985e+01 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [ -1.70268841e+00 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [  1.69398030e+00 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [ -1.70804887e+00 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [  8.42661698e-01 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [ -1.72450055e+01 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [  1.05067430e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [  1.66062970e+00 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [ -1.77329700e-01 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [ -6.15479868e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  7.01457702e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [  2.30202411e-01 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [  3.48813240e-01 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [ -1.38788654e-01 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [ -2.50968063e-01 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [ -5.16472878e-02 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [ -5.32591857e-01 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [ -1.02897694e-02 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [ -1.24444296e-01 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+----------------------------------------------------------
+Calculating nonlinear optimization step
+Finding trust radius: H+0.0000*I, length 3.9364e-01 (target 1.2469e-02)
+Finding trust radius: H+9.0000*I, length 1.9438e-01 (target 1.2469e-02)
+Finding trust radius: H+61.6869*I, length 7.3052e-02 (target 1.2469e-02)
+Finding trust radius: H+38.2732*I, length 9.5626e-02 (target 1.2469e-02)
+Finding trust radius: H+246.7477*I, length 3.5946e-02 (target 1.2469e-02)
+Finding trust radius: H+149.4922*I, length 4.5605e-02 (target 1.2469e-02)
+Finding trust radius: H+807.4923*I, length 2.0565e-02 (target 1.2469e-02)
+Finding trust radius: H+536.2394*I, length 2.5090e-02 (target 1.2469e-02)
+Finding trust radius: H+2398.9145*I, length 1.1706e-02 (target 1.2469e-02)
+Finding trust radius: H+1615.8007*I, length 1.4439e-02 (target 1.2469e-02)
+Finding trust radius: H+6764.9351*I, length 6.3286e-03 (target 1.2469e-02)
+Finding trust radius: H+2398.9145*I, length 1.1706e-02 (target 1.2469e-02)
+Finding trust radius: H+3805.2759*I, length 9.0423e-03 (target 1.2469e-02)
+Finding trust radius: H+1691.2338*I, length 1.4098e-02 (target 1.2469e-02)
+Finding trust radius: H+2249.2025*I, length 1.2120e-02 (target 1.2469e-02)
+Finding trust radius: H+2165.4685*I, length 1.2369e-02 (target 1.2469e-02)
+Finding trust radius: H+2123.5313*I, length 1.2499e-02 (target 1.2469e-02)
+Finding trust radius: H+2132.5591*I, length 1.2471e-02 (target 1.2469e-02)
+Finding trust radius: H+2133.1368*I, length 1.2469e-02 (target 1.2469e-02)
+Finding trust radius: H+2133.5727*I, length 1.2468e-02 (target 1.2469e-02)
+Starting Hessian diagonal search with step size 1.2469e-02
+Hessian diagonal search: H+2133.1368*I, length 1.2469e-02, result -2.6035e-01
+Hessian diagonal search: H+35247.6505*I, length 1.7215e-03, result -1.0327e-01
+Hessian diagonal search: H+33437.5049*I, length 1.8043e-03, result -1.0752e-01
+Hessian diagonal search: H+2133.1368*I, length 1.2469e-02, result -2.6035e-01
+Hessian diagonal search: H+1705.8191*I, length 1.4035e-02, result -2.5237e-01
+Hessian diagonal search: H+10051.2888*I, length 4.8060e-03, result -2.2018e-01
+Hessian diagonal search: H+103.6450*I, length 5.4981e-02, result  6.5789e-02
+Hessian diagonal search: H+4467.4359*I, length 8.2236e-03, result -2.6691e-01
+Hessian diagonal search: H+6336.6580*I, length 6.6068e-03, result -2.5347e-01
+Hessian diagonal search: H+3645.9572*I, length 9.2693e-03, result -2.6932e-01
+Hessian diagonal search: H+3572.5581*I, length 9.3785e-03, result -2.6936e-01
+Hessian diagonal search: H+3540.2000*I, length 9.4276e-03, result -2.6936e-01
+Hessian diagonal search: H+3544.0207*I, length 9.4218e-03, result -2.6936e-01
+Hessian diagonal search: H+2960.9056*I, length 1.0429e-02, result -2.6802e-01
+Hessian diagonal search: H+3428.5855*I, length 9.6021e-03, result -2.6931e-01
+Hessian diagonal search: H+3539.4801*I, length 9.4287e-03, result -2.6936e-01
+Hessian diagonal search: H+3523.9068*I, length 9.4526e-03, result -2.6936e-01
+Hessian diagonal search: H+3533.5276*I, length 9.4378e-03, result -2.6936e-01
+Hessian diagonal search: H+3537.2058*I, length 9.4322e-03, result -2.6936e-01
+Hessian diagonal search: H+3538.7603*I, length 9.4298e-03, result -2.6936e-01
+Optimization step found (length 9.4287e-03)
+#========================================================#
+#| [95m  Mathematical Parameters (Current + Step = Next)   [0m |#
+#========================================================#
+   0 [ -1.0677e-01 - 2.3517e-03 = -1.0912e-01 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [ -1.0557e-02 + 5.3759e-03 = -5.1812e-03 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [ -2.5833e-02 - 4.9721e-04 = -2.6330e-02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  4.3436e-02 + 3.0374e-03 =  4.6474e-02 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [ -2.1369e-02 - 1.9518e-04 = -2.1564e-02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  1.7987e-02 - 2.3747e-03 =  1.5612e-02 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [  1.1186e-02 + 3.5037e-05 =  1.1221e-02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  5.9721e-03 - 3.9220e-03 =  2.0500e-03 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [ -4.1326e-02 + 4.7940e-04 = -4.0846e-02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [ -2.9758e-02 - 5.0493e-04 = -3.0263e-02 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [  3.5289e-02 + 8.4852e-04 =  3.6138e-02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [ -8.6429e-03 - 1.2375e-04 = -8.7667e-03 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [  1.0507e-03 + 3.5408e-03 =  4.5914e-03 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [ -2.2279e-01 - 2.8648e-03 = -2.2566e-01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [ -4.6445e-02 - 3.9111e-04 = -4.6836e-02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [  2.4949e-03 + 5.1901e-05 =  2.5468e-03 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [ -5.1584e-03 + 1.3326e-03 = -3.8257e-03 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  3.5073e-19 + 1.4550e-21 =  3.5218e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [ -1.7476e-03 - 5.6007e-05 = -1.8036e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [ -2.4740e-03 - 8.0315e-05 = -2.5543e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [ -1.2294e-03 + 4.1239e-05 = -1.1882e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [ -2.4730e-03 + 6.4159e-05 = -2.4088e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  4.3178e-04 + 1.5326e-05 =  4.4711e-04 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  4.2617e-03 + 1.5370e-04 =  4.4154e-03 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [  9.2441e-05 + 3.3765e-06 =  9.5817e-05 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [  5.6304e-04 + 3.5467e-05 =  5.9851e-04 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+----------------------------------------------------------
+#========================================================#
+#| [95m    Physical Parameters (Current + Step = Next)     [0m |#
+#========================================================#
+   0 [  7.2391e+02 - 2.1166e+00 =  7.2179e+02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [  1.3852e+00 + 7.5263e-03 =  1.3927e+00 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [  8.7675e+02 - 4.4749e-01 =  8.7630e+02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  1.3838e+00 + 4.2524e-03 =  1.3881e+00 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [  6.6077e+02 - 1.7566e-01 =  6.6059e+02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  1.1152e+00 - 3.3246e-03 =  1.1119e+00 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [  7.4407e+02 + 3.1534e-02 =  7.4410e+02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  1.0884e+00 - 5.4908e-03 =  1.0829e+00 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [  1.0454e+02 + 5.7528e-02 =  1.0460e+02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [  6.5834e+01 - 7.0691e-02 =  6.5763e+01 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [  1.2423e+02 + 1.0182e-01 =  1.2434e+02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [  1.3879e+02 - 1.7325e-02 =  1.3877e+02 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [  1.2013e+02 + 4.2489e-01 =  1.2055e+02 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [  6.8809e+01 - 4.0107e-01 =  6.8408e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [  1.1443e+02 - 4.6933e-02 =  1.1438e+02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [  1.4035e+02 + 7.2662e-03 =  1.4036e+02 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [  3.6063e+00 + 4.8308e-03 =  3.6111e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  1.0500e+00 + 0.0000e+00 =  1.0500e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [  1.5403e-02 - 9.5212e-06 =  1.5393e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [  1.4823e+00 - 1.5324e-04 =  1.4821e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [  1.4791e-02 + 7.0107e-06 =  1.4798e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [  1.4543e+00 + 1.2242e-04 =  1.4544e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  1.0947e-01 + 2.6055e-06 =  1.0948e-01 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  1.9161e+00 + 2.9326e-04 =  1.9164e+00 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [  1.7002e-01 + 5.7400e-07 =  1.7002e-01 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [  1.6848e+00 + 6.7672e-05 =  1.6848e+00 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+----------------------------------------------------------
+Input file with saved parameters: optimize.sav
+Setting finite difference step to 9.4287e-04
+#========================================================#
+#| [94m    Iteration 10: Evaluating objective function     [0m |#
+#| [94m        and derivatives through second order        [0m |#
+#========================================================#
+
+#======================================================================================================================#
+#| [92m                                         optgeo, Objective =  9.02688e-01                                         [0m |#
+#| [92m  System                       Bonds            Angles           Dihedrals         Impropers               Term.  [0m |#
+#| [92m                            RMSD   denom      RMSD   denom      RMSD   denom      RMSD   denom                    [0m |#
+#======================================================================================================================#
+9HXanthene                    0.006    0.01     0.019    0.03     0.076    0.20     0.005    0.20             0.903 
+------------------------------------------------------------------------------------------------------------------------
+
+#==========================================================================#
+#|                       Frequencies (wavenumbers)                        |#
+#|  Target: vibration  Type: Vibration_SMIRNOFF  Objective = 2.13123e+00  |#
+#|  Mode #            Reference   Calculated   Difference   Ref(dot)Calc  |#
+#==========================================================================#
+    0                   31.1817      53.7518      22.5701         0.9916 
+    1                  127.2863     140.2567      12.9704         0.9958 
+    2                  200.5311     231.7272      31.1961         0.9377 
+    3                  245.4174     232.4935     -12.9239         0.9370 
+    4                  258.8788     251.8852      -6.9936         0.9950 
+    5                  295.5887     328.0108      32.4221         0.0305 
+    6                  385.5805     328.5412     -57.0393         0.0200 
+    7                  413.3227     419.4837       6.1610         0.9696 
+    8                  461.1571     460.7592      -0.3979         0.9820 
+    9                  468.4759     479.3047      10.8288         0.9895 
+    10                 553.9686     537.1613     -16.8073         0.9559 
+    11                 557.9183     541.8797     -16.0386         0.1059 
+    12                 559.2968     562.7821       3.4853         0.1397 
+    13                 609.7540     598.1391     -11.6149         0.0013 
+    14                 650.9588     610.7039     -40.2549         0.0039 
+    15                 691.9021     621.4524     -70.4497         0.5908 
+    16                 731.3959     687.7758     -43.6201         0.1050 
+    17                 748.6224     719.9565     -28.6659         0.0297 
+    18                 757.4865     735.3356     -22.1509         0.0017 
+    19                 793.4162     757.4535     -35.9627         0.0234 
+    20                 796.3137     772.1516     -24.1621         0.9242 
+    21                 829.9391     780.6133     -49.3258         0.0015 
+    22                 886.2937     847.8353     -38.4584         0.0055 
+    23                 898.9488     857.6094     -41.3394         0.3071 
+    24                 905.1053     887.8268     -17.2785         0.0731 
+    25                 931.8180     904.1254     -27.6926         0.0015 
+    26                 972.6908     918.0399     -54.6509         0.0018 
+    27                 981.1443     933.2692     -47.8751         0.0842 
+    28                1002.3531     962.7816     -39.5715         0.2253 
+    29                1002.6108    1014.7684      12.1576         0.0184 
+    30                1006.9971    1027.4678      20.4707         0.0259 
+    31                1043.4229    1066.4592      23.0363         0.0108 
+    32                1045.2039    1070.0377      24.8338         0.0180 
+    33                1101.4212    1092.8251      -8.5961         0.0028 
+    34                1122.1664    1104.0715     -18.0949         0.0001 
+    35                1175.8590    1144.3058     -31.5532         0.0166 
+    36                1177.5535    1144.8601     -32.6934         0.0161 
+    37                1180.0345    1146.1357     -33.8988         0.0076 
+    38                1198.0738    1156.7993     -41.2745         0.0149 
+    39                1209.4283    1175.8001     -33.6282         0.4035 
+    40                1213.4868    1233.0965      19.6097         0.1932 
+    41                1233.7197    1274.9617      41.2420         0.0224 
+    42                1248.6007    1276.2068      27.6061         0.0097 
+    43                1296.1008    1326.3750      30.2742         0.0321 
+    44                1311.1904    1350.7641      39.5737         0.0064 
+    45                1325.6114    1402.7450      77.1336         0.0041 
+    46                1351.5363    1415.6680      64.1317         0.0005 
+    47                1456.1390    1484.4894      28.3504         0.5799 
+    48                1461.1551    1486.0226      24.8675         0.1926 
+    49                1467.0845    1520.6490      53.5645         0.0125 
+    50                1486.3167    1550.8237      64.5070         0.2747 
+    51                1498.4933    1556.7509      58.2576         0.0650 
+    52                1571.5221    1607.0761      35.5540         0.5163 
+    53                1591.5923    1621.3126      29.7203         0.5974 
+    54                1597.5166    1644.9782      47.4616         0.0566 
+    55                1620.6702    1722.9839     102.3137         0.0237 
+    56                2881.8985    2876.8206      -5.0779         0.8737 
+    57                2918.3100    2930.6592      12.3492         0.8789 
+    58                3057.8158    3082.9921      25.1763         0.2620 
+    59                3058.9610    3083.1276      24.1666         0.2182 
+    60                3076.7507    3083.6220       6.8713         0.2831 
+    61                3076.9099    3083.6859       6.7760         0.2875 
+    62                3093.3546    3084.5889      -8.7657         0.1476 
+    63                3093.7472    3084.6545      -9.0927         0.1893 
+    64                3108.9905    3085.5886     -23.4019         0.8102 
+    65                3109.6289    3085.9340     -23.6949         0.8238 
+----------------------------------------------------------------------------
+#===================================================================================#
+#| [94m                         Objective Function Breakdown                          [0m |#
+#| [94m  Target Name              Residual  x  Weight  =  Contribution (Current-Prev) [0m |#
+#===================================================================================#
+optgeo                         0.90269      1.000 [92m     9.02688e-01[0m ( -2.104e-01 ) 
+vibration                      2.13123      1.000 [92m     2.13123e+00[0m ( -6.099e-02 ) 
+Regularization                 0.07279      1.000 [91m     7.27869e-02[0m ( +2.005e-03 ) 
+Total                                             [92m     3.10670e+00[0m ( -2.694e-01 ) 
+-------------------------------------------------------------------------------------
+Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_35.offxml
+#========================================================================#
+#|  The force field has been written to the result/optimize directory.  |#
+#|    Input file with optimization parameters saved to optimize.sav.    |#
+#========================================================================#
+
+  Step       |k|        |dk|       |grad|       -=X2=-     Delta(X2)    StepQual
+    10   2.698e-01   9.429e-03   5.217e+01[92m   3.10670e+00[0m  -2.694e-01      1.000
+
+#========================================================#
+#| [94m                   Total Gradient                   [0m |#
+#========================================================#
+   0 [  7.69735260e+00 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [  3.80155030e+01 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [  1.84832759e+00 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [ -1.57125527e+01 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [  6.87517417e-01 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  1.78698038e+01 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [ -1.08926262e-01 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [ -1.79954390e+01 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [ -1.38142004e+00 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [  1.85891111e+00 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [ -1.52386008e+00 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [  5.44202032e-01 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [ -1.32816722e+01 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [  1.07357747e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [  1.02501983e+00 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [ -1.68723447e-01 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [ -4.71840658e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  7.04367654e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [  1.50361261e-01 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [  2.53347281e-01 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [ -8.20571822e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [ -1.02874678e-01 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [ -3.53867763e-02 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [ -3.32233187e-01 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [  8.34647289e-04 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [  1.12656304e-01 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+----------------------------------------------------------
+Convergence criterion reached in step size (1.00e-02)
 #========================================================#
 #| [92m               [0m[1mOptimization Converged[0m               [0m |#
 #| [92m           Final objective function value           [0m |#
-#| [92m  Full:  2.108884e+01  Un-penalized:  1.658759e+01  [0m |#
+#| [92m  Full:  3.106704e+00  Un-penalized:  3.033917e+00  [0m |#
 #========================================================#
 #========================================================#
 #| [94m           Final optimization parameters:           [0m |#
 #========================================================#
-   0 [ -2.5881e-01 ] : HarmonicBondForce/Bond/k/[#6X3:1]:[#6X3:2]
-   1 [ -1.9056e-01 ] : HarmonicBondForce/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [ -3.7015e-02 ] : HarmonicBondForce/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [  4.9067e-01 ] : HarmonicBondForce/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [ -4.8598e-02 ] : HarmonicBondForce/Bond/k/[#6X4:1]-[#1:2]
-   5 [  1.5322e-01 ] : HarmonicBondForce/Bond/length/[#6X4:1]-[#1:2]
-   6 [  6.7567e-02 ] : HarmonicBondForce/Bond/k/[#6X3:1]-[#1:2]
-   7 [  3.2236e-01 ] : HarmonicBondForce/Bond/length/[#6X3:1]-[#1:2]
-   8 [ -2.2054e-01 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [ -2.0534e-01 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [  1.7811e-01 ] : HarmonicAngleForce/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [ -2.8540e-01 ] : HarmonicAngleForce/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [ -1.5857e-01 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [ -1.8989e+00 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [ -3.8923e-01 ] : HarmonicAngleForce/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [  7.5816e-03 ] : HarmonicAngleForce/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [ -1.1078e-01 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
-  17 [  2.0668e-02 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [ -2.9211e-02 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X4]
-  19 [ -3.8230e-02 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [ -8.6403e-02 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X3]
-  21 [ -1.1072e-01 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [ -5.0955e-04 ] : NonbondedForce/Atom/epsilon/[#6X4:1]
-  23 [ -6.7854e-03 ] : NonbondedForce/Atom/rmin_half/[#6X4:1]
-  24 [ -8.5706e-04 ] : NonbondedForce/Atom/epsilon/[#8X2H0+0:1]
-  25 [ -1.1279e-02 ] : NonbondedForce/Atom/rmin_half/[#8X2H0+0:1]
+   0 [ -1.0912e-01 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [ -5.1812e-03 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [ -2.6330e-02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  4.6474e-02 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [ -2.1564e-02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  1.5612e-02 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [  1.1221e-02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  2.0500e-03 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [ -4.0846e-02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [ -3.0263e-02 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [  3.6138e-02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [ -8.7667e-03 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [  4.5914e-03 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [ -2.2566e-01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [ -4.6836e-02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [  2.5468e-03 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [ -3.8257e-03 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  3.5218e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [ -1.8036e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [ -2.5543e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [ -1.1882e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [ -2.4088e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  4.4711e-04 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  4.4154e-03 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [  9.5817e-05 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [  5.9851e-04 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
 #========================================================#
 #| [94m             Final physical parameters:             [0m |#
 #========================================================#
-   0 [  9.3541e+02 ] : HarmonicBondForce/Bond/k/[#6X3:1]:[#6X3:2]
-   1 [  1.3981e+00 ] : HarmonicBondForce/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [  8.9963e+02 ] : HarmonicBondForce/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [  1.3279e+00 ] : HarmonicBondForce/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [  6.7951e+02 ] : HarmonicBondForce/Bond/k/[#6X4:1]-[#1:2]
-   5 [  1.0915e+00 ] : HarmonicBondForce/Bond/length/[#6X4:1]-[#1:2]
-   6 [  7.3468e+02 ] : HarmonicBondForce/Bond/k/[#6X3:1]-[#1:2]
-   7 [  1.0832e+00 ] : HarmonicBondForce/Bond/length/[#6X3:1]-[#1:2]
-   8 [  1.0729e+02 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [  6.7947e+01 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [  1.2178e+02 ] : HarmonicAngleForce/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [  1.3715e+02 ] : HarmonicAngleForce/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [  1.1841e+02 ] : HarmonicAngleForce/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [  8.1011e+01 ] : HarmonicAngleForce/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [  1.1611e+02 ] : HarmonicAngleForce/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [  1.4008e+02 ] : HarmonicAngleForce/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [  3.5142e+00 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
-  17 [  1.0707e+00 ] : PeriodicTorsionForce/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [  1.5408e-02 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X4]
-  19 [  1.4832e+00 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [  1.4136e-02 ] : NonbondedForce/Atom/epsilon/[#1:1]-[#6X3]
-  21 [  1.4479e+00 ] : NonbondedForce/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [  1.0939e-01 ] : NonbondedForce/Atom/epsilon/[#6X4:1]
-  23 [  1.9073e+00 ] : NonbondedForce/Atom/rmin_half/[#6X4:1]
-  24 [  1.6999e-01 ] : NonbondedForce/Atom/epsilon/[#8X2H0+0:1]
-  25 [  1.6826e+00 ] : NonbondedForce/Atom/rmin_half/[#8X2H0+0:1]
+   0 [  7.2179e+02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [  1.3927e+00 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [  8.7630e+02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  1.3881e+00 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [  6.6059e+02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  1.1119e+00 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [  7.4410e+02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  1.0829e+00 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [  1.0460e+02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [  6.5763e+01 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [  1.2434e+02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [  1.3877e+02 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [  1.2055e+02 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [  6.8408e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [  1.1438e+02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [  1.4036e+02 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [  3.6111e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  1.0500e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [  1.5393e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [  1.4821e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [  1.4798e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [  1.4544e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  1.0948e-01 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  1.9164e+00 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [  1.7002e-01 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [  1.6848e+00 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
 ----------------------------------------------------------
-Backing up result/optimize/smirnoff99Frosst.offxml -> result/optimize/smirnoff99Frosst_52.offxml
+Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_36.offxml
 #========================================================================#
 #|  The force field has been written to the result/optimize directory.  |#
 #|    Input file with optimization parameters saved to optimize.sav.    |#


### PR DESCRIPTION
1) This PR adds an improved representation of the parameters as a NetworkX graph in `ForceField.pTree`, allowing the connections between parameters to be easily identified.  

2) A new method `ForceField.get_mathid(pid)` was added to obtain all of the mathematical parameter IDs associated with a parameter name (including evaluated and repeated parameters).

3) These methods are used in `OptGeoTarget_SMIRNOFF.build_system_mval_masks` to ensure that each SMIRKS-based parameter (including evaluated and repeated parameters) is correctly mapped to all of its mathematical parameter IDs.

4) Some changes in the example calculation.