### PR TITLE
Use the OpenFF API for force field modification

### DIFF
--- a/src/optimizer.py
+++ b/src/optimizer.py
@@ -24,7 +24,7 @@ from forcebalance.nifty import col, flat, row, printcool, printcool_dictionary, 
 from forcebalance.finite_difference import f1d7p, f1d5p, fdwrap
 from collections import OrderedDict
 import random
-import time
+import time, datetime
 from forcebalance.output import getLogger, DEBUG, CleanStreamHandler
 logger = getLogger(__name__)
 
@@ -313,7 +313,9 @@ class Optimizer(forcebalance.BaseClass):
             
     def Run(self):
         """ Call the appropriate optimizer.  This is the method we might want to call from an executable. """
-
+        now = datetime.datetime.now().strftime("%Y-%m-%d %I:%M %p")
+        logger.info("Calculation started at %s\n" % now)
+        t0        = time.time()
         xk = self.OptTab[self.jobtype]()
 
         ## Don't print a "result" force field if it's the same as the input.
@@ -363,6 +365,7 @@ class Optimizer(forcebalance.BaseClass):
         self.writechk()
 
         ## Print out final message
+        logger.info("Wall time since calculation start: %.1f seconds\n" % (time.time() - t0))
         if self.failmsg:
             bar = printcool("I have not failed.\nI've just found 10,000 ways that won't work.",ansi="40;97")
         else:

--- a/src/smirnoff_hack.py
+++ b/src/smirnoff_hack.py
@@ -49,7 +49,7 @@ OpenEyeToolkitWrapper.generate_conformers = cached_generate_conformers
 
 # final timing: 56s
 
-# cache the ForceField creation
+# cache the ForceField creation (no longer needed since using OpenFF API for parameter modifications)
 
 import hashlib
 from openforcefield.typing.engines.smirnoff import ForceField

--- a/studies/022_opt_geo_target/optimize.out
+++ b/studies/022_opt_geo_target/optimize.out
@@ -142,7 +142,7 @@ Reading force field from file: smirnoff99Frosst_experimental.offxml
 fnms                      ['smirnoff99Frosst_experimental.offxml'] 
 priors                    OrderedDict([('HarmonicBondForce/Bond/k', 10.0), ('HarmonicBondForce/Bond/length', 0.01), ('HarmonicAngleForce/Angle/k', 10.0), ('HarmonicAngleForce/Angle/angle', 10.0), ('PeriodicTorsionForce/Proper/k1', 1.0), ('NonbondedForce/Atom/epsilon', 0.01), ('NonbondedForce/Atom/rmin_half', 0.1)]) 
 ----------------------------------------------------------
-Backing up: optimize.tmp/optgeo to: optimize.bak/optgeo_33.tar.bz2
+Backing up: optimize.tmp/optgeo to: optimize.bak/optgeo_34.tar.bz2
 Reading optgeo options from file: targets/optgeo/optgeo_options.txt
 #========================================================#
 #| [92m             Setup for target optgeo :              [0m |#
@@ -155,7 +155,7 @@ tgtdir                    targets/optgeo
 optgeo_options            targets/optgeo/optgeo_options.txt 
 writelevel                1 
 ----------------------------------------------------------
-Backing up: optimize.tmp/vibration to: optimize.bak/vibration_24.tar.bz2
+Backing up: optimize.tmp/vibration to: optimize.bak/vibration_25.tar.bz2
 #========================================================#
 #| [92m            Setup for target vibration :            [0m |#
 #========================================================#
@@ -224,6 +224,7 @@ adapt_damp                1.0
 err_tol                   1.0 
 input_file                optimize.in 
 ----------------------------------------------------------
+Calculation started at 2019-07-08 10:53 AM
 #========================================================#
 #| [1m                  Main Optimizer                    [0m |#
 #| [1m  Newton-Raphson Method (Hessian Diagonal Search)   [0m |#
@@ -464,7 +465,7 @@ Optimization step found (length 3.1621e-02)
   24 [  1.7000e-01 - 1.4260e-06 =  1.7000e-01 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
   25 [  1.6837e+00 - 2.4771e-04 =  1.6835e+00 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
 ----------------------------------------------------------
-Backing up optimize.sav -> optimize.bak/optimize_7.sav
+Backing up optimize.sav -> optimize.bak/optimize_8.sav
 Input file with saved parameters: optimize.sav
 #========================================================#
 #| [94m     Iteration 1: Evaluating objective function     [0m |#
@@ -560,7 +561,7 @@ vibration                     12.69260      1.000 [92m     1.26926e+01[0m ( -3
 Regularization                 0.00100      1.000 [91m     9.99883e-04[0m ( +9.999e-04 ) 
 Total                                             [92m     1.77753e+01[0m ( -4.178e+00 ) 
 -------------------------------------------------------------------------------------
-Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_37.offxml
+Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_48.offxml
 #========================================================================#
 #|  The force field has been written to the result/optimize directory.  |#
 #|    Input file with optimization parameters saved to optimize.sav.    |#
@@ -797,7 +798,7 @@ vibration                      7.62679      1.000 [92m     7.62679e+00[0m ( -5
 Regularization                 0.01249      1.000 [91m     1.24865e-02[0m ( +1.149e-02 ) 
 Total                                             [92m     1.19490e+01[0m ( -5.826e+00 ) 
 -------------------------------------------------------------------------------------
-Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_38.offxml
+Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_49.offxml
 #========================================================================#
 #|  The force field has been written to the result/optimize directory.  |#
 #|    Input file with optimization parameters saved to optimize.sav.    |#
@@ -1028,7 +1029,7 @@ vibration                      7.47968      1.000 [92m     7.47968e+00[0m ( -1
 Regularization                 0.01411      1.000 [91m     1.41063e-02[0m ( +1.620e-03 ) 
 Total                                             [92m     9.77497e+00[0m ( -2.174e+00 ) 
 -------------------------------------------------------------------------------------
-Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_39.offxml
+Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_50.offxml
 #========================================================================#
 #|  The force field has been written to the result/optimize directory.  |#
 #|    Input file with optimization parameters saved to optimize.sav.    |#
@@ -1264,7 +1265,7 @@ vibration                      6.94823      1.000 [92m     6.94823e+00[0m ( -5
 Regularization                 0.01615      1.000 [91m     1.61481e-02[0m ( +2.042e-03 ) 
 Total                                             [92m     8.81139e+00[0m ( -9.636e-01 ) 
 -------------------------------------------------------------------------------------
-Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_40.offxml
+Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_51.offxml
 #========================================================================#
 #|  The force field has been written to the result/optimize directory.  |#
 #|    Input file with optimization parameters saved to optimize.sav.    |#
@@ -1501,7 +1502,7 @@ vibration                      6.53400      1.000 [92m     6.53400e+00[0m ( -4
 Regularization                 0.01812      1.000 [91m     1.81186e-02[0m ( +1.971e-03 ) 
 Total                                             [92m     8.10548e+00[0m ( -7.059e-01 ) 
 -------------------------------------------------------------------------------------
-Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_41.offxml
+Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_52.offxml
 #========================================================================#
 #|  The force field has been written to the result/optimize directory.  |#
 #|    Input file with optimization parameters saved to optimize.sav.    |#
@@ -1738,7 +1739,7 @@ vibration                      5.94679      1.000 [92m     5.94679e+00[0m ( -5
 Regularization                 0.02131      1.000 [91m     2.13130e-02[0m ( +3.194e-03 ) 
 Total                                             [92m     7.47122e+00[0m ( -6.343e-01 ) 
 -------------------------------------------------------------------------------------
-Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_42.offxml
+Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_53.offxml
 #========================================================================#
 #|  The force field has been written to the result/optimize directory.  |#
 #|    Input file with optimization parameters saved to optimize.sav.    |#
@@ -1977,7 +1978,7 @@ vibration                      5.60809      1.000 [92m     5.60809e+00[0m ( -3
 Regularization                 0.02333      1.000 [91m     2.33271e-02[0m ( +2.014e-03 ) 
 Total                                             [92m     6.92431e+00[0m ( -5.469e-01 ) 
 -------------------------------------------------------------------------------------
-Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_43.offxml
+Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_54.offxml
 #========================================================================#
 #|  The force field has been written to the result/optimize directory.  |#
 #|    Input file with optimization parameters saved to optimize.sav.    |#
@@ -2214,7 +2215,7 @@ vibration                      2.32283      1.000 [92m     2.32283e+00[0m ( -3
 Regularization                 0.06841      1.000 [91m     6.84052e-02[0m ( +4.508e-02 ) 
 Total                                             [92m     3.86223e+00[0m ( -3.062e+00 ) 
 -------------------------------------------------------------------------------------
-Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_44.offxml
+Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_55.offxml
 #========================================================================#
 #|  The force field has been written to the result/optimize directory.  |#
 #|    Input file with optimization parameters saved to optimize.sav.    |#
@@ -2438,7 +2439,7 @@ vibration                      2.19355      1.000 [92m     2.19355e+00[0m ( -1
 Regularization                 0.07072      1.000 [91m     7.07179e-02[0m ( +2.313e-03 ) 
 Total                                             [92m     3.37464e+00[0m ( -4.876e-01 ) 
 -------------------------------------------------------------------------------------
-Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_45.offxml
+Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_56.offxml
 #========================================================================#
 #|  The force field has been written to the result/optimize directory.  |#
 #|    Input file with optimization parameters saved to optimize.sav.    |#
@@ -2677,7 +2678,7 @@ vibration                      2.13213      1.000 [92m     2.13213e+00[0m ( -6
 Regularization                 0.07273      1.000 [91m     7.27315e-02[0m ( +2.014e-03 ) 
 Total                                             [92m     3.10602e+00[0m ( -2.686e-01 ) 
 -------------------------------------------------------------------------------------
-Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_46.offxml
+Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_57.offxml
 #========================================================================#
 #|  The force field has been written to the result/optimize directory.  |#
 #|    Input file with optimization parameters saved to optimize.sav.    |#
@@ -2781,11 +2782,12 @@ Convergence criterion reached in step size (1.00e-02)
   24 [  1.7002e-01 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
   25 [  1.6848e+00 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
 ----------------------------------------------------------
-Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_47.offxml
+Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_58.offxml
 #========================================================================#
 #|  The force field has been written to the result/optimize directory.  |#
 #|    Input file with optimization parameters saved to optimize.sav.    |#
 #========================================================================#
+Wall time since calculation start: 142.5 seconds
 #========================================================#
 #| [1;44;93m               Calculation Finished.                [0m |#
 #| [1;44;93m     ---==(  May the Force be with you!  )==---     [0m |#

--- a/studies/022_opt_geo_target/optimize.out
+++ b/studies/022_opt_geo_target/optimize.out
@@ -58,8 +58,6 @@ Reading options from file: optimize.in
 #| [95m        Use 'verbose_options True' to Enable        [0m |#
 #========================================================#
 Reading force field from file: smirnoff99Frosst_experimental.offxml
-In assign_field, matches = ["['Bonds/Bond/k/[#6X3:1]-[#6X3:2]']"]
-Adding edge between Bonds/Bond/k/[#6X3:1]-[#6X3:2] and Bonds/Bond/k/[#6X3:1]:[#6X3:2]
 #=========================================================#
 #| [92m Starting parameter indices, physical values and IDs [0m |#
 #=========================================================#
@@ -144,35 +142,8 @@ Adding edge between Bonds/Bond/k/[#6X3:1]-[#6X3:2] and Bonds/Bond/k/[#6X3:1]:[#6
 fnms                      ['smirnoff99Frosst_experimental.offxml'] 
 priors                    OrderedDict([('HarmonicBondForce/Bond/k', 10.0), ('HarmonicBondForce/Bond/length', 0.01), ('HarmonicAngleForce/Angle/k', 10.0), ('HarmonicAngleForce/Angle/angle', 10.0), ('PeriodicTorsionForce/Proper/k1', 1.0), ('NonbondedForce/Atom/epsilon', 0.01), ('NonbondedForce/Atom/rmin_half', 0.1)]) 
 ----------------------------------------------------------
-Backing up: optimize.tmp/optgeo to: optimize.bak/optgeo_32.tar.bz2
+Backing up: optimize.tmp/optgeo to: optimize.bak/optgeo_33.tar.bz2
 Reading optgeo options from file: targets/optgeo/optgeo_options.txt
-pname Bonds/Bond/k/[#6X3:1]-[#6X3:2] mathid [0] -> smirks [#6X3:1]-[#6X3:2]
-pname Bonds/Bond/length/[#6X3:1]:[#6X3:2] mathid [1] -> smirks [#6X3:1]:[#6X3:2]
-pname Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2] mathid [2] -> smirks [#6X3a:1]-[#8X2H0:2]
-pname Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2] mathid [3] -> smirks [#6X3a:1]-[#8X2H0:2]
-pname Bonds/Bond/k/[#6X4:1]-[#1:2] mathid [4] -> smirks [#6X4:1]-[#1:2]
-pname Bonds/Bond/length/[#6X4:1]-[#1:2] mathid [5] -> smirks [#6X4:1]-[#1:2]
-pname Bonds/Bond/k/[#6X3:1]-[#1:2] mathid [6] -> smirks [#6X3:1]-[#1:2]
-pname Bonds/Bond/length/[#6X3:1]-[#1:2] mathid [7] -> smirks [#6X3:1]-[#1:2]
-pname Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3] mathid [8] -> smirks [#1:1]-[#6X4:2]-[#1:3]
-pname Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3] mathid [9] -> smirks [#1:1]-[#6X4:2]-[#1:3]
-pname Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3] mathid [10] -> smirks [*:1]~[#6X3:2]~[*:3]
-pname Angles/Angle/k/[*:1]~[#6X3:2]~[*:3] mathid [11] -> smirks [*:1]~[#6X3:2]~[*:3]
-pname Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3] mathid [12] -> smirks [#1:1]-[#6X3:2]~[*:3]
-pname Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3] mathid [13] -> smirks [#1:1]-[#6X3:2]~[*:3]
-pname Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3] mathid [14] -> smirks [#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-pname Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3] mathid [15] -> smirks [#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-pname ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4] mathid [16] -> smirks [*:1]~[#6X3:2]:[#6X3:3]~[*:4]
-pname ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4] mathid [17] -> smirks [*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-pname vdW/Atom/epsilon/[#1:1]-[#6X4] mathid [18] -> smirks [#1:1]-[#6X4]
-pname vdW/Atom/rmin_half/[#1:1]-[#6X4] mathid [19] -> smirks [#1:1]-[#6X4]
-pname vdW/Atom/epsilon/[#1:1]-[#6X3] mathid [20] -> smirks [#1:1]-[#6X3]
-pname vdW/Atom/rmin_half/[#1:1]-[#6X3] mathid [21] -> smirks [#1:1]-[#6X3]
-pname vdW/Atom/epsilon/[#6X4:1] mathid [22] -> smirks [#6X4:1]
-pname vdW/Atom/rmin_half/[#6X4:1] mathid [23] -> smirks [#6X4:1]
-pname vdW/Atom/epsilon/[#8X2H0+0:1] mathid [24] -> smirks [#8X2H0+0:1]
-pname vdW/Atom/rmin_half/[#8X2H0+0:1] mathid [25] -> smirks [#8X2H0+0:1]
-pname Bonds/Bond/k/[#6X3:1]:[#6X3:2] mathid [0] -> smirks [#6X3:1]:[#6X3:2]
 #========================================================#
 #| [92m             Setup for target optgeo :              [0m |#
 #========================================================#
@@ -184,7 +155,7 @@ tgtdir                    targets/optgeo
 optgeo_options            targets/optgeo/optgeo_options.txt 
 writelevel                1 
 ----------------------------------------------------------
-Backing up: optimize.tmp/vibration to: optimize.bak/vibration_23.tar.bz2
+Backing up: optimize.tmp/vibration to: optimize.bak/vibration_24.tar.bz2
 #========================================================#
 #| [92m            Setup for target vibration :            [0m |#
 #========================================================#
@@ -371,13 +342,13 @@ Total                                             [94m     2.19537e+01[0m
 #| [94m                   Total Gradient                   [0m |#
 #========================================================#
    0 [  4.41764031e+01 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
-   1 [  8.06913714e+01 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   1 [  8.06913103e+01 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
    2 [  7.77711193e+00 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [ -1.53864038e+02 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   3 [ -1.53864209e+02 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
    4 [  8.97283289e+00 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
-   5 [ -5.33406770e+01 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   5 [ -5.33406347e+01 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
    6 [ -1.37984988e+01 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
-   7 [ -1.70363979e+02 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   7 [ -1.70363975e+02 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
    8 [  1.05168255e+01 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
    9 [  7.91094133e+00 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
   10 [ -1.34572642e+01 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
@@ -388,113 +359,112 @@ Total                                             [94m     2.19537e+01[0m
   15 [ -1.07191023e-01 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
   16 [  2.26687326e-01 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
   17 [  0.00000000e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [  1.25197866e+00 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
-  19 [  1.89778833e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  18 [  1.25185421e+00 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [  1.89808315e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
   20 [  4.75651899e+00 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
   21 [  7.18732208e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
   22 [  4.40975946e-02 ] : vdW/Atom/epsilon/[#6X4:1]
   23 [  4.24312354e-01 ] : vdW/Atom/rmin_half/[#6X4:1]
-  24 [  4.72051166e-02 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  24 [  4.73083339e-02 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
   25 [  6.52015727e-01 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
 ----------------------------------------------------------
 Calculating nonlinear optimization step
-Finding trust radius: H+0.0000*I, length 6.4421e-01 (target 1.0000e-01)
+Finding trust radius: H+0.0000*I, length 6.4420e-01 (target 1.0000e-01)
 Finding trust radius: H+9.0000*I, length 3.2061e-01 (target 1.0000e-01)
 Finding trust radius: H+61.6869*I, length 1.9578e-01 (target 1.0000e-01)
-Finding trust radius: H+34.3013*I, length 2.2304e-01 (target 1.0000e-01)
+Finding trust radius: H+34.3014*I, length 2.2304e-01 (target 1.0000e-01)
 Finding trust radius: H+246.7477*I, length 1.4369e-01 (target 1.0000e-01)
-Finding trust radius: H+158.6628*I, length 1.5994e-01 (target 1.0000e-01)
+Finding trust radius: H+158.6631*I, length 1.5994e-01 (target 1.0000e-01)
 Finding trust radius: H+807.4923*I, length 9.6018e-02 (target 1.0000e-01)
-Finding trust radius: H+577.7227*I, length 1.0986e-01 (target 1.0000e-01)
+Finding trust radius: H+577.7245*I, length 1.0986e-01 (target 1.0000e-01)
 Finding trust radius: H+2398.9145*I, length 5.5269e-02 (target 1.0000e-01)
 Finding trust radius: H+807.4923*I, length 9.6018e-02 (target 1.0000e-01)
 Finding trust radius: H+1315.5499*I, length 7.6549e-02 (target 1.0000e-01)
 Finding trust radius: H+555.1823*I, length 1.1150e-01 (target 1.0000e-01)
-Finding trust radius: H+764.2909*I, length 9.8280e-02 (target 1.0000e-01)
-Finding trust radius: H+739.3851*I, length 9.9647e-02 (target 1.0000e-01)
-Finding trust radius: H+731.9794*I, length 1.0006e-01 (target 1.0000e-01)
-Finding trust radius: H+733.0323*I, length 1.0000e-01 (target 1.0000e-01)
-Finding trust radius: H+733.1843*I, length 9.9995e-02 (target 1.0000e-01)
-Finding trust radius: H+732.8803*I, length 1.0001e-01 (target 1.0000e-01)
+Finding trust radius: H+764.2920*I, length 9.8280e-02 (target 1.0000e-01)
+Finding trust radius: H+739.3860*I, length 9.9647e-02 (target 1.0000e-01)
+Finding trust radius: H+731.9804*I, length 1.0006e-01 (target 1.0000e-01)
+Finding trust radius: H+733.0333*I, length 1.0000e-01 (target 1.0000e-01)
+Finding trust radius: H+733.1853*I, length 9.9995e-02 (target 1.0000e-01)
+Finding trust radius: H+732.8812*I, length 1.0001e-01 (target 1.0000e-01)
 Starting Hessian diagonal search with step size 1.0000e-01
-Hessian diagonal search: H+733.0323*I, length 1.0000e-01, result  1.1864e+01
-Hessian diagonal search: H+12387.3064*I, length 1.7383e-02, result -3.3540e+00
-Hessian diagonal search: H+61293.4299*I, length 4.1266e-03, result -1.0259e+00
-Hessian diagonal search: H+12387.3064*I, length 1.7383e-02, result -3.3540e+00
-Hessian diagonal search: H+26683.6765*I, length 8.9490e-03, result -2.0479e+00
-Hessian diagonal search: H+6261.1904*I, length 2.9506e-02, result -4.1592e+00
-Hessian diagonal search: H+3509.9895*I, length 4.3795e-02, result -3.5622e+00
-Hessian diagonal search: H+6952.2969*I, length 2.7323e-02, result -4.1004e+00
-Hessian diagonal search: H+5998.5990*I, length 3.0434e-02, result -4.1723e+00
-Hessian diagonal search: H+4969.7927*I, length 3.4753e-02, result -4.1369e+00
-Hessian diagonal search: H+5727.1403*I, length 3.1460e-02, result -4.1782e+00
-Hessian diagonal search: H+5666.7778*I, length 3.1698e-02, result -4.1783e+00
-Hessian diagonal search: H+5685.0884*I, length 3.1625e-02, result -4.1783e+00
-Hessian diagonal search: H+5686.2405*I, length 3.1621e-02, result -4.1783e+00
-Hessian diagonal search: H+5682.6859*I, length 3.1635e-02, result -4.1783e+00
-Hessian diagonal search: H+5683.9363*I, length 3.1630e-02, result -4.1783e+00
-Optimization step found (length 3.1625e-02)
+Hessian diagonal search: H+733.0333*I, length 1.0000e-01, result  1.1864e+01
+Hessian diagonal search: H+12387.3222*I, length 1.7383e-02, result -3.3540e+00
+Hessian diagonal search: H+61293.5073*I, length 4.1266e-03, result -1.0259e+00
+Hessian diagonal search: H+12387.3222*I, length 1.7383e-02, result -3.3540e+00
+Hessian diagonal search: H+26683.7103*I, length 8.9490e-03, result -2.0479e+00
+Hessian diagonal search: H+6261.1984*I, length 2.9506e-02, result -4.1592e+00
+Hessian diagonal search: H+3509.9940*I, length 4.3795e-02, result -3.5622e+00
+Hessian diagonal search: H+6952.2911*I, length 2.7323e-02, result -4.1004e+00
+Hessian diagonal search: H+5998.5958*I, length 3.0434e-02, result -4.1723e+00
+Hessian diagonal search: H+4969.7929*I, length 3.4753e-02, result -4.1369e+00
+Hessian diagonal search: H+5727.1372*I, length 3.1460e-02, result -4.1782e+00
+Hessian diagonal search: H+5666.7582*I, length 3.1698e-02, result -4.1783e+00
+Hessian diagonal search: H+5685.0625*I, length 3.1625e-02, result -4.1783e+00
+Hessian diagonal search: H+5686.2147*I, length 3.1621e-02, result -4.1783e+00
+Hessian diagonal search: H+5687.3671*I, length 3.1616e-02, result -4.1783e+00
+Optimization step found (length 3.1621e-02)
 #========================================================#
 #| [95m  Mathematical Parameters (Current + Step = Next)   [0m |#
 #========================================================#
-   0 [  0.0000e+00 - 6.6980e-03 = -6.6980e-03 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
-   1 [  0.0000e+00 - 6.8872e-03 = -6.8872e-03 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [  0.0000e+00 - 1.1571e-03 = -1.1571e-03 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [  0.0000e+00 + 1.5559e-02 =  1.5559e-02 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [  0.0000e+00 - 1.4773e-03 = -1.4773e-03 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
-   5 [  0.0000e+00 + 6.9353e-03 =  6.9353e-03 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
-   6 [  0.0000e+00 + 1.9753e-03 =  1.9753e-03 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
-   7 [  0.0000e+00 + 2.1787e-02 =  2.1787e-02 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
-   8 [  0.0000e+00 - 1.6047e-03 = -1.6047e-03 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [  0.0000e+00 - 1.2080e-03 = -1.2080e-03 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [  0.0000e+00 + 2.4450e-03 =  2.4450e-03 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [  0.0000e+00 - 1.4200e-03 = -1.4200e-03 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [  0.0000e+00 + 1.0860e-03 =  1.0860e-03 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [  0.0000e+00 - 1.0810e-02 = -1.0810e-02 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [  0.0000e+00 - 1.8520e-03 = -1.8520e-03 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [  0.0000e+00 + 1.0402e-05 =  1.0402e-05 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [  0.0000e+00 + 6.1563e-04 =  6.1563e-04 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
-  17 [  0.0000e+00 - 1.7438e-20 = -1.7438e-20 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [  0.0000e+00 - 1.8325e-04 = -1.8325e-04 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+   0 [  0.0000e+00 - 6.6969e-03 = -6.6969e-03 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [  0.0000e+00 - 6.8866e-03 = -6.8866e-03 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [  0.0000e+00 - 1.1569e-03 = -1.1569e-03 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  0.0000e+00 + 1.5558e-02 =  1.5558e-02 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [  0.0000e+00 - 1.4770e-03 = -1.4770e-03 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  0.0000e+00 + 6.9343e-03 =  6.9343e-03 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [  0.0000e+00 + 1.9750e-03 =  1.9750e-03 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  0.0000e+00 + 2.1783e-02 =  2.1783e-02 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [  0.0000e+00 - 1.6044e-03 = -1.6044e-03 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [  0.0000e+00 - 1.2078e-03 = -1.2078e-03 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [  0.0000e+00 + 2.4446e-03 =  2.4446e-03 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [  0.0000e+00 - 1.4197e-03 = -1.4197e-03 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [  0.0000e+00 + 1.0855e-03 =  1.0855e-03 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [  0.0000e+00 - 1.0808e-02 = -1.0808e-02 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [  0.0000e+00 - 1.8517e-03 = -1.8517e-03 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [  0.0000e+00 + 1.0400e-05 =  1.0400e-05 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [  0.0000e+00 + 6.1543e-04 =  6.1543e-04 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  0.0000e+00 + 9.6879e-20 =  9.6879e-20 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [  0.0000e+00 - 1.8321e-04 = -1.8321e-04 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
   19 [  0.0000e+00 - 2.7552e-04 = -2.7552e-04 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [  0.0000e+00 - 6.9613e-04 = -6.9613e-04 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
-  21 [  0.0000e+00 - 1.0502e-03 = -1.0502e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [  0.0000e+00 - 5.9446e-06 = -5.9446e-06 ] : vdW/Atom/epsilon/[#6X4:1]
-  23 [  0.0000e+00 - 5.5130e-05 = -5.5130e-05 ] : vdW/Atom/rmin_half/[#6X4:1]
-  24 [  0.0000e+00 - 8.3738e-06 = -8.3738e-06 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
-  25 [  0.0000e+00 - 1.2985e-04 = -1.2985e-04 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+  20 [  0.0000e+00 - 6.9601e-04 = -6.9601e-04 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [  0.0000e+00 - 1.0500e-03 = -1.0500e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  0.0000e+00 - 5.9438e-06 = -5.9438e-06 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  0.0000e+00 - 5.5124e-05 = -5.5124e-05 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [  0.0000e+00 - 8.3880e-06 = -8.3880e-06 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [  0.0000e+00 - 1.2982e-04 = -1.2982e-04 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
 ----------------------------------------------------------
 #========================================================#
 #| [95m    Physical Parameters (Current + Step = Next)     [0m |#
 #========================================================#
-   0 [  8.2000e+02 - 6.0282e+00 =  8.1397e+02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
-   1 [  1.4000e+00 - 9.6420e-03 =  1.3904e+00 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [  9.0000e+02 - 1.0414e+00 =  8.9896e+02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [  1.3230e+00 + 2.1783e-02 =  1.3448e+00 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [  6.8000e+02 - 1.3296e+00 =  6.7867e+02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
-   5 [  1.0900e+00 + 9.7095e-03 =  1.0997e+00 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
-   6 [  7.3400e+02 + 1.7778e+00 =  7.3578e+02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
-   7 [  1.0800e+00 + 3.0501e-02 =  1.1105e+00 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
-   8 [  1.0950e+02 - 1.9256e-01 =  1.0931e+02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [  7.0000e+01 - 1.6912e-01 =  6.9831e+01 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [  1.2000e+02 + 2.9341e-01 =  1.2029e+02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [  1.4000e+02 - 1.9880e-01 =  1.3980e+02 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [  1.2000e+02 + 1.3032e-01 =  1.2013e+02 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [  1.0000e+02 - 1.5134e+00 =  9.8487e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [  1.2000e+02 - 2.2224e-01 =  1.1978e+02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [  1.4000e+02 + 1.4562e-03 =  1.4000e+02 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [  3.6250e+00 + 2.2316e-03 =  3.6272e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+   0 [  8.2000e+02 - 6.0272e+00 =  8.1397e+02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [  1.4000e+00 - 9.6412e-03 =  1.3904e+00 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [  9.0000e+02 - 1.0412e+00 =  8.9896e+02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  1.3230e+00 + 2.1781e-02 =  1.3448e+00 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [  6.8000e+02 - 1.3293e+00 =  6.7867e+02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  1.0900e+00 + 9.7080e-03 =  1.0997e+00 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [  7.3400e+02 + 1.7775e+00 =  7.3578e+02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  1.0800e+00 + 3.0497e-02 =  1.1105e+00 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [  1.0950e+02 - 1.9253e-01 =  1.0931e+02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [  7.0000e+01 - 1.6909e-01 =  6.9831e+01 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [  1.2000e+02 + 2.9335e-01 =  1.2029e+02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [  1.4000e+02 - 1.9876e-01 =  1.3980e+02 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [  1.2000e+02 + 1.3026e-01 =  1.2013e+02 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [  1.0000e+02 - 1.5131e+00 =  9.8487e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [  1.2000e+02 - 2.2220e-01 =  1.1978e+02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [  1.4000e+02 + 1.4560e-03 =  1.4000e+02 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [  3.6250e+00 + 2.2309e-03 =  3.6272e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
   17 [  1.0500e+00 + 0.0000e+00 =  1.0500e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [  1.5700e-02 - 3.1153e-05 =  1.5669e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  18 [  1.5700e-02 - 3.1145e-05 =  1.5669e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
   19 [  1.4870e+00 - 5.2569e-04 =  1.4865e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [  1.5000e-02 - 1.1834e-04 =  1.4882e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
-  21 [  1.4590e+00 - 2.0038e-03 =  1.4570e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [  1.0940e-01 - 1.0106e-06 =  1.0940e-01 ] : vdW/Atom/epsilon/[#6X4:1]
-  23 [  1.9080e+00 - 1.0519e-04 =  1.9079e+00 ] : vdW/Atom/rmin_half/[#6X4:1]
-  24 [  1.7000e-01 - 1.4235e-06 =  1.7000e-01 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
-  25 [  1.6837e+00 - 2.4775e-04 =  1.6835e+00 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+  20 [  1.5000e-02 - 1.1832e-04 =  1.4882e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [  1.4590e+00 - 2.0034e-03 =  1.4570e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  1.0940e-01 - 1.0104e-06 =  1.0940e-01 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  1.9080e+00 - 1.0518e-04 =  1.9079e+00 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [  1.7000e-01 - 1.4260e-06 =  1.7000e-01 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [  1.6837e+00 - 2.4771e-04 =  1.6835e+00 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
 ----------------------------------------------------------
-Backing up optimize.sav -> optimize.bak/optimize_6.sav
+Backing up optimize.sav -> optimize.bak/optimize_7.sav
 Input file with saved parameters: optimize.sav
 #========================================================#
 #| [94m     Iteration 1: Evaluating objective function     [0m |#
@@ -502,7 +472,7 @@ Input file with saved parameters: optimize.sav
 #========================================================#
 
 #======================================================================================================================#
-#| [92m                                         optgeo, Objective =  5.08226e+00                                         [0m |#
+#| [92m                                         optgeo, Objective =  5.08174e+00                                         [0m |#
 #| [92m  System                       Bonds            Angles           Dihedrals         Impropers               Term.  [0m |#
 #| [92m                            RMSD   denom      RMSD   denom      RMSD   denom      RMSD   denom                    [0m |#
 #======================================================================================================================#
@@ -511,226 +481,226 @@ Input file with saved parameters: optimize.sav
 
 #==========================================================================#
 #|                       Frequencies (wavenumbers)                        |#
-#|  Target: vibration  Type: Vibration_SMIRNOFF  Objective = 1.26921e+01  |#
+#|  Target: vibration  Type: Vibration_SMIRNOFF  Objective = 1.26926e+01  |#
 #|  Mode #            Reference   Calculated   Difference   Ref(dot)Calc  |#
 #==========================================================================#
-    0                   31.1817      58.5546      27.3729         0.9896 
+    0                   31.1817      58.5547      27.3730         0.9896 
     1                  127.2863     138.4285      11.1422         0.9962 
     2                  200.5311     226.7545      26.2234         0.9297 
     3                  245.4174     234.0549     -11.3625         0.9371 
-    4                  258.8788     238.5788     -20.3000         0.9950 
+    4                  258.8788     238.5786     -20.3002         0.9950 
     5                  295.5887     327.6623      32.0736         0.9671 
-    6                  385.5805     338.2137     -47.3668         0.9890 
-    7                  413.3227     426.2949      12.9722         0.0038 
-    8                  461.1571     429.3742     -31.7829         0.0005 
-    9                  468.4759     442.2267     -26.2492         0.9883 
-    10                 553.9686     500.6560     -53.3126         0.9596 
-    11                 557.9183     539.7662     -18.1521         0.9311 
-    12                 559.2968     556.5626      -2.7342         0.9412 
-    13                 609.7540     618.3188       8.5648         0.0013 
-    14                 650.9588     627.5670     -23.3918         0.0037 
-    15                 691.9021     647.8456     -44.0565         0.7663 
-    16                 731.3959     691.3408     -40.0551         0.9420 
-    17                 748.6224     704.8961     -43.7263         0.9927 
+    6                  385.5805     338.2139     -47.3666         0.9890 
+    7                  413.3227     426.2944      12.9717         0.0038 
+    8                  461.1571     429.3747     -31.7824         0.0005 
+    9                  468.4759     442.2262     -26.2497         0.9883 
+    10                 553.9686     500.6553     -53.3133         0.9596 
+    11                 557.9183     539.7660     -18.1523         0.9311 
+    12                 559.2968     556.5625      -2.7343         0.9412 
+    13                 609.7540     618.3185       8.5645         0.0013 
+    14                 650.9588     627.5669     -23.3919         0.0037 
+    15                 691.9021     647.8461     -44.0560         0.7663 
+    16                 731.3959     691.3407     -40.0552         0.9420 
+    17                 748.6224     704.8953     -43.7271         0.9927 
     18                 757.4865     716.6557     -40.8308         0.9146 
-    19                 793.4162     748.6031     -44.8131         0.0492 
-    20                 796.3137     755.8152     -40.4985         0.0484 
-    21                 829.9391     769.4663     -60.4728         0.9610 
+    19                 793.4162     748.6048     -44.8114         0.0492 
+    20                 796.3137     755.8166     -40.4971         0.0484 
+    21                 829.9391     769.4666     -60.4725         0.9610 
     22                 886.2937     879.1133      -7.1804         0.0056 
-    23                 898.9488     883.5413     -15.4075         0.8224 
-    24                 905.1053     888.0482     -17.0571         0.0157 
-    25                 931.8180     905.5953     -26.2227         0.0033 
-    26                 972.6908     941.4902     -31.2006         0.4651 
-    27                 981.1443     962.8748     -18.2695         0.0017 
-    28                1002.3531     979.6165     -22.7366         0.0022 
-    29                1002.6108    1038.6833      36.0725         0.0583 
-    30                1006.9971    1042.4358      35.4387         0.4823 
-    31                1043.4229    1098.1745      54.7516         0.0064 
-    32                1045.2039    1111.9475      66.7436         0.0007 
-    33                1101.4212    1112.3394      10.9182         0.0015 
-    34                1122.1664    1118.3932      -3.7732         0.7110 
-    35                1175.8590    1182.7592       6.9002         0.1449 
-    36                1177.5535    1186.0974       8.5439         0.2013 
-    37                1180.0345    1242.1142      62.0797         0.0156 
-    38                1198.0738    1253.2794      55.2056         0.0066 
-    39                1209.4283    1271.6697      62.2414         0.4226 
-    40                1213.4868    1278.2167      64.7299         0.0123 
-    41                1233.7197    1293.8513      60.1316         0.0162 
-    42                1248.6007    1396.6810     148.0803         0.0099 
-    43                1296.1008    1422.8601     126.7593         0.4176 
-    44                1311.1904    1462.7857     151.5953         0.2204 
-    45                1325.6114    1543.7068     218.0954         0.0309 
-    46                1351.5363    1602.9592     251.4229         0.0046 
-    47                1456.1390    1606.5798     150.4408         0.4341 
-    48                1461.1551    1634.7399     173.5848         0.0266 
-    49                1467.0845    1653.6862     186.6017         0.3043 
-    50                1486.3167    1681.0531     194.7364         0.0406 
-    51                1498.4933    1684.2499     185.7566         0.0724 
-    52                1571.5221    1728.1234     156.6013         0.6057 
-    53                1591.5923    1732.4523     140.8600         0.7416 
-    54                1597.5166    1770.0301     172.5135         0.0331 
-    55                1620.6702    1809.3742     188.7040         0.0278 
-    56                2881.8985    2908.4794      26.5809         0.8771 
-    57                2918.3100    2977.6175      59.3075         0.8761 
-    58                3057.8158    3067.6455       9.8297         0.3205 
-    59                3058.9610    3067.8054       8.8444         0.2794 
-    60                3076.7507    3068.1683      -8.5824         0.2651 
-    61                3076.9099    3068.2591      -8.6508         0.2880 
-    62                3093.3546    3069.3236     -24.0310         0.0570 
-    63                3093.7472    3069.3707     -24.3765         0.0942 
-    64                3108.9905    3070.0710     -38.9195         0.7571 
-    65                3109.6289    3070.4183     -39.2106         0.7840 
+    23                 898.9488     883.5432     -15.4056         0.8224 
+    24                 905.1053     888.0483     -17.0570         0.0157 
+    25                 931.8180     905.5973     -26.2207         0.0033 
+    26                 972.6908     941.4912     -31.1996         0.4651 
+    27                 981.1443     962.8759     -18.2684         0.0017 
+    28                1002.3531     979.6181     -22.7350         0.0022 
+    29                1002.6108    1038.6859      36.0751         0.0583 
+    30                1006.9971    1042.4383      35.4412         0.4823 
+    31                1043.4229    1098.1767      54.7538         0.0064 
+    32                1045.2039    1111.9503      66.7464         0.0007 
+    33                1101.4212    1112.3423      10.9211         0.0015 
+    34                1122.1664    1118.3959      -3.7705         0.7110 
+    35                1175.8590    1182.7604       6.9014         0.1449 
+    36                1177.5535    1186.0994       8.5459         0.2013 
+    37                1180.0345    1242.1177      62.0832         0.0156 
+    38                1198.0738    1253.2822      55.2084         0.0066 
+    39                1209.4283    1271.6727      62.2444         0.4226 
+    40                1213.4868    1278.2180      64.7312         0.0123 
+    41                1233.7197    1293.8531      60.1334         0.0162 
+    42                1248.6007    1396.6845     148.0838         0.0099 
+    43                1296.1008    1422.8629     126.7621         0.4177 
+    44                1311.1904    1462.7889     151.5985         0.2204 
+    45                1325.6114    1543.7108     218.0994         0.0309 
+    46                1351.5363    1602.9654     251.4291         0.0046 
+    47                1456.1390    1606.5821     150.4431         0.4341 
+    48                1461.1551    1634.7439     173.5888         0.0266 
+    49                1467.0845    1653.6896     186.6051         0.3043 
+    50                1486.3167    1681.0570     194.7403         0.0406 
+    51                1498.4933    1684.2547     185.7614         0.0724 
+    52                1571.5221    1728.1272     156.6051         0.6057 
+    53                1591.5923    1732.4556     140.8633         0.7416 
+    54                1597.5166    1770.0335     172.5169         0.0331 
+    55                1620.6702    1809.3767     188.7065         0.0278 
+    56                2881.8985    2908.4799      26.5814         0.8771 
+    57                2918.3100    2977.6182      59.3082         0.8761 
+    58                3057.8158    3067.6450       9.8292         0.3205 
+    59                3058.9610    3067.8048       8.8438         0.2794 
+    60                3076.7507    3068.1678      -8.5829         0.2651 
+    61                3076.9099    3068.2586      -8.6513         0.2880 
+    62                3093.3546    3069.3230     -24.0316         0.0570 
+    63                3093.7472    3069.3701     -24.3771         0.0942 
+    64                3108.9905    3070.0704     -38.9201         0.7572 
+    65                3109.6289    3070.4177     -39.2112         0.7841 
 ----------------------------------------------------------------------------
 #===================================================================================#
 #| [94m                         Objective Function Breakdown                          [0m |#
 #| [94m  Target Name              Residual  x  Weight  =  Contribution (Current-Prev) [0m |#
 #===================================================================================#
-optgeo                         5.08226      1.000 [92m     5.08226e+00[0m ( -5.185e-01 ) 
-vibration                     12.69208      1.000 [92m     1.26921e+01[0m ( -3.661e+00 ) 
-Regularization                 0.00100      1.000 [91m     1.00016e-03[0m ( +1.000e-03 ) 
+optgeo                         5.08174      1.000 [92m     5.08174e+00[0m ( -5.190e-01 ) 
+vibration                     12.69260      1.000 [92m     1.26926e+01[0m ( -3.660e+00 ) 
+Regularization                 0.00100      1.000 [91m     9.99883e-04[0m ( +9.999e-04 ) 
 Total                                             [92m     1.77753e+01[0m ( -4.178e+00 ) 
 -------------------------------------------------------------------------------------
-Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_26.offxml
+Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_37.offxml
 #========================================================================#
 #|  The force field has been written to the result/optimize directory.  |#
 #|    Input file with optimization parameters saved to optimize.sav.    |#
 #========================================================================#
 
   Step       |k|        |dk|       |grad|       -=X2=-     Delta(X2)    StepQual
-     1   3.163e-02   3.163e-02   1.829e+02[92m   1.77753e+01[0m  -4.178e+00      1.000
+     1   3.162e-02   3.162e-02   1.828e+02[92m   1.77753e+01[0m  -4.178e+00      1.000
 
 #========================================================#
 #| [94m                   Total Gradient                   [0m |#
 #========================================================#
-   0 [  3.61113001e+01 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
-   1 [ -2.32891952e+01 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [  6.45155237e+00 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [ -1.09601431e+02 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [  8.40133701e+00 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
-   5 [ -2.72514106e+01 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
-   6 [ -1.13010470e+01 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
-   7 [  1.19231727e+02 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
-   8 [  9.31610637e+00 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [  6.69027307e+00 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [ -1.15511402e+01 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [  7.55937685e+00 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [  3.34584196e+00 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [  6.21370170e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [  1.19890806e+01 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [ -1.07588101e-01 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [ -5.90323238e-01 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
-  17 [ -3.48756098e-20 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [  1.01759403e+00 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
-  19 [  1.52684492e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [  3.50888314e+00 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
-  21 [  5.49487467e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [  1.60085079e-02 ] : vdW/Atom/epsilon/[#6X4:1]
-  23 [  1.29415275e-01 ] : vdW/Atom/rmin_half/[#6X4:1]
-  24 [  2.76281981e-02 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
-  25 [  3.88465080e-01 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+   0 [  3.61119249e+01 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [ -2.32808921e+01 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [  6.45205064e+00 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [ -1.09606174e+02 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [  8.40134591e+00 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [ -2.72557375e+01 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [ -1.13014812e+01 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  1.19187880e+02 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [  9.31645108e+00 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [  6.69037510e+00 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [ -1.15512344e+01 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [  7.55957495e+00 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [  3.34751371e+00 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [  6.21390330e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [  1.19893112e+01 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [ -1.07592220e-01 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [ -5.89991432e-01 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  1.93757341e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [  1.01777484e+00 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [  1.52669532e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [  3.50888422e+00 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [  5.49482184e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  1.60121865e-02 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  1.29671477e-01 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [  2.77251489e-02 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [  3.88632561e-01 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
 ----------------------------------------------------------
 Calculating nonlinear optimization step
-Finding trust radius: H+0.0000*I, length 6.5285e-01 (target 3.1625e-02)
-Finding trust radius: H+9.0000*I, length 3.7562e-01 (target 3.1625e-02)
-Finding trust radius: H+61.6869*I, length 2.4512e-01 (target 3.1625e-02)
-Finding trust radius: H+38.6904*I, length 2.7284e-01 (target 3.1625e-02)
-Finding trust radius: H+246.7477*I, length 1.5778e-01 (target 3.1625e-02)
-Finding trust radius: H+193.8192*I, length 1.7351e-01 (target 3.1625e-02)
-Finding trust radius: H+807.4923*I, length 8.5160e-02 (target 3.1625e-02)
-Finding trust radius: H+670.8516*I, length 9.5385e-02 (target 3.1625e-02)
-Finding trust radius: H+2398.9145*I, length 3.9691e-02 (target 3.1625e-02)
-Finding trust radius: H+1700.9039*I, length 5.1221e-02 (target 3.1625e-02)
-Finding trust radius: H+6764.9351*I, length 1.7867e-02 (target 3.1625e-02)
-Finding trust radius: H+2398.9145*I, length 3.9691e-02 (target 3.1625e-02)
-Finding trust radius: H+3805.2759*I, length 2.7913e-02 (target 3.1625e-02)
-Finding trust radius: H+4835.9536*I, length 2.3196e-02 (target 3.1625e-02)
-Finding trust radius: H+3480.3980*I, length 2.9896e-02 (target 3.1625e-02)
-Finding trust radius: H+3346.0538*I, length 3.0813e-02 (target 3.1625e-02)
-Finding trust radius: H+2965.7209*I, length 3.3792e-02 (target 3.1625e-02)
-Finding trust radius: H+3248.0369*I, length 3.1523e-02 (target 3.1625e-02)
-Finding trust radius: H+3228.0416*I, length 3.1672e-02 (target 3.1625e-02)
-Finding trust radius: H+3234.1723*I, length 3.1626e-02 (target 3.1625e-02)
-Finding trust radius: H+3234.8306*I, length 3.1621e-02 (target 3.1625e-02)
-Finding trust radius: H+3233.5141*I, length 3.1631e-02 (target 3.1625e-02)
-Starting Hessian diagonal search with step size 3.1626e-02
-Hessian diagonal search: H+3234.1723*I, length 3.1626e-02, result -3.8156e+00
-Hessian diagonal search: H+53120.6319*I, length 3.1432e-03, result -5.4363e-01
-Hessian diagonal search: H+50192.1516*I, length 3.3110e-03, result -5.7099e-01
-Hessian diagonal search: H+3234.1723*I, length 3.1626e-02, result -3.8156e+00
-Hessian diagonal search: H+2542.8514*I, length 3.7983e-02, result -4.2837e+00
-Hessian diagonal search: H+13628.1260*I, length 1.0234e-02, result -1.5839e+00
-Hessian diagonal search: H+26.8210*I, length 2.9516e-01, result  1.4323e+01
-Hessian diagonal search: H+5738.9649*I, length 2.0310e-02, result -2.7743e+00
-Hessian diagonal search: H+1098.4964*I, length 6.9669e-02, result -5.6292e+00
-Hessian diagonal search: H+504.5422*I, length 1.1218e-01, result -5.5893e+00
-Hessian diagonal search: H+808.9890*I, length 8.5061e-02, result -5.8175e+00
-Hessian diagonal search: H+787.2355*I, length 8.6524e-02, result -5.8227e+00
-Hessian diagonal search: H+727.5211*I, length 9.0837e-02, result -5.8258e+00
-Hessian diagonal search: H+637.5478*I, length 9.8298e-02, result -5.7898e+00
-Hessian diagonal search: H+746.2385*I, length 8.9435e-02, result -5.8267e+00
-Hessian diagonal search: H+746.8226*I, length 8.9392e-02, result -5.8267e+00
-Hessian diagonal search: H+746.5388*I, length 8.9413e-02, result -5.8267e+00
-Hessian diagonal search: H+746.3949*I, length 8.9424e-02, result -5.8267e+00
-Optimization step found (length 8.9413e-02)
+Finding trust radius: H+0.0000*I, length 6.5287e-01 (target 3.1621e-02)
+Finding trust radius: H+9.0000*I, length 3.7561e-01 (target 3.1621e-02)
+Finding trust radius: H+61.6869*I, length 2.4511e-01 (target 3.1621e-02)
+Finding trust radius: H+38.6890*I, length 2.7284e-01 (target 3.1621e-02)
+Finding trust radius: H+246.7477*I, length 1.5778e-01 (target 3.1621e-02)
+Finding trust radius: H+193.8170*I, length 1.7351e-01 (target 3.1621e-02)
+Finding trust radius: H+807.4923*I, length 8.5163e-02 (target 3.1621e-02)
+Finding trust radius: H+670.8815*I, length 9.5386e-02 (target 3.1621e-02)
+Finding trust radius: H+2398.9145*I, length 3.9692e-02 (target 3.1621e-02)
+Finding trust radius: H+1700.9439*I, length 5.1221e-02 (target 3.1621e-02)
+Finding trust radius: H+6764.9351*I, length 1.7866e-02 (target 3.1621e-02)
+Finding trust radius: H+2398.9145*I, length 3.9692e-02 (target 3.1621e-02)
+Finding trust radius: H+3805.2759*I, length 2.7913e-02 (target 3.1621e-02)
+Finding trust radius: H+4835.9536*I, length 2.3196e-02 (target 3.1621e-02)
+Finding trust radius: H+3481.2552*I, length 2.9891e-02 (target 3.1621e-02)
+Finding trust radius: H+3346.7284*I, length 3.0809e-02 (target 3.1621e-02)
+Finding trust radius: H+2966.1134*I, length 3.3790e-02 (target 3.1621e-02)
+Finding trust radius: H+3248.7212*I, length 3.1518e-02 (target 3.1621e-02)
+Finding trust radius: H+3228.6974*I, length 3.1668e-02 (target 3.1621e-02)
+Finding trust radius: H+3234.8337*I, length 3.1622e-02 (target 3.1621e-02)
+Finding trust radius: H+3235.4921*I, length 3.1617e-02 (target 3.1621e-02)
+Finding trust radius: H+3234.1754*I, length 3.1627e-02 (target 3.1621e-02)
+Starting Hessian diagonal search with step size 3.1622e-02
+Hessian diagonal search: H+3234.8337*I, length 3.1622e-02, result -3.8152e+00
+Hessian diagonal search: H+53131.3534*I, length 3.1423e-03, result -5.4341e-01
+Hessian diagonal search: H+50202.1933*I, length 3.3100e-03, result -5.7076e-01
+Hessian diagonal search: H+3234.8337*I, length 3.1622e-02, result -3.8152e+00
+Hessian diagonal search: H+2543.3523*I, length 3.7978e-02, result -4.2833e+00
+Hessian diagonal search: H+13630.8413*I, length 1.0231e-02, result -1.5834e+00
+Hessian diagonal search: H+26.8336*I, length 2.9512e-01, result  1.4331e+01
+Hessian diagonal search: H+5740.1030*I, length 2.0307e-02, result -2.7738e+00
+Hessian diagonal search: H+1098.7309*I, length 6.9661e-02, result -5.6289e+00
+Hessian diagonal search: H+504.6614*I, length 1.1217e-01, result -5.5886e+00
+Hessian diagonal search: H+809.5249*I, length 8.5028e-02, result -5.8171e+00
+Hessian diagonal search: H+787.5542*I, length 8.6505e-02, result -5.8223e+00
+Hessian diagonal search: H+727.7429*I, length 9.0822e-02, result -5.8254e+00
+Hessian diagonal search: H+637.7274*I, length 9.8285e-02, result -5.7893e+00
+Hessian diagonal search: H+746.5317*I, length 8.9417e-02, result -5.8263e+00
+Hessian diagonal search: H+747.1168*I, length 8.9374e-02, result -5.8263e+00
+Hessian diagonal search: H+746.6862*I, length 8.9405e-02, result -5.8263e+00
+Hessian diagonal search: H+746.8300*I, length 8.9395e-02, result -5.8263e+00
+Optimization step found (length 8.9395e-02)
 #========================================================#
 #| [95m  Mathematical Parameters (Current + Step = Next)   [0m |#
 #========================================================#
-   0 [ -6.6980e-03 - 3.0791e-02 = -3.7489e-02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
-   1 [ -6.8872e-03 + 1.1781e-02 =  4.8934e-03 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [ -1.1571e-03 - 5.7575e-03 = -6.9146e-03 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [  1.5559e-02 + 4.8557e-02 =  6.4117e-02 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [ -1.4773e-03 - 7.3714e-03 = -8.8487e-03 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
-   5 [  6.9353e-03 + 2.2657e-02 =  2.9592e-02 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
-   6 [  1.9753e-03 + 5.7265e-03 =  7.7018e-03 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
-   7 [  2.1787e-02 - 1.7893e-03 =  1.9997e-02 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
-   8 [ -1.6047e-03 - 8.8631e-03 = -1.0468e-02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [ -1.2080e-03 - 5.6007e-03 = -6.8087e-03 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [  2.4450e-03 + 1.3010e-02 =  1.5455e-02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [ -1.4200e-03 - 4.7296e-03 = -6.1495e-03 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [  1.0860e-03 - 2.1484e-03 = -1.0623e-03 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [ -1.0810e-02 - 5.9097e-02 = -6.9907e-02 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [ -1.8520e-03 - 9.5586e-03 = -1.1411e-02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [  1.0402e-05 + 2.6574e-04 =  2.7614e-04 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [  6.1563e-04 + 8.5239e-04 =  1.4680e-03 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
-  17 [ -1.7438e-20 + 1.9909e-19 =  1.8165e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [ -1.8325e-04 - 6.4759e-04 = -8.3085e-04 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
-  19 [ -2.7552e-04 - 9.6210e-04 = -1.2376e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [ -6.9613e-04 - 2.4837e-03 = -3.1799e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
-  21 [ -1.0502e-03 - 3.8568e-03 = -4.9069e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [ -5.9446e-06 + 2.5511e-05 =  1.9567e-05 ] : vdW/Atom/epsilon/[#6X4:1]
-  23 [ -5.5130e-05 + 2.6070e-04 =  2.0557e-04 ] : vdW/Atom/rmin_half/[#6X4:1]
-  24 [ -8.3738e-06 - 9.1717e-06 = -1.7546e-05 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
-  25 [ -1.2985e-04 - 2.0373e-04 = -3.3358e-04 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+   0 [ -6.6969e-03 - 3.0783e-02 = -3.7480e-02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [ -6.8866e-03 + 1.1777e-02 =  4.8900e-03 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [ -1.1569e-03 - 5.7563e-03 = -6.9131e-03 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  1.5558e-02 + 4.8553e-02 =  6.4111e-02 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [ -1.4770e-03 - 7.3696e-03 = -8.8466e-03 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  6.9343e-03 + 2.2653e-02 =  2.9588e-02 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [  1.9750e-03 + 5.7258e-03 =  7.7008e-03 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  2.1783e-02 - 1.7846e-03 =  1.9999e-02 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [ -1.6044e-03 - 8.8606e-03 = -1.0465e-02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [ -1.2078e-03 - 5.5992e-03 = -6.8070e-03 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [  2.4446e-03 + 1.3006e-02 =  1.5451e-02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [ -1.4197e-03 - 4.7291e-03 = -6.1488e-03 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [  1.0855e-03 - 2.1473e-03 = -1.0617e-03 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [ -1.0808e-02 - 5.9081e-02 = -6.9889e-02 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [ -1.8517e-03 - 9.5558e-03 = -1.1408e-02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [  1.0400e-05 + 2.6555e-04 =  2.7595e-04 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [  6.1543e-04 + 8.5251e-04 =  1.4679e-03 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  9.6879e-20 + 2.7838e-19 =  3.7526e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [ -1.8321e-04 - 6.4776e-04 = -8.3096e-04 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [ -2.7552e-04 - 9.6195e-04 = -1.2375e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [ -6.9601e-04 - 2.4831e-03 = -3.1791e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [ -1.0500e-03 - 3.8558e-03 = -4.9058e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [ -5.9438e-06 + 2.5515e-05 =  1.9572e-05 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [ -5.5124e-05 + 2.6022e-04 =  2.0510e-04 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [ -8.3880e-06 - 9.1862e-06 = -1.7574e-05 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [ -1.2982e-04 - 2.0397e-04 = -3.3380e-04 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
 ----------------------------------------------------------
 #========================================================#
 #| [95m    Physical Parameters (Current + Step = Next)     [0m |#
 #========================================================#
-   0 [  8.1397e+02 - 2.7712e+01 =  7.8626e+02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
-   1 [  1.3904e+00 + 1.6493e-02 =  1.4069e+00 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [  8.9896e+02 - 5.1818e+00 =  8.9378e+02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [  1.3448e+00 + 6.7980e-02 =  1.4128e+00 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [  6.7867e+02 - 6.6342e+00 =  6.7204e+02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
-   5 [  1.0997e+00 + 3.1720e-02 =  1.1314e+00 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
-   6 [  7.3578e+02 + 5.1538e+00 =  7.4093e+02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
-   7 [  1.1105e+00 - 2.5050e-03 =  1.1080e+00 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
-   8 [  1.0931e+02 - 1.0636e+00 =  1.0824e+02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [  6.9831e+01 - 7.8410e-01 =  6.9047e+01 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [  1.2029e+02 + 1.5612e+00 =  1.2185e+02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [  1.3980e+02 - 6.6214e-01 =  1.3914e+02 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [  1.2013e+02 - 2.5781e-01 =  1.1987e+02 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [  9.8487e+01 - 8.2735e+00 =  9.0213e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [  1.1978e+02 - 1.1470e+00 =  1.1863e+02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [  1.4000e+02 + 3.7204e-02 =  1.4004e+02 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [  3.6272e+00 + 3.0899e-03 =  3.6303e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+   0 [  8.1397e+02 - 2.7705e+01 =  7.8627e+02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [  1.3904e+00 + 1.6487e-02 =  1.4068e+00 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [  8.9896e+02 - 5.1806e+00 =  8.9378e+02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  1.3448e+00 + 6.7974e-02 =  1.4128e+00 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [  6.7867e+02 - 6.6327e+00 =  6.7204e+02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  1.0997e+00 + 3.1715e-02 =  1.1314e+00 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [  7.3578e+02 + 5.1532e+00 =  7.4093e+02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  1.1105e+00 - 2.4984e-03 =  1.1080e+00 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [  1.0931e+02 - 1.0633e+00 =  1.0824e+02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [  6.9831e+01 - 7.8389e-01 =  6.9047e+01 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [  1.2029e+02 + 1.5607e+00 =  1.2185e+02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [  1.3980e+02 - 6.6207e-01 =  1.3914e+02 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [  1.2013e+02 - 2.5767e-01 =  1.1987e+02 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [  9.8487e+01 - 8.2713e+00 =  9.0216e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [  1.1978e+02 - 1.1467e+00 =  1.1863e+02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [  1.4000e+02 + 3.7176e-02 =  1.4004e+02 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [  3.6272e+00 + 3.0903e-03 =  3.6303e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
   17 [  1.0500e+00 + 0.0000e+00 =  1.0500e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [  1.5669e-02 - 1.1009e-04 =  1.5559e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
-  19 [  1.4865e+00 - 1.8357e-03 =  1.4846e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [  1.4882e-02 - 4.2223e-04 =  1.4459e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
-  21 [  1.4570e+00 - 7.3587e-03 =  1.4496e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [  1.0940e-01 + 4.3369e-06 =  1.0940e-01 ] : vdW/Atom/epsilon/[#6X4:1]
-  23 [  1.9079e+00 + 4.9741e-04 =  1.9084e+00 ] : vdW/Atom/rmin_half/[#6X4:1]
-  24 [  1.7000e-01 - 1.5592e-06 =  1.7000e-01 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
-  25 [  1.6835e+00 - 3.8872e-04 =  1.6831e+00 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+  18 [  1.5669e-02 - 1.1012e-04 =  1.5559e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [  1.4865e+00 - 1.8354e-03 =  1.4846e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [  1.4882e-02 - 4.2213e-04 =  1.4460e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [  1.4570e+00 - 7.3569e-03 =  1.4496e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  1.0940e-01 + 4.3376e-06 =  1.0940e-01 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  1.9079e+00 + 4.9651e-04 =  1.9084e+00 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [  1.7000e-01 - 1.5616e-06 =  1.7000e-01 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [  1.6835e+00 - 3.8918e-04 =  1.6831e+00 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
 ----------------------------------------------------------
 Input file with saved parameters: optimize.sav
 #========================================================#
@@ -739,7 +709,7 @@ Input file with saved parameters: optimize.sav
 #========================================================#
 
 #======================================================================================================================#
-#| [92m                                         optgeo, Objective =  4.31049e+00                                         [0m |#
+#| [92m                                         optgeo, Objective =  4.30973e+00                                         [0m |#
 #| [92m  System                       Bonds            Angles           Dihedrals         Impropers               Term.  [0m |#
 #| [92m                            RMSD   denom      RMSD   denom      RMSD   denom      RMSD   denom                    [0m |#
 #======================================================================================================================#
@@ -748,219 +718,220 @@ Input file with saved parameters: optimize.sav
 
 #==========================================================================#
 #|                       Frequencies (wavenumbers)                        |#
-#|  Target: vibration  Type: Vibration_SMIRNOFF  Objective = 7.62565e+00  |#
+#|  Target: vibration  Type: Vibration_SMIRNOFF  Objective = 7.62679e+00  |#
 #|  Mode #            Reference   Calculated   Difference   Ref(dot)Calc  |#
 #==========================================================================#
-    0                   31.1817      54.4059      23.2242         0.9908 
+    0                   31.1817      54.4066      23.2249         0.9908 
     1                  127.2863     137.3924      10.1061         0.9950 
     2                  200.5311     224.2878      23.7567         0.9326 
-    3                  245.4174     230.9935     -14.4239         0.9373 
-    4                  258.8788     240.1857     -18.6931         0.9939 
-    5                  295.5887     320.8013      25.2126         0.9750 
-    6                  385.5805     329.6971     -55.8834         0.9893 
-    7                  413.3227     417.0504       3.7277         0.9725 
-    8                  461.1571     434.3372     -26.8199         0.9809 
-    9                  468.4759     452.0916     -16.3843         0.9884 
-    10                 553.9686     508.3788     -45.5898         0.9583 
-    11                 557.9183     539.6872     -18.2311         0.9410 
-    12                 559.2968     543.5809     -15.7159         0.9438 
-    13                 609.7540     604.0198      -5.7342         0.0013 
-    14                 650.9588     617.3847     -33.5741         0.0034 
-    15                 691.9021     624.5236     -67.3785         0.8418 
-    16                 731.3959     692.7602     -38.6357         0.9332 
-    17                 748.6224     698.6893     -49.9331         0.0139 
-    18                 757.4865     718.1322     -39.3543         0.0118 
-    19                 793.4162     746.6266     -46.7896         0.0488 
-    20                 796.3137     753.0862     -43.2275         0.0030 
-    21                 829.9391     754.4044     -75.5347         0.0015 
-    22                 886.2937     861.5715     -24.7222         0.0056 
-    23                 898.9488     869.1707     -29.7781         0.3109 
-    24                 905.1053     870.6315     -34.4738         0.0757 
-    25                 931.8180     905.2251     -26.5929         0.0036 
-    26                 972.6908     933.9343     -38.7565         0.4112 
-    27                 981.1443     942.5691     -38.5752         0.0016 
-    28                1002.3531     958.7992     -43.5539         0.0022 
-    29                1002.6108    1037.5971      34.9863         0.0569 
-    30                1006.9971    1041.1976      34.2005         0.4725 
-    31                1043.4229    1070.7683      27.3454         0.0002 
-    32                1045.2039    1089.3537      44.1498         0.0083 
-    33                1101.4212    1111.5878      10.1666         0.0176 
-    34                1122.1664    1112.0192     -10.1472         0.0229 
-    35                1175.8590    1159.5639     -16.2951         0.0350 
-    36                1177.5535    1160.3693     -17.1842         0.0572 
-    37                1180.0345    1205.7586      25.7241         0.0173 
-    38                1198.0738    1219.4080      21.3342         0.0088 
-    39                1209.4283    1237.5135      28.0852         0.4323 
-    40                1213.4868    1252.0453      38.5585         0.0123 
-    41                1233.7197    1269.3490      35.6293         0.0130 
-    42                1248.6007    1351.4168     102.8161         0.0073 
-    43                1296.1008    1375.9352      79.8344         0.5759 
-    44                1311.1904    1425.2156     114.0252         0.2577 
-    45                1325.6114    1500.9794     175.3680         0.0237 
-    46                1351.5363    1544.4939     192.9576         0.0038 
-    47                1456.1390    1571.2096     115.0706         0.6497 
-    48                1461.1551    1592.6695     131.5144         0.0170 
-    49                1467.0845    1606.1842     139.0997         0.3368 
-    50                1486.3167    1634.0750     147.7583         0.6889 
-    51                1498.4933    1637.9373     139.4440         0.2620 
-    52                1571.5221    1685.1330     113.6109         0.5822 
-    53                1591.5923    1689.4322      97.8399         0.7225 
-    54                1597.5166    1726.0614     128.5448         0.0400 
-    55                1620.6702    1772.5415     151.8713         0.0269 
-    56                2881.8985    2896.1354      14.2369         0.8761 
-    57                2918.3100    2960.4448      42.1348         0.8770 
-    58                3057.8158    3077.2774      19.4616         0.2966 
-    59                3058.9610    3077.4265      18.4655         0.2556 
-    60                3076.7507    3077.8930       1.1423         0.2804 
-    61                3076.9099    3077.9690       1.0591         0.3035 
-    62                3093.3546    3078.9512     -14.4034         0.0793 
-    63                3093.7472    3079.0002     -14.7470         0.1113 
-    64                3108.9905    3079.5171     -29.4734         0.7609 
-    65                3109.6289    3079.8394     -29.7895         0.7846 
+    3                  245.4174     230.9943     -14.4231         0.9373 
+    4                  258.8788     240.1848     -18.6940         0.9939 
+    5                  295.5887     320.8018      25.2131         0.9750 
+    6                  385.5805     329.6987     -55.8818         0.9893 
+    7                  413.3227     417.0524       3.7297         0.9725 
+    8                  461.1571     434.3346     -26.8225         0.9809 
+    9                  468.4759     452.0886     -16.3873         0.9884 
+    10                 553.9686     508.3760     -45.5926         0.9583 
+    11                 557.9183     539.6857     -18.2326         0.9410 
+    12                 559.2968     543.5843     -15.7125         0.9438 
+    13                 609.7540     604.0238      -5.7302         0.0013 
+    14                 650.9588     617.3872     -33.5716         0.0034 
+    15                 691.9021     624.5280     -67.3741         0.8418 
+    16                 731.3959     692.7589     -38.6370         0.9332 
+    17                 748.6224     698.6940     -49.9284         0.0139 
+    18                 757.4865     718.1278     -39.3587         0.0118 
+    19                 793.4162     746.6261     -46.7901         0.0488 
+    20                 796.3137     753.0906     -43.2231         0.0030 
+    21                 829.9391     754.4035     -75.5356         0.0015 
+    22                 886.2937     861.5763     -24.7174         0.0056 
+    23                 898.9488     869.1754     -29.7734         0.3109 
+    24                 905.1053     870.6332     -34.4721         0.0757 
+    25                 931.8180     905.2241     -26.5939         0.0036 
+    26                 972.6908     933.9339     -38.7569         0.4112 
+    27                 981.1443     942.5747     -38.5696         0.0016 
+    28                1002.3531     958.8050     -43.5481         0.0022 
+    29                1002.6108    1037.5963      34.9855         0.0569 
+    30                1006.9971    1041.1967      34.1996         0.4725 
+    31                1043.4229    1070.7758      27.3529         0.0002 
+    32                1045.2039    1089.3616      44.1577         0.0083 
+    33                1101.4212    1111.5866      10.1654         0.0176 
+    34                1122.1664    1112.0179     -10.1485         0.0229 
+    35                1175.8590    1159.5712     -16.2878         0.0350 
+    36                1177.5535    1160.3756     -17.1779         0.0572 
+    37                1180.0345    1205.7688      25.7343         0.0173 
+    38                1198.0738    1219.4172      21.3434         0.0088 
+    39                1209.4283    1237.5228      28.0945         0.4323 
+    40                1213.4868    1252.0513      38.5645         0.0123 
+    41                1233.7197    1269.3553      35.6356         0.0130 
+    42                1248.6007    1351.4281     102.8274         0.0073 
+    43                1296.1008    1375.9458      79.8450         0.5759 
+    44                1311.1904    1425.2261     114.0357         0.2577 
+    45                1325.6114    1500.9922     175.3808         0.0237 
+    46                1351.5363    1544.5103     192.9740         0.0038 
+    47                1456.1390    1571.2198     115.0808         0.6496 
+    48                1461.1551    1592.6803     131.5252         0.0170 
+    49                1467.0845    1606.1984     139.1139         0.3367 
+    50                1486.3167    1634.0887     147.7720         0.6890 
+    51                1498.4933    1637.9479     139.4546         0.2621 
+    52                1571.5221    1685.1449     113.6228         0.5822 
+    53                1591.5923    1689.4438      97.8515         0.7225 
+    54                1597.5166    1726.0735     128.5569         0.0400 
+    55                1620.6702    1772.5511     151.8809         0.0269 
+    56                2881.8985    2896.1388      14.2403         0.8761 
+    57                2918.3100    2960.4494      42.1394         0.8770 
+    58                3057.8158    3077.2758      19.4600         0.2966 
+    59                3058.9610    3077.4249      18.4639         0.2556 
+    60                3076.7507    3077.8914       1.1407         0.2804 
+    61                3076.9099    3077.9674       1.0575         0.3035 
+    62                3093.3546    3078.9496     -14.4050         0.0793 
+    63                3093.7472    3078.9986     -14.7486         0.1113 
+    64                3108.9905    3079.5156     -29.4749         0.7609 
+    65                3109.6289    3079.8378     -29.7911         0.7846 
 ----------------------------------------------------------------------------
 #===================================================================================#
 #| [94m                         Objective Function Breakdown                          [0m |#
 #| [94m  Target Name              Residual  x  Weight  =  Contribution (Current-Prev) [0m |#
 #===================================================================================#
-optgeo                         4.31049      1.000 [92m     4.31049e+00[0m ( -7.718e-01 ) 
-vibration                      7.62565      1.000 [92m     7.62565e+00[0m ( -5.066e+00 ) 
-Regularization                 0.01249      1.000 [91m     1.24910e-02[0m ( +1.149e-02 ) 
-Total                                             [92m     1.19486e+01[0m ( -5.827e+00 ) 
+optgeo                         4.30973      1.000 [92m     4.30973e+00[0m ( -7.720e-01 ) 
+vibration                      7.62679      1.000 [92m     7.62679e+00[0m ( -5.066e+00 ) 
+Regularization                 0.01249      1.000 [91m     1.24865e-02[0m ( +1.149e-02 ) 
+Total                                             [92m     1.19490e+01[0m ( -5.826e+00 ) 
 -------------------------------------------------------------------------------------
-Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_27.offxml
+Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_38.offxml
 #========================================================================#
 #|  The force field has been written to the result/optimize directory.  |#
 #|    Input file with optimization parameters saved to optimize.sav.    |#
 #========================================================================#
 
   Step       |k|        |dk|       |grad|       -=X2=-     Delta(X2)    StepQual
-     2   1.118e-01   8.941e-02   2.337e+02[92m   1.19486e+01[0m  -5.827e+00      1.000
+     2   1.117e-01   8.939e-02   2.337e+02[92m   1.19490e+01[0m  -5.826e+00      1.000
 
 #========================================================#
 #| [94m                   Total Gradient                   [0m |#
 #========================================================#
-   0 [  2.48602534e+01 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
-   1 [  1.71407377e+02 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [  4.43669620e+00 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [  2.47923945e+01 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [  5.50757730e+00 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
-   5 [  5.12513029e+01 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
-   6 [ -4.28845595e+00 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
-   7 [  1.37517532e+02 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
-   8 [  5.52756502e+00 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [  4.34970489e+00 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [ -1.13979119e+01 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [  4.21440930e+00 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [ -8.60261075e+00 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [  4.55726324e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [  3.04873593e+00 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [ -4.18517350e-02 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [ -3.83221743e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
-  17 [  3.63297700e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [  6.26253871e-01 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
-  19 [  1.07191483e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [  2.23090075e+00 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
-  21 [  3.76861106e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [  6.39773193e-02 ] : vdW/Atom/epsilon/[#6X4:1]
-  23 [  7.01975461e-01 ] : vdW/Atom/rmin_half/[#6X4:1]
-  24 [  5.18935724e-02 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
-  25 [  1.11487602e+00 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+   0 [  2.48635517e+01 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [  1.71350721e+02 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [  4.43683616e+00 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  2.47747939e+01 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [  5.50834795e+00 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  5.12349829e+01 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [ -4.29028175e+00 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  1.37527175e+02 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [  5.52857754e+00 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [  4.35018737e+00 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [ -1.14000460e+01 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [  4.21524625e+00 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [ -8.60280535e+00 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [  4.55777683e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [  3.05041745e+00 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [ -4.19030677e-02 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [ -3.83262336e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  7.50526378e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [  6.26298084e-01 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [  1.07191999e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [  2.23082989e+00 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [  3.76903289e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  6.41095361e-02 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  7.02122290e-01 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [  5.17031576e-02 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [  1.11412366e+00 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
 ----------------------------------------------------------
 Calculating nonlinear optimization step
-Finding trust radius: H+0.0000*I, length 5.8346e-01 (target 8.9413e-02)
-Finding trust radius: H+9.0000*I, length 2.9552e-01 (target 8.9413e-02)
-Finding trust radius: H+61.6869*I, length 1.8406e-01 (target 8.9413e-02)
-Finding trust radius: H+34.5372*I, length 2.1006e-01 (target 8.9413e-02)
-Finding trust radius: H+246.7477*I, length 1.2025e-01 (target 8.9413e-02)
-Finding trust radius: H+165.9323*I, length 1.3964e-01 (target 8.9413e-02)
-Finding trust radius: H+807.4923*I, length 6.4304e-02 (target 8.9413e-02)
-Finding trust radius: H+498.3300*I, length 8.5646e-02 (target 8.9413e-02)
-Finding trust radius: H+498.3300*I, length 8.5646e-02 (target 8.9413e-02)
-Finding trust radius: H+391.9039*I, length 9.7246e-02 (target 8.9413e-02)
-Finding trust radius: H+607.6552*I, length 7.6491e-02 (target 8.9413e-02)
-Finding trust radius: H+466.4347*I, length 8.8793e-02 (target 8.9413e-02)
-Finding trust radius: H+462.4993*I, length 8.9199e-02 (target 8.9413e-02)
-Finding trust radius: H+460.1970*I, length 8.9438e-02 (target 8.9413e-02)
-Finding trust radius: H+460.4260*I, length 8.9414e-02 (target 8.9413e-02)
-Finding trust radius: H+460.5224*I, length 8.9404e-02 (target 8.9413e-02)
-Finding trust radius: H+460.3297*I, length 8.9424e-02 (target 8.9413e-02)
-Starting Hessian diagonal search with step size 8.9414e-02
-Hessian diagonal search: H+460.4260*I, length 8.9414e-02, result  7.8970e+00
-Hessian diagonal search: H+7890.7973*I, length 1.4513e-02, result -2.0240e+00
-Hessian diagonal search: H+39141.1996*I, length 4.7579e-03, result -9.6077e-01
-Hessian diagonal search: H+7890.7973*I, length 1.4513e-02, result -2.0240e+00
-Hessian diagonal search: H+17022.0890*I, length 8.8532e-03, result -1.5492e+00
-Hessian diagonal search: H+3981.1191*I, length 2.2188e-02, result -2.1655e+00
-Hessian diagonal search: H+1988.1027*I, length 3.5168e-02, result -1.5485e+00
-Hessian diagonal search: H+5318.1493*I, length 1.8499e-02, result -2.1579e+00
-Hessian diagonal search: H+4449.0544*I, length 2.0679e-02, result -2.1744e+00
-Hessian diagonal search: H+4524.4081*I, length 2.0462e-02, result -2.1744e+00
-Hessian diagonal search: H+4478.5247*I, length 2.0593e-02, result -2.1744e+00
-Hessian diagonal search: H+4477.5008*I, length 2.0596e-02, result -2.1744e+00
-Hessian diagonal search: H+4476.5920*I, length 2.0599e-02, result -2.1744e+00
-Hessian diagonal search: H+4466.0635*I, length 2.0629e-02, result -2.1744e+00
-Hessian diagonal search: H+4472.5690*I, length 2.0610e-02, result -2.1744e+00
-Hessian diagonal search: H+4475.0552*I, length 2.0603e-02, result -2.1744e+00
-Optimization step found (length 2.0599e-02)
+Finding trust radius: H+0.0000*I, length 5.8348e-01 (target 8.9395e-02)
+Finding trust radius: H+9.0000*I, length 2.9555e-01 (target 8.9395e-02)
+Finding trust radius: H+61.6869*I, length 1.8408e-01 (target 8.9395e-02)
+Finding trust radius: H+34.5385*I, length 2.1009e-01 (target 8.9395e-02)
+Finding trust radius: H+246.7477*I, length 1.2027e-01 (target 8.9395e-02)
+Finding trust radius: H+165.9494*I, length 1.3966e-01 (target 8.9395e-02)
+Finding trust radius: H+807.4923*I, length 6.4307e-02 (target 8.9395e-02)
+Finding trust radius: H+498.4315*I, length 8.5642e-02 (target 8.9395e-02)
+Finding trust radius: H+498.4315*I, length 8.5642e-02 (target 8.9395e-02)
+Finding trust radius: H+391.9595*I, length 9.7247e-02 (target 8.9395e-02)
+Finding trust radius: H+607.7245*I, length 7.6490e-02 (target 8.9395e-02)
+Finding trust radius: H+466.7031*I, length 8.8771e-02 (target 8.9395e-02)
+Finding trust radius: H+462.7405*I, length 8.9180e-02 (target 8.9395e-02)
+Finding trust radius: H+460.4383*I, length 8.9419e-02 (target 8.9395e-02)
+Finding trust radius: H+460.6673*I, length 8.9395e-02 (target 8.9395e-02)
+Finding trust radius: H+460.7637*I, length 8.9385e-02 (target 8.9395e-02)
+Finding trust radius: H+460.5709*I, length 8.9405e-02 (target 8.9395e-02)
+Starting Hessian diagonal search with step size 8.9395e-02
+Hessian diagonal search: H+460.6673*I, length 8.9395e-02, result  7.8875e+00
+Hessian diagonal search: H+7894.7928*I, length 1.4507e-02, result -2.0233e+00
+Hessian diagonal search: H+39160.8973*I, length 4.7552e-03, result -9.6013e-01
+Hessian diagonal search: H+7894.7928*I, length 1.4507e-02, result -2.0233e+00
+Hessian diagonal search: H+17030.6775*I, length 8.8488e-03, result -1.5483e+00
+Hessian diagonal search: H+3983.1441*I, length 2.2179e-02, result -2.1653e+00
+Hessian diagonal search: H+1971.2877*I, length 3.5371e-02, result -1.5324e+00
+Hessian diagonal search: H+5320.8487*I, length 1.8491e-02, result -2.1573e+00
+Hessian diagonal search: H+4444.5382*I, length 2.0690e-02, result -2.1740e+00
+Hessian diagonal search: H+4522.9904*I, length 2.0464e-02, result -2.1740e+00
+Hessian diagonal search: H+4476.8997*I, length 2.0596e-02, result -2.1740e+00
+Hessian diagonal search: H+4475.9910*I, length 2.0599e-02, result -2.1740e+00
+Hessian diagonal search: H+4477.8085*I, length 2.0593e-02, result -2.1740e+00
+Hessian diagonal search: H+4495.0397*I, length 2.0544e-02, result -2.1740e+00
+Hessian diagonal search: H+4484.3863*I, length 2.0574e-02, result -2.1740e+00
+Hessian diagonal search: H+4480.3205*I, length 2.0586e-02, result -2.1740e+00
+Hessian diagonal search: H+4478.7679*I, length 2.0591e-02, result -2.1740e+00
+Optimization step found (length 2.0593e-02)
 #========================================================#
 #| [95m  Mathematical Parameters (Current + Step = Next)   [0m |#
 #========================================================#
-   0 [ -3.7489e-02 - 5.7872e-03 = -4.3276e-02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
-   1 [  4.8934e-03 - 1.5267e-02 = -1.0373e-02 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [ -6.9146e-03 - 1.0213e-03 = -7.9359e-03 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [  6.4117e-02 - 2.5637e-03 =  6.1553e-02 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [ -8.8487e-03 - 1.1446e-03 = -9.9932e-03 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
-   5 [  2.9592e-02 - 2.9518e-03 =  2.6641e-02 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
-   6 [  7.7018e-03 + 6.8164e-04 =  8.3834e-03 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
-   7 [  1.9997e-02 - 5.0403e-03 =  1.4957e-02 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
-   8 [ -1.0468e-02 - 1.2598e-03 = -1.1728e-02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [ -6.8087e-03 - 1.0072e-03 = -7.8159e-03 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [  1.5455e-02 + 1.6805e-03 =  1.7135e-02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [ -6.1495e-03 - 1.0876e-03 = -7.2372e-03 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [ -1.0623e-03 + 6.5122e-04 = -4.1113e-04 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [ -6.9907e-02 - 1.0271e-02 = -8.0178e-02 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [ -1.1411e-02 - 8.6583e-04 = -1.2276e-02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [  2.7614e-04 + 6.6131e-06 =  2.8276e-04 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [  1.4680e-03 + 3.3925e-04 =  1.8073e-03 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
-  17 [  1.8165e-19 + 1.8779e-20 =  2.0043e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [ -8.3085e-04 - 1.3406e-04 = -9.6491e-04 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
-  19 [ -1.2376e-03 - 2.1189e-04 = -1.4495e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [ -3.1799e-03 - 4.5807e-04 = -3.6379e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
-  21 [ -4.9069e-03 - 7.3038e-04 = -5.6373e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [  1.9567e-05 - 8.9357e-06 =  1.0631e-05 ] : vdW/Atom/epsilon/[#6X4:1]
-  23 [  2.0557e-04 - 9.0709e-05 =  1.1486e-04 ] : vdW/Atom/rmin_half/[#6X4:1]
-  24 [ -1.7546e-05 - 8.4536e-06 = -2.5999e-05 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
-  25 [ -3.3358e-04 - 1.7648e-04 = -5.1006e-04 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+   0 [ -3.7480e-02 - 5.7864e-03 = -4.3266e-02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [  4.8900e-03 - 1.5260e-02 = -1.0370e-02 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [ -6.9131e-03 - 1.0211e-03 = -7.9342e-03 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  6.4111e-02 - 2.5617e-03 =  6.1549e-02 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [ -8.8466e-03 - 1.1445e-03 = -9.9911e-03 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  2.9588e-02 - 2.9505e-03 =  2.6637e-02 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [  7.7008e-03 + 6.8182e-04 =  8.3826e-03 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  1.9999e-02 - 5.0428e-03 =  1.4956e-02 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [ -1.0465e-02 - 1.2596e-03 = -1.1725e-02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [ -6.8070e-03 - 1.0071e-03 = -7.8140e-03 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [  1.5451e-02 + 1.6807e-03 =  1.7131e-02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [ -6.1488e-03 - 1.0875e-03 = -7.2362e-03 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [ -1.0617e-03 + 6.5092e-04 = -4.1081e-04 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [ -6.9889e-02 - 1.0270e-02 = -8.0159e-02 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [ -1.1408e-02 - 8.6581e-04 = -1.2273e-02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [  2.7595e-04 + 6.6166e-06 =  2.8256e-04 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [  1.4679e-03 + 3.3925e-04 =  1.8072e-03 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  3.7526e-19 + 9.5913e-21 =  3.8485e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [ -8.3096e-04 - 1.3404e-04 = -9.6500e-04 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [ -1.2375e-03 - 2.1187e-04 = -1.4493e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [ -3.1791e-03 - 4.5793e-04 = -3.6370e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [ -4.9058e-03 - 7.3034e-04 = -5.6362e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  1.9572e-05 - 8.9556e-06 =  1.0616e-05 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  2.0510e-04 - 9.0759e-05 =  1.1434e-04 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [ -1.7574e-05 - 8.4140e-06 = -2.5988e-05 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [ -3.3380e-04 - 1.7630e-04 = -5.1010e-04 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
 ----------------------------------------------------------
 #========================================================#
 #| [95m    Physical Parameters (Current + Step = Next)     [0m |#
 #========================================================#
-   0 [  7.8626e+02 - 5.2085e+00 =  7.8105e+02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
-   1 [  1.4069e+00 - 2.1373e-02 =  1.3855e+00 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [  8.9378e+02 - 9.1919e-01 =  8.9286e+02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [  1.4128e+00 - 3.5892e-03 =  1.4092e+00 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [  6.7204e+02 - 1.0301e+00 =  6.7101e+02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
-   5 [  1.1314e+00 - 4.1325e-03 =  1.1273e+00 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
-   6 [  7.4093e+02 + 6.1348e-01 =  7.4155e+02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
-   7 [  1.1080e+00 - 7.0565e-03 =  1.1009e+00 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
-   8 [  1.0824e+02 - 1.5117e-01 =  1.0809e+02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [  6.9047e+01 - 1.4101e-01 =  6.8906e+01 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [  1.2185e+02 + 2.0166e-01 =  1.2206e+02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [  1.3914e+02 - 1.5227e-01 =  1.3899e+02 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [  1.1987e+02 + 7.8147e-02 =  1.1995e+02 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [  9.0213e+01 - 1.4380e+00 =  8.8775e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+   0 [  7.8627e+02 - 5.2077e+00 =  7.8106e+02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [  1.4068e+00 - 2.1365e-02 =  1.3855e+00 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [  8.9378e+02 - 9.1898e-01 =  8.9286e+02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  1.4128e+00 - 3.5864e-03 =  1.4092e+00 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [  6.7204e+02 - 1.0300e+00 =  6.7101e+02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  1.1314e+00 - 4.1307e-03 =  1.1273e+00 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [  7.4093e+02 + 6.1364e-01 =  7.4154e+02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  1.1080e+00 - 7.0599e-03 =  1.1009e+00 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [  1.0824e+02 - 1.5116e-01 =  1.0809e+02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [  6.9047e+01 - 1.4099e-01 =  6.8906e+01 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [  1.2185e+02 + 2.0168e-01 =  1.2206e+02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [  1.3914e+02 - 1.5224e-01 =  1.3899e+02 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [  1.1987e+02 + 7.8110e-02 =  1.1995e+02 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [  9.0216e+01 - 1.4378e+00 =  8.8778e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
   14 [  1.1863e+02 - 1.0390e-01 =  1.1853e+02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [  1.4004e+02 + 9.2583e-04 =  1.4004e+02 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [  1.4004e+02 + 9.2632e-04 =  1.4004e+02 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
   16 [  3.6303e+00 + 1.2298e-03 =  3.6316e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
   17 [  1.0500e+00 + 0.0000e+00 =  1.0500e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [  1.5559e-02 - 2.2790e-05 =  1.5536e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
-  19 [  1.4846e+00 - 4.0428e-04 =  1.4842e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [  1.4459e-02 - 7.7872e-05 =  1.4382e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
-  21 [  1.4496e+00 - 1.3936e-03 =  1.4482e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [  1.0940e-01 - 1.5191e-06 =  1.0940e-01 ] : vdW/Atom/epsilon/[#6X4:1]
-  23 [  1.9084e+00 - 1.7307e-04 =  1.9082e+00 ] : vdW/Atom/rmin_half/[#6X4:1]
-  24 [  1.7000e-01 - 1.4371e-06 =  1.7000e-01 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
-  25 [  1.6831e+00 - 3.3672e-04 =  1.6827e+00 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+  18 [  1.5559e-02 - 2.2786e-05 =  1.5536e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [  1.4846e+00 - 4.0424e-04 =  1.4842e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [  1.4460e-02 - 7.7849e-05 =  1.4382e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [  1.4496e+00 - 1.3935e-03 =  1.4482e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  1.0940e-01 - 1.5224e-06 =  1.0940e-01 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  1.9084e+00 - 1.7317e-04 =  1.9082e+00 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [  1.7000e-01 - 1.4304e-06 =  1.7000e-01 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [  1.6831e+00 - 3.3638e-04 =  1.6827e+00 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
 ----------------------------------------------------------
 Input file with saved parameters: optimize.sav
 #========================================================#
@@ -969,239 +940,234 @@ Input file with saved parameters: optimize.sav
 #========================================================#
 
 #======================================================================================================================#
-#| [92m                                         optgeo, Objective =  2.28173e+00                                         [0m |#
+#| [92m                                         optgeo, Objective =  2.28118e+00                                         [0m |#
 #| [92m  System                       Bonds            Angles           Dihedrals         Impropers               Term.  [0m |#
 #| [92m                            RMSD   denom      RMSD   denom      RMSD   denom      RMSD   denom                    [0m |#
 #======================================================================================================================#
-9HXanthene                    0.013    0.01     0.022    0.03     0.076    0.20     0.005    0.20             2.282 
+9HXanthene                    0.013    0.01     0.022    0.03     0.076    0.20     0.005    0.20             2.281 
 ------------------------------------------------------------------------------------------------------------------------
 
 #==========================================================================#
 #|                       Frequencies (wavenumbers)                        |#
-#|  Target: vibration  Type: Vibration_SMIRNOFF  Objective = 7.47835e+00  |#
+#|  Target: vibration  Type: Vibration_SMIRNOFF  Objective = 7.47968e+00  |#
 #|  Mode #            Reference   Calculated   Difference   Ref(dot)Calc  |#
 #==========================================================================#
-    0                   31.1817      55.4953      24.3136         0.9910 
-    1                  127.2863     139.1899      11.9036         0.9952 
-    2                  200.5311     226.8030      26.2719         0.9330 
-    3                  245.4174     233.9492     -11.4682         0.9372 
-    4                  258.8788     243.2052     -15.6736         0.9939 
-    5                  295.5887     324.9577      29.3690         0.9760 
-    6                  385.5805     331.8073     -53.7732         0.9895 
-    7                  413.3227     419.9563       6.6336         0.9745 
-    8                  461.1571     443.5460     -17.6111         0.9808 
-    9                  468.4759     461.2716      -7.2043         0.9886 
-    10                 553.9686     518.5241     -35.4445         0.9584 
-    11                 557.9183     548.4081      -9.5102         0.9435 
-    12                 559.2968     552.5137      -6.7831         0.9445 
-    13                 609.7540     614.5353       4.7813         0.0013 
-    14                 650.9588     622.0496     -28.9092         0.0031 
-    15                 691.9021     630.5136     -61.3885         0.8953 
-    16                 731.3959     702.4504     -28.9455         0.9268 
-    17                 748.6224     708.4081     -40.2143         0.0138 
-    18                 757.4865     731.0577     -26.4288         0.0119 
-    19                 793.4162     753.6286     -39.7876         0.0482 
-    20                 796.3137     758.1689     -38.1448         0.0032 
-    21                 829.9391     762.1466     -67.7925         0.0015 
-    22                 886.2937     870.0492     -16.2445         0.0055 
-    23                 898.9488     876.1578     -22.7910         0.7297 
-    24                 905.1053     877.0796     -28.0257         0.0157 
-    25                 931.8180     913.7413     -18.0767         0.0036 
-    26                 972.6908     942.0902     -30.6006         0.4024 
-    27                 981.1443     944.0398     -37.1045         0.0015 
-    28                1002.3531     959.6652     -42.6879         0.0022 
-    29                1002.6108    1046.7674      44.1566         0.0562 
-    30                1006.9971    1050.3320      43.3349         0.4705 
-    31                1043.4229    1071.7269      28.3040         0.0006 
-    32                1045.2039    1089.6763      44.4724         0.0078 
-    33                1101.4212    1121.2860      19.8648         0.0176 
-    34                1122.1664    1121.7353      -0.4311         0.0228 
-    35                1175.8590    1160.3160     -15.5430         0.0409 
-    36                1177.5535    1164.2126     -13.3409         0.0655 
-    37                1180.0345    1206.6208      26.5863         0.0174 
-    38                1198.0738    1221.5909      23.5171         0.0094 
-    39                1209.4283    1238.9027      29.4744         0.4329 
-    40                1213.4868    1258.0253      44.5385         0.0123 
-    41                1233.7197    1272.3706      38.6509         0.0115 
-    42                1248.6007    1354.2880     105.6873         0.0073 
-    43                1296.1008    1379.8384      83.7376         0.5666 
-    44                1311.1904    1426.5265     115.3361         0.2655 
-    45                1325.6114    1502.0128     176.4014         0.0232 
-    46                1351.5363    1544.0308     192.4945         0.0037 
-    47                1456.1390    1570.5837     114.4447         0.6143 
-    48                1461.1551    1591.8563     130.7012         0.0180 
-    49                1467.0845    1605.9160     138.8315         0.3339 
-    50                1486.3167    1633.4223     147.1056         0.6948 
-    51                1498.4933    1634.6772     136.1839         0.2816 
-    52                1571.5221    1684.5994     113.0773         0.5885 
-    53                1591.5923    1689.9059      98.3136         0.7268 
-    54                1597.5166    1727.7638     130.2472         0.0399 
-    55                1620.6702    1775.9468     155.2766         0.0268 
-    56                2881.8985    2894.3383      12.4398         0.8761 
-    57                2918.3100    2958.1985      39.8885         0.8771 
-    58                3057.8158    3078.7901      20.9743         0.3066 
-    59                3058.9610    3078.9456      19.9846         0.2691 
-    60                3076.7507    3079.4617       2.7110         0.2670 
-    61                3076.9099    3079.5445       2.6346         0.2894 
-    62                3093.3546    3080.6484     -12.7062         0.0695 
-    63                3093.7472    3080.6954     -13.0518         0.0988 
-    64                3108.9905    3081.2803     -27.7102         0.7496 
-    65                3109.6289    3081.6052     -28.0237         0.7735 
+    0                   31.1817      55.4955      24.3138         0.9910 
+    1                  127.2863     139.1894      11.9031         0.9952 
+    2                  200.5311     226.8022      26.2711         0.9330 
+    3                  245.4174     233.9489     -11.4685         0.9372 
+    4                  258.8788     243.2034     -15.6754         0.9939 
+    5                  295.5887     324.9568      29.3681         0.9760 
+    6                  385.5805     331.8079     -53.7726         0.9895 
+    7                  413.3227     419.9571       6.6344         0.9745 
+    8                  461.1571     443.5408     -17.6163         0.9808 
+    9                  468.4759     461.2662      -7.2097         0.9886 
+    10                 553.9686     518.5183     -35.4503         0.9584 
+    11                 557.9183     548.4041      -9.5142         0.9435 
+    12                 559.2968     552.5133      -6.7835         0.9445 
+    13                 609.7540     614.5348       4.7808         0.0013 
+    14                 650.9588     622.0501     -28.9087         0.0031 
+    15                 691.9021     630.5151     -61.3870         0.8953 
+    16                 731.3959     702.4471     -28.9488         0.9268 
+    17                 748.6224     708.4085     -40.2139         0.0138 
+    18                 757.4865     731.0504     -26.4361         0.0119 
+    19                 793.4162     753.6290     -39.7872         0.0482 
+    20                 796.3137     758.1708     -38.1429         0.0032 
+    21                 829.9391     762.1460     -67.7931         0.0015 
+    22                 886.2937     870.0502     -16.2435         0.0055 
+    23                 898.9488     876.1596     -22.7892         0.7297 
+    24                 905.1053     877.0807     -28.0246         0.0157 
+    25                 931.8180     913.7415     -18.0765         0.0036 
+    26                 972.6908     942.0891     -30.6017         0.4024 
+    27                 981.1443     944.0451     -37.0992         0.0015 
+    28                1002.3531     959.6711     -42.6820         0.0022 
+    29                1002.6108    1046.7683      44.1575         0.0562 
+    30                1006.9971    1050.3328      43.3357         0.4705 
+    31                1043.4229    1071.7351      28.3122         0.0006 
+    32                1045.2039    1089.6856      44.4817         0.0078 
+    33                1101.4212    1121.2868      19.8656         0.0176 
+    34                1122.1664    1121.7360      -0.4304         0.0228 
+    35                1175.8590    1160.3242     -15.5348         0.0409 
+    36                1177.5535    1164.2180     -13.3355         0.0655 
+    37                1180.0345    1206.6326      26.5981         0.0174 
+    38                1198.0738    1221.6013      23.5275         0.0094 
+    39                1209.4283    1238.9128      29.4845         0.4329 
+    40                1213.4868    1258.0290      44.5422         0.0123 
+    41                1233.7197    1272.3760      38.6563         0.0115 
+    42                1248.6007    1354.2991     105.6984         0.0073 
+    43                1296.1008    1379.8487      83.7479         0.5666 
+    44                1311.1904    1426.5386     115.3482         0.2655 
+    45                1325.6114    1502.0281     176.4167         0.0232 
+    46                1351.5363    1544.0507     192.5144         0.0037 
+    47                1456.1390    1570.5946     114.4556         0.6143 
+    48                1461.1551    1591.8687     130.7136         0.0181 
+    49                1467.0845    1605.9326     138.8481         0.3339 
+    50                1486.3167    1633.4381     147.1214         0.6948 
+    51                1498.4933    1634.6895     136.1962         0.2817 
+    52                1571.5221    1684.6125     113.0904         0.5885 
+    53                1591.5923    1689.9177      98.3254         0.7268 
+    54                1597.5166    1727.7761     130.2595         0.0399 
+    55                1620.6702    1775.9553     155.2851         0.0268 
+    56                2881.8985    2894.3418      12.4433         0.8761 
+    57                2918.3100    2958.2034      39.8934         0.8771 
+    58                3057.8158    3078.7887      20.9729         0.3066 
+    59                3058.9610    3078.9442      19.9832         0.2692 
+    60                3076.7507    3079.4603       2.7096         0.2670 
+    61                3076.9099    3079.5432       2.6333         0.2894 
+    62                3093.3546    3080.6469     -12.7077         0.0695 
+    63                3093.7472    3080.6939     -13.0533         0.0988 
+    64                3108.9905    3081.2789     -27.7116         0.7496 
+    65                3109.6289    3081.6037     -28.0252         0.7735 
 ----------------------------------------------------------------------------
 #===================================================================================#
 #| [94m                         Objective Function Breakdown                          [0m |#
 #| [94m  Target Name              Residual  x  Weight  =  Contribution (Current-Prev) [0m |#
 #===================================================================================#
-optgeo                         2.28173      1.000 [92m     2.28173e+00[0m ( -2.029e+00 ) 
-vibration                      7.47835      1.000 [92m     7.47835e+00[0m ( -1.473e-01 ) 
-Regularization                 0.01411      1.000 [91m     1.41115e-02[0m ( +1.620e-03 ) 
-Total                                             [92m     9.77419e+00[0m ( -2.174e+00 ) 
+optgeo                         2.28118      1.000 [92m     2.28118e+00[0m ( -2.029e+00 ) 
+vibration                      7.47968      1.000 [92m     7.47968e+00[0m ( -1.471e-01 ) 
+Regularization                 0.01411      1.000 [91m     1.41063e-02[0m ( +1.620e-03 ) 
+Total                                             [92m     9.77497e+00[0m ( -2.174e+00 ) 
 -------------------------------------------------------------------------------------
-Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_28.offxml
+Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_39.offxml
 #========================================================================#
 #|  The force field has been written to the result/optimize directory.  |#
 #|    Input file with optimization parameters saved to optimize.sav.    |#
 #========================================================================#
 
   Step       |k|        |dk|       |grad|       -=X2=-     Delta(X2)    StepQual
-     3   1.188e-01   2.060e-02   1.226e+02[92m   9.77419e+00[0m  -2.174e+00      1.000
+     3   1.188e-01   2.059e-02   1.226e+02[92m   9.77497e+00[0m  -2.174e+00      1.000
 
 #========================================================#
 #| [94m                   Total Gradient                   [0m |#
 #========================================================#
-   0 [  2.67235427e+01 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
-   1 [ -6.82502365e+01 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [  4.53991148e+00 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [  1.84574160e+01 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [  5.11771412e+00 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
-   5 [  4.10491099e+01 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
-   6 [ -3.04554973e+00 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
-   7 [  7.24162582e+01 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
-   8 [  5.50689681e+00 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [  4.53981329e+00 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [ -6.35991637e+00 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [  5.04386162e+00 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [ -3.14381266e+00 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [  4.66606381e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [  3.57271935e+00 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [ -2.45165342e-02 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [ -1.42739193e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
-  17 [  4.00855963e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [  6.85373482e-01 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
-  19 [  1.07093820e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [  2.26086573e+00 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
-  21 [  3.44841517e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [  3.19962872e-02 ] : vdW/Atom/epsilon/[#6X4:1]
-  23 [  2.67304002e-01 ] : vdW/Atom/rmin_half/[#6X4:1]
-  24 [  3.93304642e-02 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
-  25 [  7.65891233e-01 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+   0 [  2.67264054e+01 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [ -6.82106596e+01 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [  4.54008205e+00 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  1.84455304e+01 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [  5.11884437e+00 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  4.10363069e+01 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [ -3.04692561e+00 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  7.23934952e+01 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [  5.50768916e+00 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [  4.54032242e+00 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [ -6.36236662e+00 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [  5.04441111e+00 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [ -3.14324371e+00 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [  4.66666769e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [  3.57343459e+00 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [ -2.45514960e-02 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [ -1.42759222e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  7.69708924e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [  6.85652590e-01 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [  1.07054669e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [  2.26109697e+00 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [  3.44907771e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  3.22766309e-02 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  2.67329222e-01 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [  3.95748262e-02 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [  7.65558986e-01 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
 ----------------------------------------------------------
 Calculating nonlinear optimization step
-Finding trust radius: H+0.0000*I, length 5.9657e-01 (target 2.0599e-02)
-Finding trust radius: H+9.0000*I, length 3.4209e-01 (target 2.0599e-02)
-Finding trust radius: H+61.6869*I, length 1.9104e-01 (target 2.0599e-02)
-Finding trust radius: H+41.1586*I, length 2.2129e-01 (target 2.0599e-02)
-Finding trust radius: H+246.7477*I, length 1.0540e-01 (target 2.0599e-02)
-Finding trust radius: H+174.0510*I, length 1.2379e-01 (target 2.0599e-02)
-Finding trust radius: H+807.4923*I, length 5.5416e-02 (target 2.0599e-02)
-Finding trust radius: H+583.4375*I, length 6.7364e-02 (target 2.0599e-02)
-Finding trust radius: H+2398.9145*I, length 2.5989e-02 (target 2.0599e-02)
-Finding trust radius: H+1682.2481*I, length 3.3747e-02 (target 2.0599e-02)
-Finding trust radius: H+6764.9351*I, length 1.1711e-02 (target 2.0599e-02)
-Finding trust radius: H+2398.9145*I, length 2.5989e-02 (target 2.0599e-02)
-Finding trust radius: H+3805.2759*I, length 1.8294e-02 (target 2.0599e-02)
-Finding trust radius: H+4835.9536*I, length 1.5203e-02 (target 2.0599e-02)
-Finding trust radius: H+3510.9837*I, length 1.9461e-02 (target 2.0599e-02)
-Finding trust radius: H+3370.9447*I, length 2.0078e-02 (target 2.0599e-02)
-Finding trust radius: H+2980.1944*I, length 2.2059e-02 (target 2.0599e-02)
-Finding trust radius: H+3274.4253*I, length 2.0529e-02 (target 2.0599e-02)
-Finding trust radius: H+3253.6853*I, length 2.0629e-02 (target 2.0599e-02)
-Finding trust radius: H+3259.8399*I, length 2.0600e-02 (target 2.0599e-02)
-Finding trust radius: H+3260.5033*I, length 2.0596e-02 (target 2.0599e-02)
-Finding trust radius: H+3259.1765*I, length 2.0603e-02 (target 2.0599e-02)
-Starting Hessian diagonal search with step size 2.0600e-02
-Hessian diagonal search: H+3259.8399*I, length 2.0600e-02, result -9.5299e-01
-Hessian diagonal search: H+53536.7182*I, length 2.0731e-03, result -2.3433e-01
-Hessian diagonal search: H+50581.8472*I, length 2.1830e-03, result -2.4566e-01
-Hessian diagonal search: H+3259.8399*I, length 2.0600e-02, result -9.5299e-01
-Hessian diagonal search: H+2562.2890*I, length 2.4734e-02, result -8.8493e-01
-Hessian diagonal search: H+15293.2697*I, length 6.1228e-03, result -5.8293e-01
-Hessian diagonal search: H+147.1722*I, length 1.3336e-01, result -9.2386e-01
-Hessian diagonal search: H+6810.0204*I, length 1.1650e-02, result -8.6037e-01
-Hessian diagonal search: H+1593.6431*I, length 3.5083e-02, result -5.0817e-01
-Hessian diagonal search: H+4463.2525*I, length 1.6176e-02, result -9.5383e-01
-Hessian diagonal search: H+4382.9252*I, length 1.6405e-02, result -9.5586e-01
-Hessian diagonal search: H+3852.2520*I, length 1.8122e-02, result -9.6360e-01
-Hessian diagonal search: H+3620.1361*I, length 1.9009e-02, result -9.6263e-01
-Hessian diagonal search: H+3814.3680*I, length 1.8260e-02, result -9.6366e-01
-Hessian diagonal search: H+3803.9249*I, length 1.8299e-02, result -9.6367e-01
-Hessian diagonal search: H+3801.5361*I, length 1.8308e-02, result -9.6367e-01
-Hessian diagonal search: H+3802.3088*I, length 1.8305e-02, result -9.6367e-01
-Hessian diagonal search: H+3731.7241*I, length 1.8571e-02, result -9.6352e-01
-Hessian diagonal search: H+3774.7939*I, length 1.8407e-02, result -9.6364e-01
-Hessian diagonal search: H+3791.3104*I, length 1.8346e-02, result -9.6366e-01
-Hessian diagonal search: H+3797.6286*I, length 1.8322e-02, result -9.6367e-01
-Hessian diagonal search: H+3800.0434*I, length 1.8313e-02, result -9.6367e-01
-Optimization step found (length 1.8308e-02)
+Finding trust radius: H+0.0000*I, length 5.9659e-01 (target 2.0593e-02)
+Finding trust radius: H+9.0000*I, length 3.4211e-01 (target 2.0593e-02)
+Finding trust radius: H+61.6869*I, length 1.9106e-01 (target 2.0593e-02)
+Finding trust radius: H+41.1586*I, length 2.2132e-01 (target 2.0593e-02)
+Finding trust radius: H+246.7477*I, length 1.0542e-01 (target 2.0593e-02)
+Finding trust radius: H+174.0633*I, length 1.2380e-01 (target 2.0593e-02)
+Finding trust radius: H+807.4923*I, length 5.5420e-02 (target 2.0593e-02)
+Finding trust radius: H+583.4528*I, length 6.7369e-02 (target 2.0593e-02)
+Finding trust radius: H+2398.9145*I, length 2.5989e-02 (target 2.0593e-02)
+Finding trust radius: H+1682.2644*I, length 3.3748e-02 (target 2.0593e-02)
+Finding trust radius: H+6764.9351*I, length 1.1709e-02 (target 2.0593e-02)
+Finding trust radius: H+2398.9145*I, length 2.5989e-02 (target 2.0593e-02)
+Finding trust radius: H+3805.2759*I, length 1.8293e-02 (target 2.0593e-02)
+Finding trust radius: H+4835.9536*I, length 1.5201e-02 (target 2.0593e-02)
+Finding trust radius: H+3512.1951*I, length 1.9455e-02 (target 2.0593e-02)
+Finding trust radius: H+3061.9879*I, length 2.1608e-02 (target 2.0593e-02)
+Finding trust radius: H+3267.5812*I, length 2.0561e-02 (target 2.0593e-02)
+Finding trust radius: H+3270.2420*I, length 2.0549e-02 (target 2.0593e-02)
+Finding trust radius: H+3261.5140*I, length 2.0591e-02 (target 2.0593e-02)
+Finding trust radius: H+3260.8503*I, length 2.0594e-02 (target 2.0593e-02)
+Finding trust radius: H+3260.1868*I, length 2.0597e-02 (target 2.0593e-02)
+Starting Hessian diagonal search with step size 2.0594e-02
+Hessian diagonal search: H+3260.8503*I, length 2.0594e-02, result -9.5302e-01
+Hessian diagonal search: H+53553.0981*I, length 2.0719e-03, result -2.3414e-01
+Hessian diagonal search: H+50597.1879*I, length 2.1818e-03, result -2.4546e-01
+Hessian diagonal search: H+3260.8503*I, length 2.0594e-02, result -9.5302e-01
+Hessian diagonal search: H+2563.0542*I, length 2.4728e-02, result -8.8520e-01
+Hessian diagonal search: H+15297.9663*I, length 6.1200e-03, result -5.8256e-01
+Hessian diagonal search: H+146.3338*I, length 1.3372e-01, result -9.5269e-01
+Hessian diagonal search: H+1222.8116*I, length 4.2228e-02, result -1.3565e-01
+Hessian diagonal search: H+6812.1202*I, length 1.1646e-02, result -8.6002e-01
+Hessian diagonal search: H+4464.6325*I, length 1.6171e-02, result -9.5364e-01
+Hessian diagonal search: H+5302.9736*I, length 1.4152e-02, result -9.2482e-01
+Hessian diagonal search: H+3982.5526*I, length 1.7662e-02, result -9.6269e-01
+Hessian diagonal search: H+3848.7529*I, length 1.8133e-02, result -9.6351e-01
+Hessian diagonal search: H+3777.9714*I, length 1.8394e-02, result -9.6356e-01
+Hessian diagonal search: H+3800.0342*I, length 1.8312e-02, result -9.6358e-01
+Hessian diagonal search: H+3800.8066*I, length 1.8309e-02, result -9.6358e-01
+Hessian diagonal search: H+3796.5492*I, length 1.8325e-02, result -9.6358e-01
+Hessian diagonal search: H+3798.7029*I, length 1.8317e-02, result -9.6358e-01
+Optimization step found (length 1.8312e-02)
 #========================================================#
 #| [95m  Mathematical Parameters (Current + Step = Next)   [0m |#
 #========================================================#
-   0 [ -4.3276e-02 - 6.3050e-03 = -4.9581e-02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
-   1 [ -1.0373e-02 + 1.0520e-02 =  1.4637e-04 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [ -7.9359e-03 - 1.1015e-03 = -9.0374e-03 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [  6.1553e-02 - 2.8974e-03 =  5.8656e-02 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [ -9.9932e-03 - 1.2213e-03 = -1.1215e-02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
-   5 [  2.6641e-02 - 4.1593e-03 =  2.2481e-02 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
-   6 [  8.3834e-03 + 6.4980e-04 =  9.0332e-03 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
-   7 [  1.4957e-02 - 3.7088e-03 =  1.1248e-02 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
-   8 [ -1.1728e-02 - 1.4339e-03 = -1.3162e-02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [ -7.8159e-03 - 1.1661e-03 = -8.9820e-03 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [  1.7135e-02 + 1.9925e-03 =  1.9128e-02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [ -7.2372e-03 - 1.0636e-03 = -8.3008e-03 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [ -4.1113e-04 + 1.3762e-04 = -2.7351e-04 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [ -8.0178e-02 - 1.1468e-02 = -9.1646e-02 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [ -1.2276e-02 - 1.0465e-03 = -1.3323e-02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [  2.8276e-04 + 1.9781e-05 =  3.0254e-04 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [  1.8073e-03 + 2.4935e-04 =  2.0566e-03 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
-  17 [  2.0043e-19 + 2.3141e-20 =  2.2357e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [ -9.6491e-04 - 1.5446e-04 = -1.1194e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
-  19 [ -1.4495e-03 - 2.3493e-04 = -1.6844e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [ -3.6379e-03 - 5.0964e-04 = -4.1476e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
-  21 [ -5.6373e-03 - 7.7116e-04 = -6.4085e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [  1.0631e-05 - 3.9833e-06 =  6.6478e-06 ] : vdW/Atom/epsilon/[#6X4:1]
-  23 [  1.1486e-04 - 2.8626e-05 =  8.6232e-05 ] : vdW/Atom/rmin_half/[#6X4:1]
-  24 [ -2.5999e-05 - 7.4842e-06 = -3.3483e-05 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
-  25 [ -5.1006e-04 - 1.5194e-04 = -6.6200e-04 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+   0 [ -4.3266e-02 - 6.3080e-03 = -4.9574e-02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [ -1.0370e-02 + 1.0519e-02 =  1.4841e-04 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [ -7.9342e-03 - 1.1020e-03 = -9.0362e-03 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  6.1549e-02 - 2.8970e-03 =  5.8652e-02 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [ -9.9911e-03 - 1.2220e-03 = -1.1213e-02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  2.6637e-02 - 4.1597e-03 =  2.2477e-02 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [  8.3826e-03 + 6.5026e-04 =  9.0329e-03 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  1.4956e-02 - 3.7082e-03 =  1.1248e-02 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [ -1.1725e-02 - 1.4347e-03 = -1.3159e-02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [ -7.8140e-03 - 1.1667e-03 = -8.9807e-03 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [  1.7131e-02 + 1.9937e-03 =  1.9125e-02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [ -7.2362e-03 - 1.0642e-03 = -8.3004e-03 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [ -4.1081e-04 + 1.3756e-04 = -2.7325e-04 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [ -8.0159e-02 - 1.1474e-02 = -9.1633e-02 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [ -1.2273e-02 - 1.0470e-03 = -1.3320e-02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [  2.8256e-04 + 1.9802e-05 =  3.0236e-04 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [  1.8072e-03 + 2.4947e-04 =  2.0567e-03 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  3.8485e-19 - 5.4823e-20 =  3.3003e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [ -9.6500e-04 - 1.5460e-04 = -1.1196e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [ -1.4493e-03 - 2.3492e-04 = -1.6843e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [ -3.6370e-03 - 5.0987e-04 = -4.1469e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [ -5.6362e-03 - 7.7159e-04 = -6.4078e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  1.0616e-05 - 4.0541e-06 =  6.5619e-06 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  1.1434e-04 - 2.8635e-05 =  8.5705e-05 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [ -2.5988e-05 - 7.5551e-06 = -3.3543e-05 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [ -5.1010e-04 - 1.5191e-04 = -6.6201e-04 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
 ----------------------------------------------------------
 #========================================================#
 #| [95m    Physical Parameters (Current + Step = Next)     [0m |#
 #========================================================#
-   0 [  7.8105e+02 - 5.6745e+00 =  7.7538e+02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
-   1 [  1.3855e+00 + 1.4727e-02 =  1.4002e+00 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [  8.9286e+02 - 9.9138e-01 =  8.9187e+02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [  1.4092e+00 - 4.0563e-03 =  1.4051e+00 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [  6.7101e+02 - 1.0992e+00 =  6.6991e+02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
-   5 [  1.1273e+00 - 5.8231e-03 =  1.1215e+00 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
-   6 [  7.4155e+02 + 5.8482e-01 =  7.4213e+02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
-   7 [  1.1009e+00 - 5.1923e-03 =  1.0957e+00 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
-   8 [  1.0809e+02 - 1.7207e-01 =  1.0792e+02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [  6.8906e+01 - 1.6326e-01 =  6.8743e+01 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [  1.2206e+02 + 2.3910e-01 =  1.2230e+02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [  1.3899e+02 - 1.4891e-01 =  1.3884e+02 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [  1.1995e+02 + 1.6514e-02 =  1.1997e+02 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [  8.8775e+01 - 1.6056e+00 =  8.7169e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [  1.1853e+02 - 1.2558e-01 =  1.1840e+02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [  1.4004e+02 + 2.7693e-03 =  1.4004e+02 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [  3.6316e+00 + 9.0389e-04 =  3.6325e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+   0 [  7.8106e+02 - 5.6772e+00 =  7.7538e+02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [  1.3855e+00 + 1.4726e-02 =  1.4002e+00 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [  8.9286e+02 - 9.9177e-01 =  8.9187e+02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  1.4092e+00 - 4.0558e-03 =  1.4051e+00 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [  6.7101e+02 - 1.0998e+00 =  6.6991e+02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  1.1273e+00 - 5.8236e-03 =  1.1215e+00 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [  7.4154e+02 + 5.8524e-01 =  7.4213e+02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  1.1009e+00 - 5.1915e-03 =  1.0957e+00 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [  1.0809e+02 - 1.7216e-01 =  1.0792e+02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [  6.8906e+01 - 1.6333e-01 =  6.8743e+01 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [  1.2206e+02 + 2.3925e-01 =  1.2230e+02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [  1.3899e+02 - 1.4898e-01 =  1.3884e+02 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [  1.1995e+02 + 1.6507e-02 =  1.1997e+02 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [  8.8778e+01 - 1.6064e+00 =  8.7171e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [  1.1853e+02 - 1.2564e-01 =  1.1840e+02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [  1.4004e+02 + 2.7723e-03 =  1.4004e+02 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [  3.6316e+00 + 9.0434e-04 =  3.6325e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
   17 [  1.0500e+00 + 0.0000e+00 =  1.0500e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [  1.5536e-02 - 2.6259e-05 =  1.5510e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
-  19 [  1.4842e+00 - 4.4824e-04 =  1.4838e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [  1.4382e-02 - 8.6638e-05 =  1.4295e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
-  21 [  1.4482e+00 - 1.4714e-03 =  1.4468e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [  1.0940e-01 - 6.7716e-07 =  1.0940e-01 ] : vdW/Atom/epsilon/[#6X4:1]
-  23 [  1.9082e+00 - 5.4619e-05 =  1.9082e+00 ] : vdW/Atom/rmin_half/[#6X4:1]
-  24 [  1.7000e-01 - 1.2723e-06 =  1.6999e-01 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
-  25 [  1.6827e+00 - 2.8991e-04 =  1.6824e+00 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+  18 [  1.5536e-02 - 2.6282e-05 =  1.5510e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [  1.4842e+00 - 4.4822e-04 =  1.4838e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [  1.4382e-02 - 8.6677e-05 =  1.4295e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [  1.4482e+00 - 1.4722e-03 =  1.4468e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  1.0940e-01 - 6.8920e-07 =  1.0940e-01 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  1.9082e+00 - 5.4636e-05 =  1.9082e+00 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [  1.7000e-01 - 1.2844e-06 =  1.6999e-01 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [  1.6827e+00 - 2.8984e-04 =  1.6824e+00 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
 ----------------------------------------------------------
 Input file with saved parameters: optimize.sav
 #========================================================#
@@ -1210,7 +1176,7 @@ Input file with saved parameters: optimize.sav
 #========================================================#
 
 #======================================================================================================================#
-#| [92m                                         optgeo, Objective =  1.84704e+00                                         [0m |#
+#| [92m                                         optgeo, Objective =  1.84701e+00                                         [0m |#
 #| [92m  System                       Bonds            Angles           Dihedrals         Impropers               Term.  [0m |#
 #| [92m                            RMSD   denom      RMSD   denom      RMSD   denom      RMSD   denom                    [0m |#
 #======================================================================================================================#
@@ -1219,227 +1185,226 @@ Input file with saved parameters: optimize.sav
 
 #==========================================================================#
 #|                       Frequencies (wavenumbers)                        |#
-#|  Target: vibration  Type: Vibration_SMIRNOFF  Objective = 6.94733e+00  |#
+#|  Target: vibration  Type: Vibration_SMIRNOFF  Objective = 6.94823e+00  |#
 #|  Mode #            Reference   Calculated   Difference   Ref(dot)Calc  |#
 #==========================================================================#
-    0                   31.1817      55.0701      23.8884         0.9909 
-    1                  127.2863     138.4970      11.2107         0.9952 
-    2                  200.5311     226.7262      26.1951         0.9337 
-    3                  245.4174     231.7614     -13.6560         0.9373 
-    4                  258.8788     242.9387     -15.9401         0.9941 
-    5                  295.5887     324.2852      28.6965         0.9766 
-    6                  385.5805     330.0879     -55.4926         0.9893 
-    7                  413.3227     418.1638       4.8411         0.9725 
-    8                  461.1571     441.2076     -19.9495         0.9812 
-    9                  468.4759     458.8973      -9.5786         0.9885 
-    10                 553.9686     515.7862     -38.1824         0.9579 
-    11                 557.9183     545.2488     -12.6695         0.1064 
-    12                 559.2968     546.5318     -12.7650         0.1396 
-    13                 609.7540     605.3114      -4.4426         0.0013 
-    14                 650.9588     617.5928     -33.3660         0.0035 
-    15                 691.9021     625.5990     -66.3031         0.8076 
-    16                 731.3959     699.0976     -32.2983         0.1080 
-    17                 748.6224     701.7527     -46.8697         0.0300 
-    18                 757.4865     728.5729     -28.9136         0.0118 
-    19                 793.4162     751.7447     -41.6715         0.0011 
-    20                 796.3137     756.3240     -39.9897         0.9912 
-    21                 829.9391     764.2074     -65.7317         0.0015 
-    22                 886.2937     861.5266     -24.7671         0.0056 
-    23                 898.9488     869.3797     -29.5691         0.3103 
-    24                 905.1053     879.2275     -25.8778         0.0740 
-    25                 931.8180     916.7189     -15.0991         0.0036 
-    26                 972.6908     938.6899     -34.0009         0.0097 
-    27                 981.1443     944.4012     -36.7431         0.0218 
-    28                1002.3531     955.1698     -47.1833         0.0022 
-    29                1002.6108    1050.4586      47.8478         0.0563 
-    30                1006.9971    1053.9923      46.9952         0.4691 
-    31                1043.4229    1066.6914      23.2685         0.0007 
-    32                1045.2039    1084.9755      39.7716         0.0088 
-    33                1101.4212    1125.6299      24.2087         0.0177 
-    34                1122.1664    1126.0701       3.9037         0.0229 
-    35                1175.8590    1156.0643     -19.7947         0.0430 
-    36                1177.5535    1160.1384     -17.4151         0.0658 
-    37                1180.0345    1200.5891      20.5546         0.0171 
-    38                1198.0738    1216.4881      18.4143         0.0096 
-    39                1209.4283    1234.1208      24.6925         0.4301 
-    40                1213.4868    1262.5832      49.0964         0.0123 
-    41                1233.7197    1266.6749      32.9552         0.0115 
-    42                1248.6007    1351.6513     103.0506         0.0092 
-    43                1296.1008    1379.5389      83.4381         0.4244 
-    44                1311.1904    1421.1526     109.9622         0.2831 
-    45                1325.6114    1497.9134     172.3020         0.0213 
-    46                1351.5363    1534.9776     183.4413         0.0037 
-    47                1456.1390    1564.8002     108.6612         0.6062 
-    48                1461.1551    1585.0206     123.8655         0.0171 
-    49                1467.0845    1597.2314     130.1469         0.3403 
-    50                1486.3167    1625.6214     139.3047         0.6722 
-    51                1498.4933    1628.4883     129.9950         0.2392 
-    52                1571.5221    1676.5062     104.9841         0.5761 
-    53                1591.5923    1681.2694      89.6771         0.7246 
-    54                1597.5166    1717.8432     120.3266         0.0402 
-    55                1620.6702    1767.5262     146.8560         0.0266 
-    56                2881.8985    2892.0982      10.1997         0.8759 
-    57                2918.3100    2955.5115      37.2015         0.8772 
-    58                3057.8158    3079.6678      21.8520         0.2988 
-    59                3058.9610    3079.8177      20.8567         0.2589 
-    60                3076.7507    3080.3114       3.5607         0.2773 
-    61                3076.9099    3080.3861       3.4762         0.2965 
-    62                3093.3546    3081.3664     -11.9882         0.0843 
-    63                3093.7472    3081.4160     -12.3312         0.1175 
-    64                3108.9905    3081.9989     -26.9916         0.7705 
-    65                3109.6289    3082.3269     -27.3020         0.7921 
+    0                   31.1817      55.0704      23.8887         0.9909 
+    1                  127.2863     138.4966      11.2103         0.9952 
+    2                  200.5311     226.7258      26.1947         0.9337 
+    3                  245.4174     231.7612     -13.6562         0.9373 
+    4                  258.8788     242.9375     -15.9413         0.9941 
+    5                  295.5887     324.2849      28.6962         0.9766 
+    6                  385.5805     330.0884     -55.4921         0.9893 
+    7                  413.3227     418.1643       4.8416         0.9725 
+    8                  461.1571     441.2042     -19.9529         0.9812 
+    9                  468.4759     458.8936      -9.5823         0.9885 
+    10                 553.9686     515.7823     -38.1863         0.9579 
+    11                 557.9183     545.2486     -12.6697         0.1064 
+    12                 559.2968     546.5292     -12.7676         0.1396 
+    13                 609.7540     605.3111      -4.4429         0.0013 
+    14                 650.9588     617.5931     -33.3657         0.0035 
+    15                 691.9021     625.6003     -66.3018         0.8076 
+    16                 731.3959     699.0980     -32.2979         0.1080 
+    17                 748.6224     701.7506     -46.8718         0.0300 
+    18                 757.4865     728.5678     -28.9187         0.0118 
+    19                 793.4162     751.7463     -41.6699         0.0011 
+    20                 796.3137     756.3243     -39.9894         0.9912 
+    21                 829.9391     764.2071     -65.7320         0.0015 
+    22                 886.2937     861.5273     -24.7664         0.0056 
+    23                 898.9488     869.3804     -29.5684         0.3103 
+    24                 905.1053     879.2292     -25.8761         0.0740 
+    25                 931.8180     916.7190     -15.0990         0.0036 
+    26                 972.6908     938.6936     -33.9972         0.0097 
+    27                 981.1443     944.4009     -36.7434         0.0218 
+    28                1002.3531     955.1739     -47.1792         0.0022 
+    29                1002.6108    1050.4591      47.8483         0.0563 
+    30                1006.9971    1053.9927      46.9956         0.4691 
+    31                1043.4229    1066.6971      23.2742         0.0007 
+    32                1045.2039    1084.9819      39.7780         0.0088 
+    33                1101.4212    1125.6303      24.2091         0.0177 
+    34                1122.1664    1126.0705       3.9041         0.0229 
+    35                1175.8590    1156.0702     -19.7888         0.0430 
+    36                1177.5535    1160.1426     -17.4109         0.0658 
+    37                1180.0345    1200.5973      20.5628         0.0171 
+    38                1198.0738    1216.4953      18.4215         0.0096 
+    39                1209.4283    1234.1281      24.6998         0.4301 
+    40                1213.4868    1262.5878      49.1010         0.0123 
+    41                1233.7197    1266.6787      32.9590         0.0115 
+    42                1248.6007    1351.6602     103.0595         0.0092 
+    43                1296.1008    1379.5473      83.4465         0.4244 
+    44                1311.1904    1421.1616     109.9712         0.2831 
+    45                1325.6114    1497.9250     172.3136         0.0213 
+    46                1351.5363    1534.9916     183.4553         0.0037 
+    47                1456.1390    1564.8079     108.6689         0.6062 
+    48                1461.1551    1585.0293     123.8742         0.0171 
+    49                1467.0845    1597.2432     130.1587         0.3403 
+    50                1486.3167    1625.6323     139.3156         0.6723 
+    51                1498.4933    1628.4966     130.0033         0.2393 
+    52                1571.5221    1676.5153     104.9932         0.5761 
+    53                1591.5923    1681.2776      89.6853         0.7246 
+    54                1597.5166    1717.8517     120.3351         0.0402 
+    55                1620.6702    1767.5322     146.8620         0.0266 
+    56                2881.8985    2892.1005      10.2020         0.8759 
+    57                2918.3100    2955.5148      37.2048         0.8772 
+    58                3057.8158    3079.6672      21.8514         0.2988 
+    59                3058.9610    3079.8171      20.8561         0.2589 
+    60                3076.7507    3080.3108       3.5601         0.2773 
+    61                3076.9099    3080.3855       3.4756         0.2965 
+    62                3093.3546    3081.3658     -11.9888         0.0843 
+    63                3093.7472    3081.4154     -12.3318         0.1175 
+    64                3108.9905    3081.9983     -26.9922         0.7705 
+    65                3109.6289    3082.3263     -27.3026         0.7921 
 ----------------------------------------------------------------------------
 #===================================================================================#
 #| [94m                         Objective Function Breakdown                          [0m |#
 #| [94m  Target Name              Residual  x  Weight  =  Contribution (Current-Prev) [0m |#
 #===================================================================================#
-optgeo                         1.84704      1.000 [92m     1.84704e+00[0m ( -4.347e-01 ) 
-vibration                      6.94733      1.000 [92m     6.94733e+00[0m ( -5.310e-01 ) 
-Regularization                 0.01615      1.000 [91m     1.61522e-02[0m ( +2.041e-03 ) 
-Total                                             [92m     8.81052e+00[0m ( -9.637e-01 ) 
+optgeo                         1.84701      1.000 [92m     1.84701e+00[0m ( -4.342e-01 ) 
+vibration                      6.94823      1.000 [92m     6.94823e+00[0m ( -5.315e-01 ) 
+Regularization                 0.01615      1.000 [91m     1.61481e-02[0m ( +2.042e-03 ) 
+Total                                             [92m     8.81139e+00[0m ( -9.636e-01 ) 
 -------------------------------------------------------------------------------------
-Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_29.offxml
+Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_40.offxml
 #========================================================================#
 #|  The force field has been written to the result/optimize directory.  |#
 #|    Input file with optimization parameters saved to optimize.sav.    |#
 #========================================================================#
 
   Step       |k|        |dk|       |grad|       -=X2=-     Delta(X2)    StepQual
-     4   1.271e-01   1.831e-02   1.186e+02[92m   8.81052e+00[0m  -9.637e-01      1.000
+     4   1.271e-01   1.831e-02   1.186e+02[92m   8.81139e+00[0m  -9.636e-01      1.000
 
 #========================================================#
 #| [94m                   Total Gradient                   [0m |#
 #========================================================#
-   0 [  2.34867310e+01 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
-   1 [  9.72589162e+01 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [  4.27471247e+00 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [  1.02877936e+01 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [  4.64170765e+00 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
-   5 [  2.88536941e+01 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
-   6 [ -2.47133393e+00 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
-   7 [  3.08470534e+01 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
-   8 [  4.95488382e+00 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [  4.31527204e+00 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [ -7.57424266e+00 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [  4.17492522e+00 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [ -2.33162554e+00 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [  4.43361831e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [  3.76505266e+00 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [ -7.85280823e-02 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [ -1.39082620e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
-  17 [  4.47138443e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [  6.57035442e-01 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
-  19 [  1.06436432e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [  2.05874345e+00 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
-  21 [  3.28137632e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [  4.37813789e-02 ] : vdW/Atom/epsilon/[#6X4:1]
-  23 [  4.61013771e-01 ] : vdW/Atom/rmin_half/[#6X4:1]
-  24 [  4.31178039e-02 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
-  25 [  8.98260269e-01 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+   0 [  2.34890150e+01 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [  9.72890158e+01 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [  4.27492668e+00 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  1.02772717e+01 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [  4.64220685e+00 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  2.88402622e+01 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [ -2.47167542e+00 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  3.08341818e+01 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [  4.95574114e+00 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [  4.31574672e+00 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [ -7.57578690e+00 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [  4.17562812e+00 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [ -2.33103895e+00 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [  4.43406586e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [  3.76610889e+00 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [ -7.86478808e-02 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [ -1.39143025e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  6.60062517e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [  6.56539372e-01 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [  1.06401267e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [  2.05909971e+00 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [  3.28199450e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  4.35841796e-02 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  4.61790281e-01 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [  4.31981598e-02 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [  8.98550582e-01 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
 ----------------------------------------------------------
 Calculating nonlinear optimization step
-Finding trust radius: H+0.0000*I, length 5.7944e-01 (target 1.8308e-02)
-Finding trust radius: H+9.0000*I, length 2.8386e-01 (target 1.8308e-02)
-Finding trust radius: H+61.6869*I, length 1.6138e-01 (target 1.8308e-02)
-Finding trust radius: H+35.9545*I, length 1.8586e-01 (target 1.8308e-02)
-Finding trust radius: H+246.7477*I, length 1.0499e-01 (target 1.8308e-02)
-Finding trust radius: H+168.7764*I, length 1.2081e-01 (target 1.8308e-02)
-Finding trust radius: H+807.4923*I, length 5.6651e-02 (target 1.8308e-02)
-Finding trust radius: H+687.8426*I, length 6.2611e-02 (target 1.8308e-02)
-Finding trust radius: H+2398.9145*I, length 2.5842e-02 (target 1.8308e-02)
-Finding trust radius: H+1722.9545*I, length 3.3318e-02 (target 1.8308e-02)
-Finding trust radius: H+6764.9351*I, length 1.1295e-02 (target 1.8308e-02)
-Finding trust radius: H+4316.9631*I, length 1.6203e-02 (target 1.8308e-02)
-Finding trust radius: H+4316.9631*I, length 1.6203e-02 (target 1.8308e-02)
-Finding trust radius: H+3518.3004*I, length 1.9087e-02 (target 1.8308e-02)
-Finding trust radius: H+3065.5106*I, length 2.1300e-02 (target 1.8308e-02)
-Finding trust radius: H+3766.1951*I, length 1.8075e-02 (target 1.8308e-02)
-Finding trust radius: H+3722.7779*I, length 1.8244e-02 (target 1.8308e-02)
-Finding trust radius: H+3708.8760*I, length 1.8299e-02 (target 1.8308e-02)
-Finding trust radius: H+3706.3922*I, length 1.8308e-02 (target 1.8308e-02)
-Finding trust radius: H+3707.1457*I, length 1.8305e-02 (target 1.8308e-02)
-Finding trust radius: H+3705.6388*I, length 1.8311e-02 (target 1.8308e-02)
-Starting Hessian diagonal search with step size 1.8308e-02
-Hessian diagonal search: H+3706.3922*I, length 1.8308e-02, result -6.2710e-01
-Hessian diagonal search: H+60772.3988*I, length 1.7695e-03, result -1.9222e-01
-Hessian diagonal search: H+57356.6074*I, length 1.8654e-03, result -2.0162e-01
-Hessian diagonal search: H+3706.3922*I, length 1.8308e-02, result -6.2710e-01
-Hessian diagonal search: H+2900.0327*I, length 2.2259e-02, result -4.6323e-01
-Hessian diagonal search: H+17368.2040*I, length 5.2601e-03, result -4.7161e-01
-Hessian diagonal search: H+1609.9839*I, length 3.5053e-02, result  6.1285e-01
-Hessian diagonal search: H+7737.7919*I, length 1.0139e-02, result -6.7266e-01
-Hessian diagonal search: H+7044.9505*I, length 1.0933e-02, result -6.8756e-01
-Hessian diagonal search: H+6088.1911*I, length 1.2293e-02, result -7.0272e-01
-Hessian diagonal search: H+5109.0186*I, length 1.4153e-02, result -7.0329e-01
-Hessian diagonal search: H+5555.2892*I, length 1.3232e-02, result -7.0584e-01
-Hessian diagonal search: H+5563.2672*I, length 1.3217e-02, result -7.0583e-01
-Hessian diagonal search: H+5542.7925*I, length 1.3256e-02, result -7.0584e-01
-Hessian diagonal search: H+5375.0197*I, length 1.3587e-02, result -7.0550e-01
-Hessian diagonal search: H+5533.0406*I, length 1.3275e-02, result -7.0584e-01
-Hessian diagonal search: H+5535.8627*I, length 1.3269e-02, result -7.0584e-01
-Hessian diagonal search: H+5536.9848*I, length 1.3267e-02, result -7.0584e-01
-Hessian diagonal search: H+5539.2028*I, length 1.3263e-02, result -7.0584e-01
-Hessian diagonal search: H+5540.5738*I, length 1.3260e-02, result -7.0584e-01
-Optimization step found (length 1.3263e-02)
+Finding trust radius: H+0.0000*I, length 5.7937e-01 (target 1.8312e-02)
+Finding trust radius: H+9.0000*I, length 2.8384e-01 (target 1.8312e-02)
+Finding trust radius: H+61.6869*I, length 1.6138e-01 (target 1.8312e-02)
+Finding trust radius: H+35.9552*I, length 1.8586e-01 (target 1.8312e-02)
+Finding trust radius: H+246.7477*I, length 1.0500e-01 (target 1.8312e-02)
+Finding trust radius: H+168.7810*I, length 1.2081e-01 (target 1.8312e-02)
+Finding trust radius: H+807.4923*I, length 5.6657e-02 (target 1.8312e-02)
+Finding trust radius: H+687.8772*I, length 6.2615e-02 (target 1.8312e-02)
+Finding trust radius: H+2398.9145*I, length 2.5845e-02 (target 1.8312e-02)
+Finding trust radius: H+1722.9695*I, length 3.3322e-02 (target 1.8312e-02)
+Finding trust radius: H+6764.9351*I, length 1.1297e-02 (target 1.8312e-02)
+Finding trust radius: H+4316.8691*I, length 1.6205e-02 (target 1.8312e-02)
+Finding trust radius: H+4316.8691*I, length 1.6205e-02 (target 1.8312e-02)
+Finding trust radius: H+3518.2480*I, length 1.9089e-02 (target 1.8312e-02)
+Finding trust radius: H+3065.4803*I, length 2.1303e-02 (target 1.8312e-02)
+Finding trust radius: H+3765.7189*I, length 1.8080e-02 (target 1.8312e-02)
+Finding trust radius: H+3722.2039*I, length 1.8249e-02 (target 1.8312e-02)
+Finding trust radius: H+3708.3440*I, length 1.8303e-02 (target 1.8312e-02)
+Finding trust radius: H+3705.8660*I, length 1.8313e-02 (target 1.8312e-02)
+Finding trust radius: H+3706.6194*I, length 1.8310e-02 (target 1.8312e-02)
+Finding trust radius: H+3705.1127*I, length 1.8316e-02 (target 1.8312e-02)
+Starting Hessian diagonal search with step size 1.8313e-02
+Hessian diagonal search: H+3705.8660*I, length 1.8313e-02, result -6.2697e-01
+Hessian diagonal search: H+60763.8765*I, length 1.7700e-03, result -1.9230e-01
+Hessian diagonal search: H+57348.6301*I, length 1.8659e-03, result -2.0170e-01
+Hessian diagonal search: H+3705.8660*I, length 1.8313e-02, result -6.2697e-01
+Hessian diagonal search: H+2899.6352*I, length 2.2264e-02, result -4.6289e-01
+Hessian diagonal search: H+17365.7598*I, length 5.2614e-03, result -4.7176e-01
+Hessian diagonal search: H+1615.3334*I, length 3.4971e-02, result  6.0389e-01
+Hessian diagonal search: H+7736.6989*I, length 1.0142e-02, result -6.7280e-01
+Hessian diagonal search: H+7050.9060*I, length 1.0927e-02, result -6.8755e-01
+Hessian diagonal search: H+6090.5656*I, length 1.2291e-02, result -7.0278e-01
+Hessian diagonal search: H+5110.1269*I, length 1.4152e-02, result -7.0335e-01
+Hessian diagonal search: H+5556.7587*I, length 1.3231e-02, result -7.0591e-01
+Hessian diagonal search: H+5564.8210*I, length 1.3216e-02, result -7.0590e-01
+Hessian diagonal search: H+5543.0700*I, length 1.3257e-02, result -7.0591e-01
+Hessian diagonal search: H+5375.6228*I, length 1.3588e-02, result -7.0557e-01
+Hessian diagonal search: H+5535.6233*I, length 1.3272e-02, result -7.0591e-01
+Hessian diagonal search: H+5540.9652*I, length 1.3261e-02, result -7.0591e-01
+Hessian diagonal search: H+5548.2966*I, length 1.3247e-02, result -7.0591e-01
+Hessian diagonal search: H+5544.1936*I, length 1.3255e-02, result -7.0591e-01
+Optimization step found (length 1.3257e-02)
 #========================================================#
 #| [95m  Mathematical Parameters (Current + Step = Next)   [0m |#
 #========================================================#
-   0 [ -4.9581e-02 - 4.1539e-03 = -5.3735e-02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
-   1 [  1.4637e-04 - 9.3574e-03 = -9.2110e-03 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [ -9.0374e-03 - 7.5788e-04 = -9.7953e-03 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [  5.8656e-02 - 1.1469e-03 =  5.7509e-02 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [ -1.1215e-02 - 7.8897e-04 = -1.2004e-02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
-   5 [  2.2481e-02 - 1.7872e-03 =  2.0694e-02 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
-   6 [  9.0332e-03 + 3.3655e-04 =  9.3698e-03 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
-   7 [  1.1248e-02 + 1.1724e-03 =  1.2421e-02 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
-   8 [ -1.3162e-02 - 8.8904e-04 = -1.4051e-02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [ -8.9820e-03 - 7.7430e-04 = -9.7563e-03 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [  1.9128e-02 + 1.0853e-03 =  2.0213e-02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [ -8.3008e-03 - 7.7905e-04 = -9.0799e-03 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [ -2.7351e-04 + 2.7789e-04 =  4.3807e-06 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [ -9.1646e-02 - 7.7221e-03 = -9.9369e-02 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [ -1.3323e-02 - 7.3526e-04 = -1.4058e-02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [  3.0254e-04 + 1.4131e-05 =  3.1667e-04 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [  2.0566e-03 + 1.5146e-04 =  2.2081e-03 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
-  17 [  2.2357e-19 - 8.6934e-21 =  2.1488e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [ -1.1194e-03 - 1.1260e-04 = -1.2320e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
-  19 [ -1.6844e-03 - 1.7497e-04 = -1.8594e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [ -4.1476e-03 - 3.3690e-04 = -4.4845e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
-  21 [ -6.4085e-03 - 5.2379e-04 = -6.9323e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [  6.6478e-06 - 5.2325e-06 =  1.4153e-06 ] : vdW/Atom/epsilon/[#6X4:1]
-  23 [  8.6232e-05 - 5.2036e-05 =  3.4196e-05 ] : vdW/Atom/rmin_half/[#6X4:1]
-  24 [ -3.3483e-05 - 6.1423e-06 = -3.9626e-05 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
-  25 [ -6.6200e-04 - 1.2795e-04 = -7.8995e-04 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+   0 [ -4.9574e-02 - 4.1515e-03 = -5.3726e-02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [  1.4841e-04 - 9.3550e-03 = -9.2065e-03 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [ -9.0362e-03 - 7.5740e-04 = -9.7936e-03 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  5.8652e-02 - 1.1451e-03 =  5.7507e-02 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [ -1.1213e-02 - 7.8854e-04 = -1.2002e-02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  2.2477e-02 - 1.7849e-03 =  2.0693e-02 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [  9.0329e-03 + 3.3642e-04 =  9.3693e-03 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  1.1248e-02 + 1.1728e-03 =  1.2421e-02 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [ -1.3159e-02 - 8.8858e-04 = -1.4048e-02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [ -8.9807e-03 - 7.7384e-04 = -9.7546e-03 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [  1.9125e-02 + 1.0849e-03 =  2.0210e-02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [ -8.3004e-03 - 7.7864e-04 = -9.0790e-03 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [ -2.7325e-04 + 2.7773e-04 =  4.4730e-06 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [ -9.1633e-02 - 7.7176e-03 = -9.9350e-02 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [ -1.3320e-02 - 7.3489e-04 = -1.4055e-02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [  3.0236e-04 + 1.4140e-05 =  3.1650e-04 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [  2.0567e-03 + 1.5152e-04 =  2.2082e-03 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  3.3003e-19 - 6.9654e-21 =  3.2307e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [ -1.1196e-03 - 1.1243e-04 = -1.2320e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [ -1.6843e-03 - 1.7478e-04 = -1.8590e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [ -4.1469e-03 - 3.3674e-04 = -4.4836e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [ -6.4078e-03 - 5.2355e-04 = -6.9313e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  6.5619e-06 - 5.1908e-06 =  1.3711e-06 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  8.5705e-05 - 5.2139e-05 =  3.3566e-05 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [ -3.3543e-05 - 6.1564e-06 = -3.9700e-05 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [ -6.6201e-04 - 1.2791e-04 = -7.8992e-04 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
 ----------------------------------------------------------
 #========================================================#
 #| [95m    Physical Parameters (Current + Step = Next)     [0m |#
 #========================================================#
-   0 [  7.7538e+02 - 3.7385e+00 =  7.7164e+02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
-   1 [  1.4002e+00 - 1.3100e-02 =  1.3871e+00 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [  8.9187e+02 - 6.8209e-01 =  8.9118e+02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [  1.4051e+00 - 1.6057e-03 =  1.4035e+00 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [  6.6991e+02 - 7.1007e-01 =  6.6920e+02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
-   5 [  1.1215e+00 - 2.5021e-03 =  1.1190e+00 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
-   6 [  7.4213e+02 + 3.0290e-01 =  7.4243e+02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
-   7 [  1.0957e+00 + 1.6413e-03 =  1.0974e+00 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
-   8 [  1.0792e+02 - 1.0669e-01 =  1.0781e+02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [  6.8743e+01 - 1.0840e-01 =  6.8634e+01 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [  1.2230e+02 + 1.3023e-01 =  1.2243e+02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [  1.3884e+02 - 1.0907e-01 =  1.3873e+02 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [  1.1997e+02 + 3.3347e-02 =  1.2000e+02 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [  8.7169e+01 - 1.0811e+00 =  8.6088e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [  1.1840e+02 - 8.8232e-02 =  1.1831e+02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [  1.4004e+02 + 1.9783e-03 =  1.4004e+02 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [  3.6325e+00 + 5.4904e-04 =  3.6330e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+   0 [  7.7538e+02 - 3.7363e+00 =  7.7165e+02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [  1.4002e+00 - 1.3097e-02 =  1.3871e+00 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [  8.9187e+02 - 6.8166e-01 =  8.9119e+02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  1.4051e+00 - 1.6031e-03 =  1.4035e+00 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [  6.6991e+02 - 7.0968e-01 =  6.6920e+02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  1.1215e+00 - 2.4988e-03 =  1.1190e+00 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [  7.4213e+02 + 3.0278e-01 =  7.4243e+02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  1.0957e+00 + 1.6419e-03 =  1.0974e+00 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [  1.0792e+02 - 1.0663e-01 =  1.0781e+02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [  6.8743e+01 - 1.0834e-01 =  6.8634e+01 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [  1.2230e+02 + 1.3019e-01 =  1.2243e+02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [  1.3884e+02 - 1.0901e-01 =  1.3873e+02 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [  1.1997e+02 + 3.3327e-02 =  1.2000e+02 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [  8.7171e+01 - 1.0805e+00 =  8.6091e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [  1.1840e+02 - 8.8187e-02 =  1.1831e+02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [  1.4004e+02 + 1.9796e-03 =  1.4004e+02 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [  3.6325e+00 + 5.4925e-04 =  3.6330e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
   17 [  1.0500e+00 + 0.0000e+00 =  1.0500e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [  1.5510e-02 - 1.9142e-05 =  1.5491e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
-  19 [  1.4838e+00 - 3.3384e-04 =  1.4835e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [  1.4295e-02 - 5.7274e-05 =  1.4238e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
-  21 [  1.4468e+00 - 9.9939e-04 =  1.4458e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [  1.0940e-01 - 8.8952e-07 =  1.0940e-01 ] : vdW/Atom/epsilon/[#6X4:1]
-  23 [  1.9082e+00 - 9.9285e-05 =  1.9081e+00 ] : vdW/Atom/rmin_half/[#6X4:1]
-  24 [  1.6999e-01 - 1.0442e-06 =  1.6999e-01 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
-  25 [  1.6824e+00 - 2.4413e-04 =  1.6822e+00 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+  18 [  1.5510e-02 - 1.9114e-05 =  1.5491e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [  1.4838e+00 - 3.3348e-04 =  1.4835e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [  1.4295e-02 - 5.7246e-05 =  1.4238e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [  1.4468e+00 - 9.9894e-04 =  1.4458e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  1.0940e-01 - 8.8244e-07 =  1.0940e-01 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  1.9082e+00 - 9.9482e-05 =  1.9081e+00 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [  1.6999e-01 - 1.0466e-06 =  1.6999e-01 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [  1.6824e+00 - 2.4406e-04 =  1.6822e+00 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
 ----------------------------------------------------------
 Input file with saved parameters: optimize.sav
 #========================================================#
@@ -1448,234 +1413,235 @@ Input file with saved parameters: optimize.sav
 #========================================================#
 
 #======================================================================================================================#
-#| [92m                                         optgeo, Objective =  1.55358e+00                                         [0m |#
+#| [92m                                         optgeo, Objective =  1.55336e+00                                         [0m |#
 #| [92m  System                       Bonds            Angles           Dihedrals         Impropers               Term.  [0m |#
 #| [92m                            RMSD   denom      RMSD   denom      RMSD   denom      RMSD   denom                    [0m |#
 #======================================================================================================================#
-9HXanthene                    0.009    0.01     0.022    0.03     0.076    0.20     0.005    0.20             1.554 
+9HXanthene                    0.009    0.01     0.022    0.03     0.076    0.20     0.005    0.20             1.553 
 ------------------------------------------------------------------------------------------------------------------------
 
 #==========================================================================#
 #|                       Frequencies (wavenumbers)                        |#
-#|  Target: vibration  Type: Vibration_SMIRNOFF  Objective = 6.53297e+00  |#
+#|  Target: vibration  Type: Vibration_SMIRNOFF  Objective = 6.53400e+00  |#
 #|  Mode #            Reference   Calculated   Difference   Ref(dot)Calc  |#
 #==========================================================================#
-    0                   31.1817      55.6921      24.5104         0.9910 
-    1                  127.2863     139.5473      12.2610         0.9953 
-    2                  200.5311     228.2130      27.6819         0.9339 
-    3                  245.4174     233.4499     -11.9675         0.9372 
-    4                  258.8788     244.7044     -14.1744         0.9941 
-    5                  295.5887     326.6768      31.0881         0.9772 
-    6                  385.5805     331.2863     -54.2942         0.9894 
+    0                   31.1817      55.6920      24.5103         0.9910 
+    1                  127.2863     139.5466      12.2603         0.9953 
+    2                  200.5311     228.2120      27.6809         0.9339 
+    3                  245.4174     233.4493     -11.9681         0.9372 
+    4                  258.8788     244.7026     -14.1762         0.9941 
+    5                  295.5887     326.6755      31.0868         0.9772 
+    6                  385.5805     331.2864     -54.2941         0.9894 
     7                  413.3227     419.6700       6.3473         0.9739 
-    8                  461.1571     446.6665     -14.4906         0.9812 
-    9                  468.4759     464.2868      -4.1891         0.9887 
-    10                 553.9686     521.8708     -32.0978         0.9580 
-    11                 557.9183     550.6040      -7.3143         0.1065 
-    12                 559.2968     551.6414      -7.6554         0.1398 
-    13                 609.7540     611.6537       1.8997         0.0013 
-    14                 650.9588     620.4280     -30.5308         0.0034 
-    15                 691.9021     628.8386     -63.0635         0.8496 
-    16                 731.3959     704.9695     -26.4264         0.1071 
-    17                 748.6224     706.6819     -41.9405         0.0300 
-    18                 757.4865     735.8737     -21.6128         0.0119 
-    19                 793.4162     754.6613     -38.7549         0.0011 
-    20                 796.3137     756.9183     -39.3954         0.9830 
-    21                 829.9391     765.7701     -64.1690         0.0015 
-    22                 886.2937     866.4824     -19.8113         0.0055 
-    23                 898.9488     873.9310     -25.0178         0.3097 
-    24                 905.1053     880.2477     -24.8576         0.0753 
-    25                 931.8180     917.5760     -14.2420         0.0037 
-    26                 972.6908     938.2875     -34.4033         0.0094 
-    27                 981.1443     947.0362     -34.1081         0.0223 
-    28                1002.3531     953.9430     -48.4101         0.0022 
-    29                1002.6108    1050.8274      48.2166         0.0558 
-    30                1006.9971    1054.4269      47.4298         0.4717 
-    31                1043.4229    1064.5831      21.1602         0.0008 
-    32                1045.2039    1081.9608      36.7569         0.0082 
-    33                1101.4212    1125.8641      24.4429         0.0176 
-    34                1122.1664    1126.3292       4.1628         0.0227 
-    35                1175.8590    1153.6270     -22.2320         0.0516 
-    36                1177.5535    1160.7259     -16.8276         0.0792 
-    37                1180.0345    1196.9799      16.9454         0.0172 
-    38                1198.0738    1213.9811      15.9073         0.0105 
-    39                1209.4283    1231.7738      22.3455         0.4314 
-    40                1213.4868    1266.2901      52.8033         0.0123 
-    41                1233.7197    1266.9933      33.2736         0.0097 
-    42                1248.6007    1349.5879     100.9872         0.0096 
-    43                1296.1008    1380.2004      84.0996         0.3695 
-    44                1311.1904    1417.3846     106.1942         0.2934 
-    45                1325.6114    1493.1273     167.5159         0.0198 
-    46                1351.5363    1527.7607     176.2244         0.0035 
-    47                1456.1390    1561.6744     105.5354         0.6215 
-    48                1461.1551    1581.1897     120.0346         0.0153 
-    49                1467.0845    1591.5318     124.4473         0.3422 
-    50                1486.3167    1620.8415     134.5248         0.6537 
-    51                1498.4933    1623.9404     125.4471         0.2090 
-    52                1571.5221    1672.7372     101.2151         0.5796 
-    53                1591.5923    1678.7294      87.1371         0.7271 
-    54                1597.5166    1715.5378     118.0212         0.0408 
-    55                1620.6702    1767.6435     146.9733         0.0264 
-    56                2881.8985    2890.8484       8.9499         0.8759 
-    57                2918.3100    2953.9350      35.6250         0.8772 
-    58                3057.8158    3080.3979      22.5821         0.3017 
-    59                3058.9610    3080.5510      21.5900         0.2640 
-    60                3076.7507    3081.0678       4.3171         0.2705 
-    61                3076.9099    3081.1481       4.2382         0.2905 
-    62                3093.3546    3082.2496     -11.1050         0.0768 
-    63                3093.7472    3082.2984     -11.4488         0.1075 
-    64                3108.9905    3082.8945     -26.0960         0.7590 
-    65                3109.6289    3083.2224     -26.4065         0.7816 
+    8                  461.1571     446.6614     -14.4957         0.9812 
+    9                  468.4759     464.2815      -4.1944         0.9887 
+    10                 553.9686     521.8651     -32.1035         0.9580 
+    11                 557.9183     550.6023      -7.3160         0.1065 
+    12                 559.2968     551.6371      -7.6597         0.1398 
+    13                 609.7540     611.6519       1.8979         0.0013 
+    14                 650.9588     620.4277     -30.5311         0.0034 
+    15                 691.9021     628.8389     -63.0632         0.8496 
+    16                 731.3959     704.9684     -26.4275         0.1071 
+    17                 748.6224     706.6781     -41.9443         0.0300 
+    18                 757.4865     735.8667     -21.6198         0.0119 
+    19                 793.4162     754.6622     -38.7540         0.0011 
+    20                 796.3137     756.9175     -39.3962         0.9831 
+    21                 829.9391     765.7685     -64.1706         0.0015 
+    22                 886.2937     866.4821     -19.8116         0.0055 
+    23                 898.9488     873.9307     -25.0181         0.3097 
+    24                 905.1053     880.2480     -24.8573         0.0753 
+    25                 931.8180     917.5749     -14.2431         0.0037 
+    26                 972.6908     938.2918     -34.3990         0.0094 
+    27                 981.1443     947.0341     -34.1102         0.0223 
+    28                1002.3531     953.9480     -48.4051         0.0022 
+    29                1002.6108    1050.8268      48.2160         0.0558 
+    30                1006.9971    1054.4262      47.4291         0.4717 
+    31                1043.4229    1064.5900      21.1671         0.0008 
+    32                1045.2039    1081.9687      36.7648         0.0082 
+    33                1101.4212    1125.8634      24.4422         0.0176 
+    34                1122.1664    1126.3285       4.1621         0.0227 
+    35                1175.8590    1153.6344     -22.2246         0.0516 
+    36                1177.5535    1160.7304     -16.8231         0.0792 
+    37                1180.0345    1196.9897      16.9552         0.0172 
+    38                1198.0738    1213.9896      15.9158         0.0105 
+    39                1209.4283    1231.7821      22.3538         0.4314 
+    40                1213.4868    1266.2912      52.8044         0.0123 
+    41                1233.7197    1266.9973      33.2776         0.0097 
+    42                1248.6007    1349.5975     100.9968         0.0096 
+    43                1296.1008    1380.2068      84.1060         0.3696 
+    44                1311.1904    1417.3955     106.2051         0.2934 
+    45                1325.6114    1493.1407     167.5293         0.0198 
+    46                1351.5363    1527.7780     176.2417         0.0035 
+    47                1456.1390    1561.6839     105.5449         0.6215 
+    48                1461.1551    1581.2003     120.0452         0.0153 
+    49                1467.0845    1591.5467     124.4622         0.3422 
+    50                1486.3167    1620.8544     134.5377         0.6537 
+    51                1498.4933    1623.9510     125.4577         0.2091 
+    52                1571.5221    1672.7481     101.2260         0.5796 
+    53                1591.5923    1678.7390      87.1467         0.7271 
+    54                1597.5166    1715.5480     118.0314         0.0408 
+    55                1620.6702    1767.6498     146.9796         0.0264 
+    56                2881.8985    2890.8515       8.9530         0.8759 
+    57                2918.3100    2953.9391      35.6291         0.8772 
+    58                3057.8158    3080.3970      22.5812         0.3017 
+    59                3058.9610    3080.5502      21.5892         0.2640 
+    60                3076.7507    3081.0669       4.3162         0.2705 
+    61                3076.9099    3081.1472       4.2373         0.2906 
+    62                3093.3546    3082.2486     -11.1060         0.0768 
+    63                3093.7472    3082.2975     -11.4497         0.1075 
+    64                3108.9905    3082.8936     -26.0969         0.7590 
+    65                3109.6289    3083.2215     -26.4074         0.7816 
 ----------------------------------------------------------------------------
 #===================================================================================#
 #| [94m                         Objective Function Breakdown                          [0m |#
 #| [94m  Target Name              Residual  x  Weight  =  Contribution (Current-Prev) [0m |#
 #===================================================================================#
-optgeo                         1.55358      1.000 [92m     1.55358e+00[0m ( -2.935e-01 ) 
-vibration                      6.53297      1.000 [92m     6.53297e+00[0m ( -4.144e-01 ) 
-Regularization                 0.01812      1.000 [91m     1.81240e-02[0m ( +1.972e-03 ) 
-Total                                             [92m     8.10468e+00[0m ( -7.058e-01 ) 
+optgeo                         1.55336      1.000 [92m     1.55336e+00[0m ( -2.937e-01 ) 
+vibration                      6.53400      1.000 [92m     6.53400e+00[0m ( -4.142e-01 ) 
+Regularization                 0.01812      1.000 [91m     1.81186e-02[0m ( +1.971e-03 ) 
+Total                                             [92m     8.10548e+00[0m ( -7.059e-01 ) 
 -------------------------------------------------------------------------------------
-Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_30.offxml
+Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_41.offxml
 #========================================================================#
 #|  The force field has been written to the result/optimize directory.  |#
 #|    Input file with optimization parameters saved to optimize.sav.    |#
 #========================================================================#
 
   Step       |k|        |dk|       |grad|       -=X2=-     Delta(X2)    StepQual
-     5   1.346e-01   1.326e-02   8.817e+01[92m   8.10468e+00[0m  -7.058e-01      1.000
+     5   1.346e-01   1.326e-02   8.813e+01[92m   8.10548e+00[0m  -7.059e-01      1.000
 
 #========================================================#
 #| [94m                   Total Gradient                   [0m |#
 #========================================================#
-   0 [  2.38755306e+01 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
-   1 [ -4.74890477e+01 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [  4.22141032e+00 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [  7.84516851e+00 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [  4.36730313e+00 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
-   5 [  2.36886005e+01 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
-   6 [ -1.87443863e+00 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
-   7 [  4.85042706e+01 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
-   8 [  4.77168818e+00 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [  4.27686958e+00 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [ -5.07768294e+00 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [  4.51008729e+00 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [ -1.89753809e+00 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [  4.25723042e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [  4.00753299e+00 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [ -7.51841346e-02 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [ -8.30030909e-01 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
-  17 [  4.29751543e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [  6.62201311e-01 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
-  19 [  1.01273175e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [  1.89257455e+00 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
-  21 [  2.86370390e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [  1.94931802e-02 ] : vdW/Atom/epsilon/[#6X4:1]
-  23 [  1.57370858e-01 ] : vdW/Atom/rmin_half/[#6X4:1]
-  24 [  3.19248797e-02 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
-  25 [  6.34128704e-01 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+   0 [  2.38778195e+01 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [ -4.74234845e+01 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [  4.22151990e+00 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  7.83952486e+00 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [  4.36772711e+00 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  2.36810507e+01 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [ -1.87502663e+00 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  4.84944461e+01 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [  4.77242737e+00 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [  4.27682398e+00 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [ -5.08004213e+00 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [  4.51109038e+00 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [ -1.89826938e+00 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [  4.25774194e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [  4.00802127e+00 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [ -7.49305659e-02 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [ -8.30762607e-01 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  6.46131691e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [  6.61906007e-01 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [  1.01261067e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [  1.89269641e+00 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [  2.86450116e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  1.94475286e-02 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  1.57830334e-01 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [  3.20574953e-02 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [  6.34652892e-01 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
 ----------------------------------------------------------
 Calculating nonlinear optimization step
-Finding trust radius: H+0.0000*I, length 5.9537e-01 (target 1.3263e-02)
-Finding trust radius: H+9.0000*I, length 3.2753e-01 (target 1.3263e-02)
-Finding trust radius: H+61.6869*I, length 1.7457e-01 (target 1.3263e-02)
-Finding trust radius: H+40.0923*I, length 2.0541e-01 (target 1.3263e-02)
-Finding trust radius: H+246.7477*I, length 9.4223e-02 (target 1.3263e-02)
-Finding trust radius: H+170.0511*I, length 1.1260e-01 (target 1.3263e-02)
-Finding trust radius: H+807.4923*I, length 4.8271e-02 (target 1.3263e-02)
-Finding trust radius: H+583.5072*I, length 5.9123e-02 (target 1.3263e-02)
-Finding trust radius: H+2398.9145*I, length 2.1892e-02 (target 1.3263e-02)
-Finding trust radius: H+1702.4300*I, length 2.8540e-02 (target 1.3263e-02)
-Finding trust radius: H+6764.9351*I, length 9.3585e-03 (target 1.3263e-02)
-Finding trust radius: H+4421.9657*I, length 1.3335e-02 (target 1.3263e-02)
-Finding trust radius: H+4421.9657*I, length 1.3335e-02 (target 1.3263e-02)
-Finding trust radius: H+3576.7748*I, length 1.5875e-02 (target 1.3263e-02)
-Finding trust radius: H+5258.3306*I, length 1.1551e-02 (target 1.3263e-02)
-Finding trust radius: H+4549.8408*I, length 1.3024e-02 (target 1.3263e-02)
-Finding trust radius: H+4443.2750*I, length 1.3282e-02 (target 1.3263e-02)
-Finding trust radius: H+4451.5426*I, length 1.3262e-02 (target 1.3263e-02)
-Finding trust radius: H+4450.6390*I, length 1.3264e-02 (target 1.3263e-02)
-Finding trust radius: H+4449.7356*I, length 1.3266e-02 (target 1.3263e-02)
-Starting Hessian diagonal search with step size 1.3264e-02
-Hessian diagonal search: H+4450.6390*I, length 1.3264e-02, result -6.0637e-01
-Hessian diagonal search: H+72820.3388*I, length 1.1396e-03, result -9.5111e-02
-Hessian diagonal search: H+68629.9741*I, length 1.2052e-03, result -1.0026e-01
-Hessian diagonal search: H+4450.6390*I, length 1.3264e-02, result -6.0637e-01
-Hessian diagonal search: H+3461.4275*I, length 1.6305e-02, result -6.3194e-01
-Hessian diagonal search: H+18612.1125*I, length 3.9457e-03, result -2.8806e-01
-Hessian diagonal search: H+0.2733*I, length 5.7096e-01, result  1.0520e+02
-Hessian diagonal search: H+7827.2107*I, length 8.2791e-03, result -4.8832e-01
-Hessian diagonal search: H+1336.7083*I, length 3.4132e-02, result -3.4662e-01
-Hessian diagonal search: H+4921.6487*I, length 1.2204e-02, result -5.8976e-01
-Hessian diagonal search: H+2532.7482*I, length 2.0971e-02, result -6.1711e-01
-Hessian diagonal search: H+3988.9290*I, length 1.4517e-02, result -6.2071e-01
-Hessian diagonal search: H+3267.0095*I, length 1.7091e-02, result -6.3366e-01
-Hessian diagonal search: H+3140.0139*I, length 1.7649e-02, result -6.3375e-01
-Hessian diagonal search: H+3189.2041*I, length 1.7428e-02, result -6.3382e-01
-Hessian diagonal search: H+3190.3015*I, length 1.7423e-02, result -6.3382e-01
-Hessian diagonal search: H+3193.9013*I, length 1.7407e-02, result -6.3382e-01
-Hessian diagonal search: H+3191.6763*I, length 1.7417e-02, result -6.3382e-01
-Hessian diagonal search: H+3190.9283*I, length 1.7421e-02, result -6.3382e-01
-Optimization step found (length 1.7423e-02)
+Finding trust radius: H+0.0000*I, length 5.9536e-01 (target 1.3257e-02)
+Finding trust radius: H+9.0000*I, length 3.2753e-01 (target 1.3257e-02)
+Finding trust radius: H+61.6869*I, length 1.7460e-01 (target 1.3257e-02)
+Finding trust radius: H+40.0910*I, length 2.0544e-01 (target 1.3257e-02)
+Finding trust radius: H+246.7477*I, length 9.4243e-02 (target 1.3257e-02)
+Finding trust radius: H+170.0704*I, length 1.1262e-01 (target 1.3257e-02)
+Finding trust radius: H+807.4923*I, length 4.8275e-02 (target 1.3257e-02)
+Finding trust radius: H+583.5405*I, length 5.9128e-02 (target 1.3257e-02)
+Finding trust radius: H+2398.9145*I, length 2.1890e-02 (target 1.3257e-02)
+Finding trust radius: H+1702.3960*I, length 2.8539e-02 (target 1.3257e-02)
+Finding trust radius: H+6764.9351*I, length 9.3564e-03 (target 1.3257e-02)
+Finding trust radius: H+4422.1059*I, length 1.3333e-02 (target 1.3257e-02)
+Finding trust radius: H+4422.1059*I, length 1.3333e-02 (target 1.3257e-02)
+Finding trust radius: H+3576.8527*I, length 1.5873e-02 (target 1.3257e-02)
+Finding trust radius: H+5258.4251*I, length 1.1548e-02 (target 1.3257e-02)
+Finding trust radius: H+4551.1854*I, length 1.3019e-02 (target 1.3257e-02)
+Finding trust radius: H+4444.9451*I, length 1.3276e-02 (target 1.3257e-02)
+Finding trust radius: H+4453.0160*I, length 1.3256e-02 (target 1.3257e-02)
+Finding trust radius: H+4452.1121*I, length 1.3258e-02 (target 1.3257e-02)
+Finding trust radius: H+4451.2083*I, length 1.3260e-02 (target 1.3257e-02)
+Starting Hessian diagonal search with step size 1.3258e-02
+Hessian diagonal search: H+4452.1121*I, length 1.3258e-02, result -6.0644e-01
+Hessian diagonal search: H+72844.1727*I, length 1.1388e-03, result -9.5006e-02
+Hessian diagonal search: H+68652.2681*I, length 1.2043e-03, result -1.0015e-01
+Hessian diagonal search: H+4452.1121*I, length 1.3258e-02, result -6.0644e-01
+Hessian diagonal search: H+3462.5370*I, length 1.6299e-02, result -6.3227e-01
+Hessian diagonal search: H+18618.1372*I, length 3.9433e-03, result -2.8782e-01
+Hessian diagonal search: H+0.3122*I, length 5.6775e-01, result  1.0302e+02
+Hessian diagonal search: H+7829.7343*I, length 8.2749e-03, result -4.8811e-01
+Hessian diagonal search: H+1338.1391*I, length 3.4105e-02, result -3.4960e-01
+Hessian diagonal search: H+4923.2308*I, length 1.2198e-02, result -5.8976e-01
+Hessian diagonal search: H+2534.0870*I, length 2.0960e-02, result -6.1794e-01
+Hessian diagonal search: H+3990.2092*I, length 1.4511e-02, result -6.2088e-01
+Hessian diagonal search: H+3259.8144*I, length 1.7119e-02, result -6.3410e-01
+Hessian diagonal search: H+3132.0582*I, length 1.7683e-02, result -6.3418e-01
+Hessian diagonal search: H+3182.6998*I, length 1.7455e-02, result -6.3426e-01
+Hessian diagonal search: H+3183.7454*I, length 1.7450e-02, result -6.3426e-01
+Hessian diagonal search: H+3194.5453*I, length 1.7403e-02, result -6.3426e-01
+Hessian diagonal search: H+3187.8684*I, length 1.7432e-02, result -6.3426e-01
+Hessian diagonal search: H+3185.1259*I, length 1.7444e-02, result -6.3426e-01
+Hessian diagonal search: H+3184.3709*I, length 1.7448e-02, result -6.3426e-01
+Optimization step found (length 1.7450e-02)
 #========================================================#
 #| [95m  Mathematical Parameters (Current + Step = Next)   [0m |#
 #========================================================#
-   0 [ -5.3735e-02 - 6.5662e-03 = -6.0301e-02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
-   1 [ -9.2110e-03 + 9.0144e-03 = -1.9663e-04 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [ -9.7953e-03 - 1.1985e-03 = -1.0994e-02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [  5.7509e-02 - 1.6632e-03 =  5.5846e-02 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [ -1.2004e-02 - 1.2188e-03 = -1.3222e-02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
-   5 [  2.0694e-02 - 2.5285e-03 =  1.8166e-02 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
-   6 [  9.3698e-03 + 4.7525e-04 =  9.8450e-03 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
-   7 [  1.2421e-02 - 2.5857e-03 =  9.8349e-03 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
-   8 [ -1.4051e-02 - 1.4758e-03 = -1.5526e-02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [ -9.7563e-03 - 1.2973e-03 = -1.1054e-02 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [  2.0213e-02 + 1.9780e-03 =  2.2191e-02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [ -9.0799e-03 - 1.0893e-03 = -1.0169e-02 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [  4.3807e-06 + 2.7385e-05 =  3.1765e-05 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [ -9.9369e-02 - 1.2191e-02 = -1.1156e-01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [ -1.4058e-02 - 1.3088e-03 = -1.5367e-02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [  3.1667e-04 + 3.8226e-05 =  3.5489e-04 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [  2.2081e-03 + 1.7376e-04 =  2.3818e-03 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
-  17 [  2.1488e-19 + 1.8071e-20 =  2.3295e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [ -1.2320e-03 - 1.7335e-04 = -1.4053e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
-  19 [ -1.8594e-03 - 2.5915e-04 = -2.1186e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [ -4.4845e-03 - 4.8264e-04 = -4.9671e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
-  21 [ -6.9323e-03 - 7.2639e-04 = -7.6587e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [  1.4153e-06 - 8.9124e-07 =  5.2408e-07 ] : vdW/Atom/epsilon/[#6X4:1]
-  23 [  3.4196e-05 + 4.4764e-07 =  3.4644e-05 ] : vdW/Atom/rmin_half/[#6X4:1]
-  24 [ -3.9626e-05 - 6.6191e-06 = -4.6245e-05 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
-  25 [ -7.8995e-04 - 1.4167e-04 = -9.3163e-04 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+   0 [ -5.3726e-02 - 6.5790e-03 = -6.0305e-02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [ -9.2065e-03 + 9.0189e-03 = -1.8769e-04 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [ -9.7936e-03 - 1.2008e-03 = -1.0994e-02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  5.7507e-02 - 1.6655e-03 =  5.5842e-02 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [ -1.2002e-02 - 1.2212e-03 = -1.3223e-02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  2.0693e-02 - 2.5312e-03 =  1.8161e-02 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [  9.3693e-03 + 4.7613e-04 =  9.8454e-03 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  1.2421e-02 - 2.5882e-03 =  9.8324e-03 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [ -1.4048e-02 - 1.4790e-03 = -1.5527e-02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [ -9.7546e-03 - 1.2999e-03 = -1.1054e-02 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [  2.0210e-02 + 1.9825e-03 =  2.2193e-02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [ -9.0790e-03 - 1.0915e-03 = -1.0171e-02 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [  4.4730e-06 + 2.7113e-05 =  3.1586e-05 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [ -9.9350e-02 - 1.2216e-02 = -1.1157e-01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [ -1.4055e-02 - 1.3116e-03 = -1.5367e-02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [  3.1650e-04 + 3.8245e-05 =  3.5475e-04 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [  2.2082e-03 + 1.7411e-04 =  2.3823e-03 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  3.2307e-19 - 3.0171e-20 =  2.9289e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [ -1.2320e-03 - 1.7360e-04 = -1.4056e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [ -1.8590e-03 - 2.5960e-04 = -2.1186e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [ -4.4836e-03 - 4.8350e-04 = -4.9671e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [ -6.9313e-03 - 7.2787e-04 = -7.6592e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  1.3711e-06 - 8.6799e-07 =  5.0312e-07 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  3.3566e-05 + 3.7362e-07 =  3.3940e-05 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [ -3.9700e-05 - 6.6675e-06 = -4.6367e-05 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [ -7.8992e-04 - 1.4205e-04 = -9.3197e-04 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
 ----------------------------------------------------------
 #========================================================#
 #| [95m    Physical Parameters (Current + Step = Next)     [0m |#
 #========================================================#
-   0 [  7.7164e+02 - 5.9096e+00 =  7.6573e+02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
-   1 [  1.3871e+00 + 1.2620e-02 =  1.3997e+00 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [  8.9118e+02 - 1.0786e+00 =  8.9011e+02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [  1.4035e+00 - 2.3284e-03 =  1.4012e+00 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [  6.6920e+02 - 1.0969e+00 =  6.6810e+02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
-   5 [  1.1190e+00 - 3.5399e-03 =  1.1154e+00 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
-   6 [  7.4243e+02 + 4.2772e-01 =  7.4286e+02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
-   7 [  1.0974e+00 - 3.6200e-03 =  1.0938e+00 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
-   8 [  1.0781e+02 - 1.7709e-01 =  1.0764e+02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [  6.8634e+01 - 1.8162e-01 =  6.8452e+01 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [  1.2243e+02 + 2.3736e-01 =  1.2266e+02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [  1.3873e+02 - 1.5251e-01 =  1.3858e+02 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [  1.2000e+02 + 3.2862e-03 =  1.2000e+02 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [  8.6088e+01 - 1.7067e+00 =  8.4382e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [  1.1831e+02 - 1.5705e-01 =  1.1816e+02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [  1.4004e+02 + 5.3516e-03 =  1.4005e+02 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [  3.6330e+00 + 6.2988e-04 =  3.6336e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+   0 [  7.7165e+02 - 5.9211e+00 =  7.6573e+02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [  1.3871e+00 + 1.2626e-02 =  1.3997e+00 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [  8.9119e+02 - 1.0807e+00 =  8.9011e+02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  1.4035e+00 - 2.3317e-03 =  1.4012e+00 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [  6.6920e+02 - 1.0991e+00 =  6.6810e+02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  1.1190e+00 - 3.5437e-03 =  1.1154e+00 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [  7.4243e+02 + 4.2852e-01 =  7.4286e+02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  1.0974e+00 - 3.6234e-03 =  1.0938e+00 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [  1.0781e+02 - 1.7748e-01 =  1.0764e+02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [  6.8634e+01 - 1.8198e-01 =  6.8452e+01 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [  1.2243e+02 + 2.3790e-01 =  1.2266e+02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [  1.3873e+02 - 1.5281e-01 =  1.3858e+02 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [  1.2000e+02 + 3.2535e-03 =  1.2000e+02 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [  8.6091e+01 - 1.7102e+00 =  8.4381e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [  1.1831e+02 - 1.5739e-01 =  1.1816e+02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [  1.4004e+02 + 5.3544e-03 =  1.4005e+02 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [  3.6330e+00 + 6.3114e-04 =  3.6336e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
   17 [  1.0500e+00 + 0.0000e+00 =  1.0500e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [  1.5491e-02 - 2.9470e-05 =  1.5461e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
-  19 [  1.4835e+00 - 4.9445e-04 =  1.4830e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [  1.4238e-02 - 8.2049e-05 =  1.4156e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
-  21 [  1.4458e+00 - 1.3860e-03 =  1.4444e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [  1.0940e-01 - 1.5151e-07 =  1.0940e-01 ] : vdW/Atom/epsilon/[#6X4:1]
-  23 [  1.9081e+00 + 8.5411e-07 =  1.9081e+00 ] : vdW/Atom/rmin_half/[#6X4:1]
-  24 [  1.6999e-01 - 1.1252e-06 =  1.6999e-01 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
-  25 [  1.6822e+00 - 2.7031e-04 =  1.6819e+00 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+  18 [  1.5491e-02 - 2.9511e-05 =  1.5461e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [  1.4835e+00 - 4.9531e-04 =  1.4830e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [  1.4238e-02 - 8.2195e-05 =  1.4156e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [  1.4458e+00 - 1.3888e-03 =  1.4444e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  1.0940e-01 - 1.4756e-07 =  1.0940e-01 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  1.9081e+00 + 7.1288e-07 =  1.9081e+00 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [  1.6999e-01 - 1.1335e-06 =  1.6999e-01 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [  1.6822e+00 - 2.7104e-04 =  1.6819e+00 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
 ----------------------------------------------------------
 Input file with saved parameters: optimize.sav
 #========================================================#
@@ -1684,7 +1650,7 @@ Input file with saved parameters: optimize.sav
 #========================================================#
 
 #======================================================================================================================#
-#| [92m                                         optgeo, Objective =  1.50254e+00                                         [0m |#
+#| [92m                                         optgeo, Objective =  1.50312e+00                                         [0m |#
 #| [92m  System                       Bonds            Angles           Dihedrals         Impropers               Term.  [0m |#
 #| [92m                            RMSD   denom      RMSD   denom      RMSD   denom      RMSD   denom                    [0m |#
 #======================================================================================================================#
@@ -1693,227 +1659,228 @@ Input file with saved parameters: optimize.sav
 
 #==========================================================================#
 #|                       Frequencies (wavenumbers)                        |#
-#|  Target: vibration  Type: Vibration_SMIRNOFF  Objective = 5.94701e+00  |#
+#|  Target: vibration  Type: Vibration_SMIRNOFF  Objective = 5.94679e+00  |#
 #|  Mode #            Reference   Calculated   Difference   Ref(dot)Calc  |#
 #==========================================================================#
-    0                   31.1817      55.2436      24.0619         0.9909 
-    1                  127.2863     138.9480      11.6617         0.9953 
+    0                   31.1817      55.2434      24.0617         0.9909 
+    1                  127.2863     138.9475      11.6612         0.9953 
     2                  200.5311     228.0662      27.5351         0.9344 
-    3                  245.4174     231.5263     -13.8911         0.9373 
-    4                  258.8788     244.5161     -14.3627         0.9943 
-    5                  295.5887     325.9690      30.3803         0.9777 
-    6                  385.5805     329.6318     -55.9487         0.9892 
-    7                  413.3227     417.8966       4.5739         0.9721 
-    8                  461.1571     444.8661     -16.2910         0.9815 
-    9                  468.4759     462.4916      -5.9843         0.9887 
-    10                 553.9686     519.7282     -34.2404         0.9575 
-    11                 557.9183     544.1868     -13.7315         0.1063 
-    12                 559.2968     550.0503      -9.2465         0.1395 
-    13                 609.7540     603.5299      -6.2241         0.0013 
-    14                 650.9588     616.1266     -34.8322         0.0037 
-    15                 691.9021     624.4802     -67.4219         0.7616 
-    16                 731.3959     696.6215     -34.7744         0.1075 
-    17                 748.6224     705.9790     -42.6434         0.0300 
-    18                 757.4865     734.0609     -23.4256         0.0119 
-    19                 793.4162     748.6770     -44.7392         0.0011 
-    20                 796.3137     758.5534     -37.7603         0.9883 
-    21                 829.9391     766.9868     -62.9523         0.0015 
-    22                 886.2937     858.8046     -27.4891         0.0056 
-    23                 898.9488     866.9427     -32.0061         0.3101 
-    24                 905.1053     882.1138     -22.9915         0.0749 
-    25                 931.8180     919.4048     -12.4132         0.0037 
-    26                 972.6908     932.8491     -39.8417         0.0095 
-    27                 981.1443     948.4330     -32.7113         0.0221 
-    28                1002.3531     949.1002     -53.2529         0.0022 
-    29                1002.6108    1053.1268      50.5160         0.0558 
-    30                1006.9971    1056.7092      49.7121         0.4708 
-    31                1043.4229    1058.8718      15.4489         0.0008 
-    32                1045.2039    1076.3341      31.1302         0.0089 
-    33                1101.4212    1128.6808      27.2596         0.0176 
-    34                1122.1664    1129.1404       6.9740         0.0228 
-    35                1175.8590    1148.3666     -27.4924         0.0556 
-    36                1177.5535    1155.8710     -21.6825         0.0829 
-    37                1180.0345    1189.7968       9.7623         0.0170 
-    38                1198.0738    1207.7379       9.6641         0.0108 
-    39                1209.4283    1225.9259      16.4976         0.4288 
-    40                1213.4868    1261.1899      47.7031         0.3800 
-    41                1233.7197    1268.8443      35.1246         0.4276 
-    42                1248.6007    1342.9018      94.3011         0.0104 
-    43                1296.1008    1380.0027      83.9019         0.2798 
-    44                1311.1904    1410.1336      98.9432         0.3072 
-    45                1325.6114    1486.2218     160.6104         0.0177 
-    46                1351.5363    1516.7193     165.1830         0.0034 
-    47                1456.1390    1555.1680      99.0290         0.6267 
-    48                1461.1551    1573.4434     112.2883         0.0133 
-    49                1467.0845    1581.0447     113.9602         0.3468 
-    50                1486.3167    1612.1121     125.7954         0.6217 
-    51                1498.4933    1617.1151     118.6218         0.1704 
-    52                1571.5221    1663.9036      92.3815         0.5674 
-    53                1591.5923    1669.5822      77.9899         0.7242 
-    54                1597.5166    1705.0756     107.5590         0.0415 
-    55                1620.6702    1759.2012     138.5310         0.0262 
-    56                2881.8985    2888.6327       6.7342         0.8757 
-    57                2918.3100    2951.2274      32.9174         0.8773 
-    58                3057.8158    3080.9735      23.1577         0.2938 
-    59                3058.9610    3081.1215      22.1605         0.2541 
-    60                3076.7507    3081.6190       4.8683         0.2794 
-    61                3076.9099    3081.6927       4.7828         0.2967 
-    62                3093.3546    3082.7000     -10.6546         0.0902 
-    63                3093.7472    3082.7513     -10.9959         0.1239 
-    64                3108.9905    3083.3399     -25.6506         0.7757 
-    65                3109.6289    3083.6698     -25.9591         0.7963 
+    3                  245.4174     231.5244     -13.8930         0.9373 
+    4                  258.8788     244.5158     -14.3630         0.9943 
+    5                  295.5887     325.9689      30.3802         0.9777 
+    6                  385.5805     329.6305     -55.9500         0.9892 
+    7                  413.3227     417.8953       4.5726         0.9721 
+    8                  461.1571     444.8641     -16.2930         0.9815 
+    9                  468.4759     462.4895      -5.9864         0.9887 
+    10                 553.9686     519.7258     -34.2428         0.9575 
+    11                 557.9183     544.1809     -13.7374         0.1063 
+    12                 559.2968     550.0489      -9.2479         0.1395 
+    13                 609.7540     603.5225      -6.2315         0.0013 
+    14                 650.9588     616.1224     -34.8364         0.0037 
+    15                 691.9021     624.4772     -67.4249         0.7615 
+    16                 731.3959     696.6143     -34.7816         0.1075 
+    17                 748.6224     705.9785     -42.6439         0.0300 
+    18                 757.4865     734.0586     -23.4279         0.0119 
+    19                 793.4162     748.6723     -44.7439         0.0011 
+    20                 796.3137     758.5549     -37.7588         0.9883 
+    21                 829.9391     766.9879     -62.9512         0.0015 
+    22                 886.2937     858.7978     -27.4959         0.0056 
+    23                 898.9488     866.9366     -32.0122         0.3101 
+    24                 905.1053     882.1165     -22.9888         0.0749 
+    25                 931.8180     919.4064     -12.4116         0.0037 
+    26                 972.6908     932.8455     -39.8453         0.0095 
+    27                 981.1443     948.4347     -32.7096         0.0221 
+    28                1002.3531     949.0973     -53.2558         0.0022 
+    29                1002.6108    1053.1289      50.5181         0.0558 
+    30                1006.9971    1056.7113      49.7142         0.4708 
+    31                1043.4229    1058.8686      15.4457         0.0008 
+    32                1045.2039    1076.3312      31.1273         0.0089 
+    33                1101.4212    1128.6833      27.2621         0.0176 
+    34                1122.1664    1129.1429       6.9765         0.0228 
+    35                1175.8590    1148.3641     -27.4949         0.0556 
+    36                1177.5535    1155.8683     -21.6852         0.0829 
+    37                1180.0345    1189.7931       9.7586         0.0170 
+    38                1198.0738    1207.7349       9.6611         0.0108 
+    39                1209.4283    1225.9232      16.4949         0.4288 
+    40                1213.4868    1261.1858      47.6990         0.3800 
+    41                1233.7197    1268.8490      35.1293         0.4276 
+    42                1248.6007    1342.8986      94.2979         0.0104 
+    43                1296.1008    1380.0069      83.9061         0.2797 
+    44                1311.1904    1410.1303      98.9399         0.3072 
+    45                1325.6114    1486.2196     160.6082         0.0177 
+    46                1351.5363    1516.7140     165.1777         0.0034 
+    47                1456.1390    1555.1649      99.0259         0.6267 
+    48                1461.1551    1573.4393     112.2842         0.0133 
+    49                1467.0845    1581.0394     113.9549         0.3468 
+    50                1486.3167    1612.1079     125.7912         0.6217 
+    51                1498.4933    1617.1118     118.6185         0.1704 
+    52                1571.5221    1663.8987      92.3766         0.5673 
+    53                1591.5923    1669.5767      77.9844         0.7242 
+    54                1597.5166    1705.0689     107.5523         0.0415 
+    55                1620.6702    1759.1956     138.5254         0.0262 
+    56                2881.8985    2888.6317       6.7332         0.8757 
+    57                2918.3100    2951.2263      32.9163         0.8773 
+    58                3057.8158    3080.9740      23.1582         0.2938 
+    59                3058.9610    3081.1220      22.1610         0.2541 
+    60                3076.7507    3081.6195       4.8688         0.2794 
+    61                3076.9099    3081.6931       4.7832         0.2967 
+    62                3093.3546    3082.7003     -10.6543         0.0903 
+    63                3093.7472    3082.7516     -10.9956         0.1240 
+    64                3108.9905    3083.3403     -25.6502         0.7757 
+    65                3109.6289    3083.6701     -25.9588         0.7963 
 ----------------------------------------------------------------------------
 #===================================================================================#
 #| [94m                         Objective Function Breakdown                          [0m |#
 #| [94m  Target Name              Residual  x  Weight  =  Contribution (Current-Prev) [0m |#
 #===================================================================================#
-optgeo                         1.50254      1.000 [92m     1.50254e+00[0m ( -5.105e-02 ) 
-vibration                      5.94701      1.000 [92m     5.94701e+00[0m ( -5.860e-01 ) 
-Regularization                 0.02131      1.000 [91m     2.13116e-02[0m ( +3.188e-03 ) 
-Total                                             [92m     7.47086e+00[0m ( -6.338e-01 ) 
+optgeo                         1.50312      1.000 [92m     1.50312e+00[0m ( -5.024e-02 ) 
+vibration                      5.94679      1.000 [92m     5.94679e+00[0m ( -5.872e-01 ) 
+Regularization                 0.02131      1.000 [91m     2.13130e-02[0m ( +3.194e-03 ) 
+Total                                             [92m     7.47122e+00[0m ( -6.343e-01 ) 
 -------------------------------------------------------------------------------------
-Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_31.offxml
+Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_42.offxml
 #========================================================================#
 #|  The force field has been written to the result/optimize directory.  |#
 #|    Input file with optimization parameters saved to optimize.sav.    |#
 #========================================================================#
 
   Step       |k|        |dk|       |grad|       -=X2=-     Delta(X2)    StepQual
-     6   1.460e-01   1.742e-02   1.092e+02[92m   7.47086e+00[0m  -6.338e-01      1.000
+     6   1.460e-01   1.745e-02   1.093e+02[92m   7.47122e+00[0m  -6.343e-01      1.000
 
 #========================================================#
 #| [94m                   Total Gradient                   [0m |#
 #========================================================#
-   0 [  2.04046723e+01 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
-   1 [  9.50186385e+01 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [  4.02362853e+00 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [  2.81173432e+00 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [  3.88853243e+00 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
-   5 [  1.75093602e+01 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
-   6 [ -1.51712431e+00 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
-   7 [  2.16728508e+01 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
-   8 [  4.65105522e+00 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [  4.16300819e+00 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [ -4.99577587e+00 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [  3.59882734e+00 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [ -1.05605855e+00 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [  3.93429836e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [  3.86393127e+00 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [ -1.09311901e-01 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [ -5.37874379e-01 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
-  17 [  4.65893270e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [  4.91203884e-01 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
-  19 [  8.02694837e-01 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [  1.62663564e+00 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
-  21 [  2.59300954e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [  3.18680966e-02 ] : vdW/Atom/epsilon/[#6X4:1]
-  23 [  3.50441455e-01 ] : vdW/Atom/rmin_half/[#6X4:1]
-  24 [  3.47225503e-02 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
-  25 [  7.52218171e-01 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+   0 [  2.04024476e+01 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [  9.51613116e+01 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [  4.02329682e+00 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  2.80044011e+00 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [  3.88857424e+00 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  1.74959934e+01 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [ -1.51708825e+00 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  2.16440298e+01 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [  4.65099947e+00 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [  4.16328849e+00 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [ -4.99845240e+00 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [  3.59809471e+00 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [ -1.05728103e+00 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [  3.93413735e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [  3.86416340e+00 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [ -1.09436488e-01 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [ -5.37259269e-01 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  5.85789116e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [  4.90986848e-01 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [  8.02395265e-01 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [  1.62649535e+00 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [  2.59315385e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  3.18088871e-02 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  3.50405031e-01 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [  3.52287421e-02 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [  7.52360724e-01 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
 ----------------------------------------------------------
 Calculating nonlinear optimization step
-Finding trust radius: H+0.0000*I, length 6.0002e-01 (target 1.7423e-02)
-Finding trust radius: H+9.0000*I, length 2.7741e-01 (target 1.7423e-02)
-Finding trust radius: H+61.6869*I, length 1.4125e-01 (target 1.7423e-02)
-Finding trust radius: H+35.4808*I, length 1.6709e-01 (target 1.7423e-02)
-Finding trust radius: H+246.7477*I, length 9.1119e-02 (target 1.7423e-02)
-Finding trust radius: H+159.3607*I, length 1.0657e-01 (target 1.7423e-02)
-Finding trust radius: H+807.4923*I, length 5.0020e-02 (target 1.7423e-02)
-Finding trust radius: H+671.6884*I, length 5.5919e-02 (target 1.7423e-02)
-Finding trust radius: H+2398.9145*I, length 2.3153e-02 (target 1.7423e-02)
-Finding trust radius: H+1725.1005*I, length 2.9716e-02 (target 1.7423e-02)
-Finding trust radius: H+6764.9351*I, length 1.0186e-02 (target 1.7423e-02)
-Finding trust radius: H+2398.9145*I, length 2.3153e-02 (target 1.7423e-02)
-Finding trust radius: H+3805.2759*I, length 1.6120e-02 (target 1.7423e-02)
-Finding trust radius: H+4835.9536*I, length 1.3319e-02 (target 1.7423e-02)
-Finding trust radius: H+3731.3880*I, length 1.6373e-02 (target 1.7423e-02)
-Finding trust radius: H+3187.8293*I, length 1.8545e-02 (target 1.7423e-02)
-Finding trust radius: H+3464.4280*I, length 1.7366e-02 (target 1.7423e-02)
-Finding trust radius: H+3463.3046*I, length 1.7370e-02 (target 1.7423e-02)
-Finding trust radius: H+3448.4657*I, length 1.7429e-02 (target 1.7423e-02)
-Finding trust radius: H+3347.7027*I, length 1.7843e-02 (target 1.7423e-02)
-Finding trust radius: H+3449.9132*I, length 1.7423e-02 (target 1.7423e-02)
-Finding trust radius: H+3450.6149*I, length 1.7421e-02 (target 1.7423e-02)
-Finding trust radius: H+3449.2115*I, length 1.7426e-02 (target 1.7423e-02)
-Starting Hessian diagonal search with step size 1.7423e-02
-Hessian diagonal search: H+3449.9132*I, length 1.7423e-02, result -4.0633e-01
-Hessian diagonal search: H+56617.2738*I, length 1.7238e-03, result -1.7023e-01
-Hessian diagonal search: H+53466.6139*I, length 1.8151e-03, result -1.7824e-01
-Hessian diagonal search: H+3449.9132*I, length 1.7423e-02, result -4.0633e-01
-Hessian diagonal search: H+2706.1428*I, length 2.1087e-02, result -2.1257e-01
-Hessian diagonal search: H+16176.6043*I, length 5.0516e-03, result -4.0114e-01
-Hessian diagonal search: H+7962.5476*I, length 8.9413e-03, result -5.2984e-01
-Hessian diagonal search: H+8577.0286*I, length 8.4251e-03, result -5.2045e-01
-Hessian diagonal search: H+7060.5519*I, length 9.8433e-03, result -5.4110e-01
-Hessian diagonal search: H+5530.4119*I, length 1.1965e-02, result -5.4311e-01
-Hessian diagonal search: H+6147.7685*I, length 1.0995e-02, result -5.4633e-01
-Hessian diagonal search: H+6180.4480*I, length 1.0948e-02, result -5.4631e-01
-Hessian diagonal search: H+6131.4429*I, length 1.1018e-02, result -5.4633e-01
-Hessian diagonal search: H+6125.3564*I, length 1.1027e-02, result -5.4633e-01
-Hessian diagonal search: H+5894.5210*I, length 1.1371e-02, result -5.4589e-01
-Hessian diagonal search: H+6113.5055*I, length 1.1044e-02, result -5.4633e-01
-Hessian diagonal search: H+6124.1157*I, length 1.1029e-02, result -5.4633e-01
-Hessian diagonal search: H+6127.6490*I, length 1.1024e-02, result -5.4633e-01
-Optimization step found (length 1.1027e-02)
+Finding trust radius: H+0.0000*I, length 6.0016e-01 (target 1.7450e-02)
+Finding trust radius: H+9.0000*I, length 2.7742e-01 (target 1.7450e-02)
+Finding trust radius: H+61.6869*I, length 1.4121e-01 (target 1.7450e-02)
+Finding trust radius: H+35.4783*I, length 1.6706e-01 (target 1.7450e-02)
+Finding trust radius: H+246.7477*I, length 9.1105e-02 (target 1.7450e-02)
+Finding trust radius: H+159.3354*I, length 1.0655e-01 (target 1.7450e-02)
+Finding trust radius: H+807.4923*I, length 5.0024e-02 (target 1.7450e-02)
+Finding trust radius: H+671.6575*I, length 5.5922e-02 (target 1.7450e-02)
+Finding trust radius: H+2398.9145*I, length 2.3160e-02 (target 1.7450e-02)
+Finding trust radius: H+1725.0231*I, length 2.9723e-02 (target 1.7450e-02)
+Finding trust radius: H+6764.9351*I, length 1.0191e-02 (target 1.7450e-02)
+Finding trust radius: H+2398.9145*I, length 2.3160e-02 (target 1.7450e-02)
+Finding trust radius: H+3805.2759*I, length 1.6126e-02 (target 1.7450e-02)
+Finding trust radius: H+4835.9536*I, length 1.3324e-02 (target 1.7450e-02)
+Finding trust radius: H+3725.9986*I, length 1.6398e-02 (target 1.7450e-02)
+Finding trust radius: H+3184.7503*I, length 1.8566e-02 (target 1.7450e-02)
+Finding trust radius: H+3458.9496*I, length 1.7394e-02 (target 1.7450e-02)
+Finding trust radius: H+3457.9525*I, length 1.7397e-02 (target 1.7450e-02)
+Finding trust radius: H+3443.2376*I, length 1.7456e-02 (target 1.7450e-02)
+Finding trust radius: H+3343.3139*I, length 1.7867e-02 (target 1.7450e-02)
+Finding trust radius: H+3444.6683*I, length 1.7451e-02 (target 1.7450e-02)
+Finding trust radius: H+3445.3690*I, length 1.7448e-02 (target 1.7450e-02)
+Finding trust radius: H+3443.9677*I, length 1.7453e-02 (target 1.7450e-02)
+Starting Hessian diagonal search with step size 1.7451e-02
+Hessian diagonal search: H+3444.6683*I, length 1.7451e-02, result -4.0554e-01
+Hessian diagonal search: H+56532.2837*I, length 1.7277e-03, result -1.7076e-01
+Hessian diagonal search: H+53387.0347*I, length 1.8192e-03, result -1.7879e-01
+Hessian diagonal search: H+3444.6683*I, length 1.7451e-02, result -4.0554e-01
+Hessian diagonal search: H+2702.1752*I, length 2.1118e-02, result -2.1074e-01
+Hessian diagonal search: H+16152.2326*I, length 5.0613e-03, result -4.0209e-01
+Hessian diagonal search: H+8171.9668*I, length 8.7623e-03, result -5.2741e-01
+Hessian diagonal search: H+8584.7475*I, length 8.4238e-03, result -5.2099e-01
+Hessian diagonal search: H+7106.6755*I, length 9.7972e-03, result -5.4127e-01
+Hessian diagonal search: H+5553.0852*I, length 1.1932e-02, result -5.4390e-01
+Hessian diagonal search: H+6137.8934*I, length 1.1014e-02, result -5.4691e-01
+Hessian diagonal search: H+6186.0382*I, length 1.0946e-02, result -5.4688e-01
+Hessian diagonal search: H+6135.3381*I, length 1.1018e-02, result -5.4691e-01
+Hessian diagonal search: H+5909.5116*I, length 1.1353e-02, result -5.4651e-01
+Hessian diagonal search: H+6087.0120*I, length 1.1088e-02, result -5.4689e-01
+Hessian diagonal search: H+6124.5176*I, length 1.1034e-02, result -5.4691e-01
+Hessian diagonal search: H+6130.6302*I, length 1.1025e-02, result -5.4691e-01
+Hessian diagonal search: H+6133.5396*I, length 1.1021e-02, result -5.4691e-01
+Hessian diagonal search: H+6136.5809*I, length 1.1016e-02, result -5.4691e-01
+Optimization step found (length 1.1018e-02)
 #========================================================#
 #| [95m  Mathematical Parameters (Current + Step = Next)   [0m |#
 #========================================================#
-   0 [ -6.0301e-02 - 3.2710e-03 = -6.3572e-02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
-   1 [ -1.9663e-04 - 8.1514e-03 = -8.3480e-03 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [ -1.0994e-02 - 6.4396e-04 = -1.1638e-02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [  5.5846e-02 - 3.0935e-04 =  5.5536e-02 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [ -1.3222e-02 - 6.0104e-04 = -1.3823e-02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
-   5 [  1.8166e-02 - 5.9166e-04 =  1.7574e-02 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
-   6 [  9.8450e-03 + 1.8534e-04 =  1.0030e-02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
-   7 [  9.8349e-03 + 1.5735e-03 =  1.1408e-02 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
-   8 [ -1.5526e-02 - 7.5089e-04 = -1.6277e-02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [ -1.1054e-02 - 6.7151e-04 = -1.1725e-02 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [  2.2191e-02 + 6.8639e-04 =  2.2877e-02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [ -1.0169e-02 - 6.0416e-04 = -1.0773e-02 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [  3.1765e-05 + 1.2170e-04 =  1.5346e-04 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [ -1.1156e-01 - 6.1806e-03 = -1.1774e-01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [ -1.5367e-02 - 6.6014e-04 = -1.6027e-02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [  3.5489e-04 + 1.7636e-05 =  3.7253e-04 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [  2.3818e-03 + 4.2710e-05 =  2.4245e-03 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
-  17 [  2.3295e-19 + 1.7437e-20 =  2.5038e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [ -1.4053e-03 - 7.3189e-05 = -1.4785e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
-  19 [ -2.1186e-03 - 1.1402e-04 = -2.2326e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [ -4.9671e-03 - 2.3543e-04 = -5.2025e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
-  21 [ -7.6587e-03 - 3.6475e-04 = -8.0234e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [  5.2408e-07 - 2.8060e-06 = -2.2820e-06 ] : vdW/Atom/epsilon/[#6X4:1]
-  23 [  3.4644e-05 - 2.9258e-05 =  5.3863e-06 ] : vdW/Atom/rmin_half/[#6X4:1]
-  24 [ -4.6245e-05 - 4.2079e-06 = -5.0453e-05 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
-  25 [ -9.3163e-04 - 9.2983e-05 = -1.0246e-03 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+   0 [ -6.0305e-02 - 3.2656e-03 = -6.3571e-02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [ -1.8769e-04 - 8.1493e-03 = -8.3370e-03 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [ -1.0994e-02 - 6.4289e-04 = -1.1637e-02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  5.5842e-02 - 3.0778e-04 =  5.5534e-02 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [ -1.3223e-02 - 6.0013e-04 = -1.3823e-02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  1.8161e-02 - 5.8877e-04 =  1.7573e-02 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [  9.8454e-03 + 1.8508e-04 =  1.0030e-02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  9.8324e-03 + 1.5755e-03 =  1.1408e-02 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [ -1.5527e-02 - 7.4966e-04 = -1.6277e-02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [ -1.1054e-02 - 6.7046e-04 = -1.1725e-02 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [  2.2193e-02 + 6.8597e-04 =  2.2879e-02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [ -1.0171e-02 - 6.0310e-04 = -1.0774e-02 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [  3.1586e-05 + 1.2193e-04 =  1.5352e-04 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [ -1.1157e-01 - 6.1706e-03 = -1.1774e-01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [ -1.5367e-02 - 6.5909e-04 = -1.6026e-02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [  3.5475e-04 + 1.7622e-05 =  3.7237e-04 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [  2.3823e-03 + 4.2635e-05 =  2.4249e-03 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  2.9289e-19 - 1.4364e-20 =  2.7853e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [ -1.4056e-03 - 7.3029e-05 = -1.4787e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [ -2.1186e-03 - 1.1377e-04 = -2.2324e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [ -4.9671e-03 - 2.3503e-04 = -5.2022e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [ -7.6592e-03 - 3.6417e-04 = -8.0234e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  5.0312e-07 - 2.7919e-06 = -2.2888e-06 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  3.3940e-05 - 2.9182e-05 =  4.7572e-06 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [ -4.6367e-05 - 4.2867e-06 = -5.0654e-05 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [ -9.3197e-04 - 9.2839e-05 = -1.0248e-03 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
 ----------------------------------------------------------
 #========================================================#
 #| [95m    Physical Parameters (Current + Step = Next)     [0m |#
 #========================================================#
-   0 [  7.6573e+02 - 2.9439e+00 =  7.6278e+02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
-   1 [  1.3997e+00 - 1.1412e-02 =  1.3883e+00 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [  8.9011e+02 - 5.7956e-01 =  8.8953e+02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [  1.4012e+00 - 4.3309e-04 =  1.4008e+00 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [  6.6810e+02 - 5.4094e-01 =  6.6756e+02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
-   5 [  1.1154e+00 - 8.2832e-04 =  1.1146e+00 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
-   6 [  7.4286e+02 + 1.6680e-01 =  7.4303e+02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
-   7 [  1.0938e+00 + 2.2030e-03 =  1.0960e+00 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
-   8 [  1.0764e+02 - 9.0107e-02 =  1.0755e+02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [  6.8452e+01 - 9.4012e-02 =  6.8358e+01 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [  1.2266e+02 + 8.2367e-02 =  1.2275e+02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [  1.3858e+02 - 8.4582e-02 =  1.3849e+02 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [  1.2000e+02 + 1.4604e-02 =  1.2002e+02 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [  8.4382e+01 - 8.6528e-01 =  8.3516e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [  1.1816e+02 - 7.9217e-02 =  1.1808e+02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [  1.4005e+02 + 2.4690e-03 =  1.4005e+02 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [  3.6336e+00 + 1.5482e-04 =  3.6338e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+   0 [  7.6573e+02 - 2.9391e+00 =  7.6279e+02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [  1.3997e+00 - 1.1409e-02 =  1.3883e+00 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [  8.9011e+02 - 5.7860e-01 =  8.8953e+02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  1.4012e+00 - 4.3089e-04 =  1.4007e+00 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [  6.6810e+02 - 5.4012e-01 =  6.6756e+02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  1.1154e+00 - 8.2428e-04 =  1.1146e+00 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [  7.4286e+02 + 1.6657e-01 =  7.4303e+02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  1.0938e+00 + 2.2057e-03 =  1.0960e+00 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [  1.0764e+02 - 8.9959e-02 =  1.0755e+02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [  6.8452e+01 - 9.3865e-02 =  6.8359e+01 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [  1.2266e+02 + 8.2317e-02 =  1.2275e+02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [  1.3858e+02 - 8.4434e-02 =  1.3849e+02 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [  1.2000e+02 + 1.4632e-02 =  1.2002e+02 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [  8.4381e+01 - 8.6388e-01 =  8.3517e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [  1.1816e+02 - 7.9091e-02 =  1.1808e+02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [  1.4005e+02 + 2.4671e-03 =  1.4005e+02 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [  3.6336e+00 + 1.5455e-04 =  3.6338e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
   17 [  1.0500e+00 + 0.0000e+00 =  1.0500e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [  1.5461e-02 - 1.2442e-05 =  1.5449e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
-  19 [  1.4830e+00 - 2.1754e-04 =  1.4827e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [  1.4156e-02 - 4.0023e-05 =  1.4116e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
-  21 [  1.4444e+00 - 6.9593e-04 =  1.4437e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [  1.0940e-01 - 4.7703e-07 =  1.0940e-01 ] : vdW/Atom/epsilon/[#6X4:1]
-  23 [  1.9081e+00 - 5.5823e-05 =  1.9080e+00 ] : vdW/Atom/rmin_half/[#6X4:1]
-  24 [  1.6999e-01 - 7.1534e-07 =  1.6999e-01 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
-  25 [  1.6819e+00 - 1.7741e-04 =  1.6817e+00 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+  18 [  1.5461e-02 - 1.2415e-05 =  1.5449e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [  1.4830e+00 - 2.1708e-04 =  1.4827e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [  1.4156e-02 - 3.9955e-05 =  1.4116e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [  1.4444e+00 - 6.9484e-04 =  1.4437e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  1.0940e-01 - 4.7462e-07 =  1.0940e-01 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  1.9081e+00 - 5.5680e-05 =  1.9080e+00 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [  1.6999e-01 - 7.2874e-07 =  1.6999e-01 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [  1.6819e+00 - 1.7714e-04 =  1.6817e+00 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
 ----------------------------------------------------------
 Input file with saved parameters: optimize.sav
 #========================================================#
@@ -1922,7 +1889,7 @@ Input file with saved parameters: optimize.sav
 #========================================================#
 
 #======================================================================================================================#
-#| [92m                                         optgeo, Objective =  1.29323e+00                                         [0m |#
+#| [92m                                         optgeo, Objective =  1.29289e+00                                         [0m |#
 #| [92m  System                       Bonds            Angles           Dihedrals         Impropers               Term.  [0m |#
 #| [92m                            RMSD   denom      RMSD   denom      RMSD   denom      RMSD   denom                    [0m |#
 #======================================================================================================================#
@@ -1931,226 +1898,226 @@ Input file with saved parameters: optimize.sav
 
 #==========================================================================#
 #|                       Frequencies (wavenumbers)                        |#
-#|  Target: vibration  Type: Vibration_SMIRNOFF  Objective = 5.60797e+00  |#
+#|  Target: vibration  Type: Vibration_SMIRNOFF  Objective = 5.60809e+00  |#
 #|  Mode #            Reference   Calculated   Difference   Ref(dot)Calc  |#
 #==========================================================================#
-    0                   31.1817      55.7221      24.5404         0.9910 
-    1                  127.2863     139.8083      12.5220         0.9954 
-    2                  200.5311     229.1666      28.6355         0.9346 
-    3                  245.4174     232.9895     -12.4279         0.9372 
-    4                  258.8788     245.8812     -12.9976         0.9942 
-    5                  295.5887     327.7660      32.1773         0.9782 
-    6                  385.5805     330.6327     -54.9478         0.9893 
-    7                  413.3227     419.1024       5.7797         0.9734 
-    8                  461.1571     449.2510     -11.9061         0.9815 
-    9                  468.4759     466.8455      -1.6304         0.9888 
-    10                 553.9686     524.6481     -29.3205         0.9577 
-    11                 557.9183     548.8364      -9.0819         0.1064 
-    12                 559.2968     554.0938      -5.2030         0.1398 
-    13                 609.7540     609.0839      -0.6701         0.0013 
-    14                 650.9588     618.7161     -32.2427         0.0035 
-    15                 691.9021     627.0514     -64.8507         0.8093 
-    16                 731.3959     701.8030     -29.5929         0.1068 
-    17                 748.6224     709.5152     -39.1072         0.0300 
-    18                 757.4865     739.6851     -17.8014         0.0119 
-    19                 793.4162     751.2688     -42.1474         0.0011 
-    20                 796.3137     758.4729     -37.8408         0.9759 
-    21                 829.9391     767.7038     -62.2353         0.0015 
-    22                 886.2937     863.1591     -23.1346         0.0055 
-    23                 898.9488     870.9013     -28.0475         0.3095 
-    24                 905.1053     882.1413     -22.9640         0.0760 
-    25                 931.8180     919.3363     -12.4817         0.0037 
-    26                 972.6908     932.5001     -40.1907         0.0092 
-    27                 981.1443     947.9577     -33.1866         0.0092 
-    28                1002.3531     949.9343     -52.4188         0.2273 
-    29                1002.6108    1052.5069      49.8961         0.0554 
-    30                1006.9971    1056.1497      49.1526         0.4732 
-    31                1043.4229    1056.8674      13.4445         0.0007 
-    32                1045.2039    1073.5344      28.3305         0.0083 
+    0                   31.1817      55.7217      24.5400         0.9910 
+    1                  127.2863     139.8075      12.5212         0.9954 
+    2                  200.5311     229.1661      28.6350         0.9346 
+    3                  245.4174     232.9873     -12.4301         0.9372 
+    4                  258.8788     245.8803     -12.9985         0.9942 
+    5                  295.5887     327.7651      32.1764         0.9782 
+    6                  385.5805     330.6313     -54.9492         0.9893 
+    7                  413.3227     419.1008       5.7781         0.9734 
+    8                  461.1571     449.2472     -11.9099         0.9815 
+    9                  468.4759     466.8416      -1.6343         0.9888 
+    10                 553.9686     524.6438     -29.3248         0.9577 
+    11                 557.9183     548.8296      -9.0887         0.1064 
+    12                 559.2968     554.0907      -5.2061         0.1398 
+    13                 609.7540     609.0757      -0.6783         0.0013 
+    14                 650.9588     618.7122     -32.2466         0.0035 
+    15                 691.9021     627.0478     -64.8543         0.8092 
+    16                 731.3959     701.7950     -29.6009         0.1068 
+    17                 748.6224     709.5127     -39.1097         0.0300 
+    18                 757.4865     739.6807     -17.8058         0.0119 
+    19                 793.4162     751.2643     -42.1519         0.0011 
+    20                 796.3137     758.4725     -37.8412         0.9759 
+    21                 829.9391     767.7031     -62.2360         0.0015 
+    22                 886.2937     863.1523     -23.1414         0.0055 
+    23                 898.9488     870.8952     -28.0536         0.3095 
+    24                 905.1053     882.1420     -22.9633         0.0760 
+    25                 931.8180     919.3358     -12.4822         0.0037 
+    26                 972.6908     932.4986     -40.1922         0.0092 
+    27                 981.1443     947.9571     -33.1872         0.0092 
+    28                1002.3531     949.9338     -52.4193         0.2272 
+    29                1002.6108    1052.5067      49.8959         0.0554 
+    30                1006.9971    1056.1495      49.1524         0.4732 
+    31                1043.4229    1056.8671      13.4442         0.0007 
+    32                1045.2039    1073.5349      28.3310         0.0083 
     33                1101.4212    1127.8691      26.4479         0.0175 
     34                1122.1664    1128.3512       6.1848         0.0227 
-    35                1175.8590    1145.7641     -30.0949         0.0631 
-    36                1177.5535    1155.5331     -22.0204         0.0979 
-    37                1180.0345    1186.8593       6.8248         0.0167 
-    38                1198.0738    1205.1922       7.1184         0.0115 
-    39                1209.4283    1223.6235      14.1952         0.4293 
-    40                1213.4868    1261.5766      48.0898         0.3603 
-    41                1233.7197    1270.7510      37.0313         0.4276 
+    35                1175.8590    1145.7646     -30.0944         0.0630 
+    36                1177.5535    1155.5319     -22.0216         0.0979 
+    37                1180.0345    1186.8591       6.8246         0.0167 
+    38                1198.0738    1205.1923       7.1185         0.0115 
+    39                1209.4283    1223.6236      14.1953         0.4293 
+    40                1213.4868    1261.5741      48.0873         0.3603 
+    41                1233.7197    1270.7511      37.0314         0.4276 
     42                1248.6007    1340.1187      91.5180         0.0104 
-    43                1296.1008    1379.6551      83.5543         0.2572 
-    44                1311.1904    1406.1928      95.0024         0.3134 
-    45                1325.6114    1481.3145     155.7031         0.0165 
-    46                1351.5363    1510.3591     158.8228         0.0031 
-    47                1456.1390    1552.1557      96.0167         0.6414 
-    48                1461.1551    1570.2114     109.0563         0.0115 
-    49                1467.0845    1575.7950     108.7105         0.3475 
-    50                1486.3167    1608.2028     121.8861         0.6025 
-    51                1498.4933    1613.2053     114.7120         0.1525 
-    52                1571.5221    1660.8974      89.3753         0.5703 
-    53                1591.5923    1667.7712      76.1789         0.7234 
-    54                1597.5166    1703.3073     105.7907         0.0422 
-    55                1620.6702    1759.4945     138.8243         0.0259 
-    56                2881.8985    2887.7050       5.8065         0.8757 
-    57                2918.3100    2950.0071      31.6971         0.8774 
+    43                1296.1008    1379.6574      83.5566         0.2572 
+    44                1311.1904    1406.1938      95.0034         0.3134 
+    45                1325.6114    1481.3166     155.7052         0.0165 
+    46                1351.5363    1510.3609     158.8246         0.0031 
+    47                1456.1390    1552.1565      96.0175         0.6414 
+    48                1461.1551    1570.2121     109.0570         0.0115 
+    49                1467.0845    1575.7962     108.7117         0.3475 
+    50                1486.3167    1608.2037     121.8870         0.6025 
+    51                1498.4933    1613.2073     114.7140         0.1525 
+    52                1571.5221    1660.8973      89.3752         0.5703 
+    53                1591.5923    1667.7700      76.1777         0.7234 
+    54                1597.5166    1703.3054     105.7888         0.0422 
+    55                1620.6702    1759.4916     138.8214         0.0260 
+    56                2881.8985    2887.7055       5.8070         0.8757 
+    57                2918.3100    2950.0081      31.6981         0.8774 
     58                3057.8158    3081.4113      23.5955         0.2963 
     59                3058.9610    3081.5623      22.6013         0.2585 
     60                3076.7507    3082.0791       5.3284         0.2737 
     61                3076.9099    3082.1576       5.2477         0.2922 
-    62                3093.3546    3083.2723     -10.0823         0.0829 
-    63                3093.7472    3083.3229     -10.4243         0.1143 
-    64                3108.9905    3083.9198     -25.0707         0.7649 
-    65                3109.6289    3084.2492     -25.3797         0.7866 
+    62                3093.3546    3083.2722     -10.0824         0.0830 
+    63                3093.7472    3083.3228     -10.4244         0.1143 
+    64                3108.9905    3083.9196     -25.0709         0.7649 
+    65                3109.6289    3084.2490     -25.3799         0.7866 
 ----------------------------------------------------------------------------
 #===================================================================================#
 #| [94m                         Objective Function Breakdown                          [0m |#
 #| [94m  Target Name              Residual  x  Weight  =  Contribution (Current-Prev) [0m |#
 #===================================================================================#
-optgeo                         1.29323      1.000 [92m     1.29323e+00[0m ( -2.093e-01 ) 
-vibration                      5.60797      1.000 [92m     5.60797e+00[0m ( -3.390e-01 ) 
-Regularization                 0.02333      1.000 [91m     2.33287e-02[0m ( +2.017e-03 ) 
-Total                                             [92m     6.92452e+00[0m ( -5.463e-01 ) 
+optgeo                         1.29289      1.000 [92m     1.29289e+00[0m ( -2.102e-01 ) 
+vibration                      5.60809      1.000 [92m     5.60809e+00[0m ( -3.387e-01 ) 
+Regularization                 0.02333      1.000 [91m     2.33271e-02[0m ( +2.014e-03 ) 
+Total                                             [92m     6.92431e+00[0m ( -5.469e-01 ) 
 -------------------------------------------------------------------------------------
-Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_32.offxml
+Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_43.offxml
 #========================================================================#
 #|  The force field has been written to the result/optimize directory.  |#
 #|    Input file with optimization parameters saved to optimize.sav.    |#
 #========================================================================#
 
   Step       |k|        |dk|       |grad|       -=X2=-     Delta(X2)    StepQual
-     7   1.527e-01   1.103e-02   7.200e+01[92m   6.92452e+00[0m  -5.463e-01      1.000
+     7   1.527e-01   1.102e-02   7.192e+01[92m   6.92431e+00[0m  -5.469e-01      1.000
 
 #========================================================#
 #| [94m                   Total Gradient                   [0m |#
 #========================================================#
-   0 [  2.11455777e+01 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
-   1 [ -3.06965123e+01 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [  3.96458726e+00 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [  2.74455057e+00 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [  3.67728346e+00 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
-   5 [  1.59829405e+01 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
-   6 [ -1.14437805e+00 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
-   7 [  4.45431594e+01 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
-   8 [  4.32441415e+00 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [  4.12520421e+00 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [ -3.96663965e+00 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [  3.91353344e+00 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [ -2.57157224e+00 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [  3.76717628e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [  3.97852541e+00 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [ -1.03652547e-01 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [ -5.72281041e-01 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
-  17 [  5.00767215e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [  4.89611446e-01 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
-  19 [  7.51514870e-01 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [  1.50700858e+00 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
-  21 [  2.27536207e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [  1.25997929e-02 ] : vdW/Atom/epsilon/[#6X4:1]
-  23 [  1.01796106e-01 ] : vdW/Atom/rmin_half/[#6X4:1]
-  24 [  2.61797863e-02 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
-  25 [  5.35732093e-01 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+   0 [  2.11440791e+01 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [ -3.05276166e+01 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [  3.96494174e+00 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  2.73663300e+00 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [  3.67751280e+00 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  1.59788940e+01 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [ -1.14458578e+00 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  4.45352424e+01 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [  4.32476141e+00 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [  4.12584320e+00 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [ -3.96768924e+00 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [  3.91288522e+00 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [ -2.57203543e+00 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [  3.76718890e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [  3.97892370e+00 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [ -1.03798523e-01 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [ -5.72915136e-01 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  5.57061386e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [  4.89442441e-01 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [  7.51864412e-01 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [  1.50702270e+00 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [  2.27557205e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  1.25021282e-02 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  1.01956635e-01 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [  2.59734249e-02 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [  5.36232254e-01 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
 ----------------------------------------------------------
 Calculating nonlinear optimization step
-Finding trust radius: H+0.0000*I, length 6.0680e-01 (target 1.1027e-02)
-Finding trust radius: H+9.0000*I, length 3.1768e-01 (target 1.1027e-02)
-Finding trust radius: H+61.6869*I, length 1.6007e-01 (target 1.1027e-02)
-Finding trust radius: H+38.8398*I, length 1.9125e-01 (target 1.1027e-02)
-Finding trust radius: H+246.7477*I, length 8.4886e-02 (target 1.1027e-02)
-Finding trust radius: H+165.1674*I, length 1.0371e-01 (target 1.1027e-02)
-Finding trust radius: H+807.4923*I, length 4.2014e-02 (target 1.1027e-02)
-Finding trust radius: H+581.0699*I, length 5.2095e-02 (target 1.1027e-02)
-Finding trust radius: H+2398.9145*I, length 1.8532e-02 (target 1.1027e-02)
-Finding trust radius: H+1685.7881*I, length 2.4537e-02 (target 1.1027e-02)
-Finding trust radius: H+6764.9351*I, length 7.7770e-03 (target 1.1027e-02)
-Finding trust radius: H+4420.0446*I, length 1.1159e-02 (target 1.1027e-02)
-Finding trust radius: H+4420.0446*I, length 1.1159e-02 (target 1.1027e-02)
-Finding trust radius: H+3575.7069*I, length 1.3334e-02 (target 1.1027e-02)
-Finding trust radius: H+5257.0358*I, length 9.6370e-03 (target 1.1027e-02)
-Finding trust radius: H+4580.1059*I, length 1.0829e-02 (target 1.1027e-02)
-Finding trust radius: H+4480.2311*I, length 1.1033e-02 (target 1.1027e-02)
-Finding trust radius: H+4483.9170*I, length 1.1025e-02 (target 1.1027e-02)
-Finding trust radius: H+4482.9935*I, length 1.1027e-02 (target 1.1027e-02)
-Finding trust radius: H+4482.0836*I, length 1.1029e-02 (target 1.1027e-02)
-Starting Hessian diagonal search with step size 1.1027e-02
-Hessian diagonal search: H+4482.9935*I, length 1.1027e-02, result -4.8711e-01
-Hessian diagonal search: H+73343.8206*I, length 9.2586e-04, result -6.3555e-02
-Hessian diagonal search: H+69119.6284*I, length 9.7933e-04, result -6.7035e-02
-Hessian diagonal search: H+4482.9935*I, length 1.1027e-02, result -4.8711e-01
-Hessian diagonal search: H+3485.7964*I, length 1.3621e-02, result -5.4335e-01
-Hessian diagonal search: H+18744.4353*I, length 3.2245e-03, result -1.9939e-01
-Hessian diagonal search: H+29.1327*I, length 2.1227e-01, result  4.4311e+00
-Hessian diagonal search: H+7882.6352*I, length 6.8252e-03, result -3.5866e-01
-Hessian diagonal search: H+1486.1617*I, length 2.7040e-02, result -6.6302e-01
-Hessian diagonal search: H+670.1541*I, length 4.7553e-02, result -7.7444e-01
-Hessian diagonal search: H+326.1962*I, length 7.3141e-02, result -1.4816e+00
-Hessian diagonal search: H+174.8715*I, length 1.0089e-01, result -2.6501e+00
-Hessian diagonal search: H+104.7444*I, length 1.2800e-01, result -3.0274e+00
-Hessian diagonal search: H+55.4621*I, length 1.6697e-01, result -9.8323e-01
-Hessian diagonal search: H+129.4209*I, length 1.1633e-01, result -3.0238e+00
-Hessian diagonal search: H+116.2498*I, length 1.2217e-01, result -3.0590e+00
-Hessian diagonal search: H+116.4262*I, length 1.2208e-01, result -3.0589e+00
-Hessian diagonal search: H+115.9493*I, length 1.2231e-01, result -3.0590e+00
-Hessian diagonal search: H+115.9283*I, length 1.2232e-01, result -3.0590e+00
-Hessian diagonal search: H+115.9703*I, length 1.2230e-01, result -3.0590e+00
-Optimization step found (length 1.2231e-01)
+Finding trust radius: H+0.0000*I, length 6.0675e-01 (target 1.1018e-02)
+Finding trust radius: H+9.0000*I, length 3.1765e-01 (target 1.1018e-02)
+Finding trust radius: H+61.6869*I, length 1.6010e-01 (target 1.1018e-02)
+Finding trust radius: H+38.8370*I, length 1.9127e-01 (target 1.1018e-02)
+Finding trust radius: H+246.7477*I, length 8.4913e-02 (target 1.1018e-02)
+Finding trust radius: H+165.1940*I, length 1.0374e-01 (target 1.1018e-02)
+Finding trust radius: H+807.4923*I, length 4.2012e-02 (target 1.1018e-02)
+Finding trust radius: H+581.1447*I, length 5.2094e-02 (target 1.1018e-02)
+Finding trust radius: H+2398.9145*I, length 1.8524e-02 (target 1.1018e-02)
+Finding trust radius: H+1685.6420*I, length 2.4530e-02 (target 1.1018e-02)
+Finding trust radius: H+6764.9351*I, length 7.7714e-03 (target 1.1018e-02)
+Finding trust radius: H+4420.0839*I, length 1.1152e-02 (target 1.1018e-02)
+Finding trust radius: H+4420.0839*I, length 1.1152e-02 (target 1.1018e-02)
+Finding trust radius: H+3575.7288*I, length 1.3326e-02 (target 1.1018e-02)
+Finding trust radius: H+5257.0623*I, length 9.6306e-03 (target 1.1018e-02)
+Finding trust radius: H+4581.0818*I, length 1.0821e-02 (target 1.1018e-02)
+Finding trust radius: H+4481.4642*I, length 1.1023e-02 (target 1.1018e-02)
+Finding trust radius: H+4485.0074*I, length 1.1016e-02 (target 1.1018e-02)
+Finding trust radius: H+4484.0725*I, length 1.1018e-02 (target 1.1018e-02)
+Finding trust radius: H+4483.1623*I, length 1.1020e-02 (target 1.1018e-02)
+Starting Hessian diagonal search with step size 1.1018e-02
+Hessian diagonal search: H+4484.0725*I, length 1.1018e-02, result -4.8728e-01
+Hessian diagonal search: H+73361.2774*I, length 9.2470e-04, result -6.3413e-02
+Hessian diagonal search: H+69135.9568*I, length 9.7810e-04, result -6.6886e-02
+Hessian diagonal search: H+4484.0725*I, length 1.1018e-02, result -4.8728e-01
+Hessian diagonal search: H+3486.6090*I, length 1.3610e-02, result -5.4397e-01
+Hessian diagonal search: H+18748.8478*I, length 3.2209e-03, result -1.9905e-01
+Hessian diagonal search: H+29.6233*I, length 2.1102e-01, result  4.2863e+00
+Hessian diagonal search: H+7884.4834*I, length 6.8187e-03, result -3.5837e-01
+Hessian diagonal search: H+1487.8230*I, length 2.7009e-02, result -6.6718e-01
+Hessian diagonal search: H+671.7394*I, length 4.7481e-02, result -7.8428e-01
+Hessian diagonal search: H+327.5051*I, length 7.2999e-02, result -1.4905e+00
+Hessian diagonal search: H+175.9221*I, length 1.0063e-01, result -2.6514e+00
+Hessian diagonal search: H+105.6017*I, length 1.2758e-01, result -3.0331e+00
+Hessian diagonal search: H+53.6672*I, length 1.6917e-01, result -7.6394e-01
+Hessian diagonal search: H+130.3550*I, length 1.1598e-01, result -3.0251e+00
+Hessian diagonal search: H+116.5054*I, length 1.2209e-01, result -3.0621e+00
+Hessian diagonal search: H+116.9090*I, length 1.2190e-01, result -3.0620e+00
+Hessian diagonal search: H+116.4312*I, length 1.2212e-01, result -3.0621e+00
+Hessian diagonal search: H+116.3943*I, length 1.2214e-01, result -3.0621e+00
+Hessian diagonal search: H+116.4523*I, length 1.2211e-01, result -3.0621e+00
+Optimization step found (length 1.2212e-01)
 #========================================================#
 #| [95m  Mathematical Parameters (Current + Step = Next)   [0m |#
 #========================================================#
-   0 [ -6.3572e-02 - 4.0883e-02 = -1.0445e-01 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
-   1 [ -8.3480e-03 + 2.6363e-03 = -5.7117e-03 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [ -1.1638e-02 - 1.3674e-02 = -2.5311e-02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [  5.5536e-02 - 1.7565e-02 =  3.7971e-02 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [ -1.3823e-02 - 7.3349e-03 = -2.1158e-02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
-   5 [  1.7574e-02 + 5.2864e-03 =  2.2860e-02 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
-   6 [  1.0030e-02 + 1.1482e-03 =  1.1179e-02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
-   7 [  1.1408e-02 - 1.1631e-02 = -2.2229e-04 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
-   8 [ -1.6277e-02 - 2.5537e-02 = -4.1814e-02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [ -1.1725e-02 - 1.7587e-02 = -2.9312e-02 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [  2.2877e-02 + 1.1636e-02 =  3.4513e-02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [ -1.0773e-02 + 2.3226e-03 = -8.4507e-03 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [  1.5346e-04 - 3.6635e-03 = -3.5101e-03 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [ -1.1774e-01 - 1.0200e-01 = -2.1974e-01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [ -1.6027e-02 - 2.9860e-02 = -4.5887e-02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [  3.7253e-04 + 2.0710e-03 =  2.4435e-03 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [  2.4245e-03 - 9.2630e-03 = -6.8385e-03 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
-  17 [  2.5038e-19 + 1.1082e-19 =  3.6120e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [ -1.4785e-03 - 2.0820e-04 = -1.6867e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
-  19 [ -2.2326e-03 - 1.4625e-04 = -2.3788e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [ -5.2025e-03 + 3.9468e-03 = -1.2557e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
-  21 [ -8.0234e-03 + 5.5054e-03 = -2.5180e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [ -2.2820e-06 + 4.2171e-04 =  4.1943e-04 ] : vdW/Atom/epsilon/[#6X4:1]
-  23 [  5.3863e-06 + 4.1345e-03 =  4.1399e-03 ] : vdW/Atom/rmin_half/[#6X4:1]
-  24 [ -5.0453e-05 + 1.4058e-04 =  9.0130e-05 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
-  25 [ -1.0246e-03 + 1.5707e-03 =  5.4611e-04 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+   0 [ -6.3571e-02 - 4.0868e-02 = -1.0444e-01 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [ -8.3370e-03 + 2.5939e-03 = -5.7431e-03 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [ -1.1637e-02 - 1.3646e-02 = -2.5283e-02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  5.5534e-02 - 1.7484e-02 =  3.8050e-02 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [ -1.3823e-02 - 7.3285e-03 = -2.1151e-02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  1.7573e-02 + 5.2582e-03 =  2.2831e-02 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [  1.0030e-02 + 1.1477e-03 =  1.1178e-02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  1.1408e-02 - 1.1626e-02 = -2.1772e-04 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [ -1.6277e-02 - 2.5466e-02 = -4.1743e-02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [ -1.1725e-02 - 1.7557e-02 = -2.9282e-02 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [  2.2879e-02 + 1.1604e-02 =  3.4483e-02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [ -1.0774e-02 + 2.2713e-03 = -8.5023e-03 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [  1.5352e-04 - 3.6669e-03 = -3.5134e-03 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [ -1.1774e-01 - 1.0187e-01 = -2.1961e-01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [ -1.6026e-02 - 2.9760e-02 = -4.5786e-02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [  3.7237e-04 + 2.0633e-03 =  2.4356e-03 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [  2.4249e-03 - 9.2240e-03 = -6.7991e-03 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  2.7853e-19 + 9.3007e-19 =  1.2086e-18 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [ -1.4787e-03 - 2.1277e-04 = -1.6914e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [ -2.2324e-03 - 1.5799e-04 = -2.3904e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [ -5.2022e-03 + 3.9106e-03 = -1.2916e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [ -8.0234e-03 + 5.4531e-03 = -2.5702e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [ -2.2888e-06 + 4.2038e-04 =  4.1809e-04 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  4.7572e-06 + 4.1134e-03 =  4.1182e-03 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [ -5.0654e-05 + 1.4128e-04 =  9.0625e-05 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [ -1.0248e-03 + 1.5549e-03 =  5.3007e-04 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
 ----------------------------------------------------------
 #========================================================#
 #| [95m    Physical Parameters (Current + Step = Next)     [0m |#
 #========================================================#
-   0 [  7.6278e+02 - 3.6794e+01 =  7.2599e+02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
-   1 [  1.3883e+00 + 3.6908e-03 =  1.3920e+00 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [  8.8953e+02 - 1.2306e+01 =  8.7722e+02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [  1.4008e+00 - 2.4591e-02 =  1.3762e+00 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [  6.6756e+02 - 6.6014e+00 =  6.6096e+02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
-   5 [  1.1146e+00 + 7.4010e-03 =  1.1220e+00 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
-   6 [  7.4303e+02 + 1.0334e+00 =  7.4406e+02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
-   7 [  1.0960e+00 - 1.6283e-02 =  1.0797e+00 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
-   8 [  1.0755e+02 - 3.0644e+00 =  1.0448e+02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [  6.8358e+01 - 2.4622e+00 =  6.5896e+01 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [  1.2275e+02 + 1.3963e+00 =  1.2414e+02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [  1.3849e+02 + 3.2516e-01 =  1.3882e+02 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [  1.2002e+02 - 4.3962e-01 =  1.1958e+02 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [  8.3516e+01 - 1.4280e+01 =  6.9236e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [  1.1808e+02 - 3.5832e+00 =  1.1449e+02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [  1.4005e+02 + 2.8994e-01 =  1.4034e+02 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [  3.6338e+00 - 3.3578e-02 =  3.6002e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+   0 [  7.6279e+02 - 3.6782e+01 =  7.2600e+02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [  1.3883e+00 + 3.6314e-03 =  1.3920e+00 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [  8.8953e+02 - 1.2282e+01 =  8.7724e+02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  1.4007e+00 - 2.4477e-02 =  1.3763e+00 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [  6.6756e+02 - 6.5956e+00 =  6.6096e+02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  1.1146e+00 + 7.3615e-03 =  1.1220e+00 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [  7.4303e+02 + 1.0329e+00 =  7.4406e+02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  1.0960e+00 - 1.6276e-02 =  1.0797e+00 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [  1.0755e+02 - 3.0559e+00 =  1.0449e+02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [  6.8359e+01 - 2.4580e+00 =  6.5901e+01 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [  1.2275e+02 + 1.3925e+00 =  1.2414e+02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [  1.3849e+02 + 3.1798e-01 =  1.3881e+02 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [  1.2002e+02 - 4.4003e-01 =  1.1958e+02 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [  8.3517e+01 - 1.4262e+01 =  6.9255e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [  1.1808e+02 - 3.5712e+00 =  1.1451e+02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [  1.4005e+02 + 2.8886e-01 =  1.4034e+02 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [  3.6338e+00 - 3.3437e-02 =  3.6004e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
   17 [  1.0500e+00 + 0.0000e+00 =  1.0500e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [  1.5449e-02 - 3.5394e-05 =  1.5413e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
-  19 [  1.4827e+00 - 2.7904e-04 =  1.4825e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [  1.4116e-02 + 6.7096e-04 =  1.4787e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
-  21 [  1.4437e+00 + 1.0504e-02 =  1.4542e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [  1.0940e-01 + 7.1691e-05 =  1.0947e-01 ] : vdW/Atom/epsilon/[#6X4:1]
-  23 [  1.9080e+00 + 7.8887e-03 =  1.9159e+00 ] : vdW/Atom/rmin_half/[#6X4:1]
-  24 [  1.6999e-01 + 2.3899e-05 =  1.7002e-01 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
-  25 [  1.6817e+00 + 2.9969e-03 =  1.6847e+00 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+  18 [  1.5449e-02 - 3.6172e-05 =  1.5412e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [  1.4827e+00 - 3.0145e-04 =  1.4824e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [  1.4116e-02 + 6.6480e-04 =  1.4780e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [  1.4437e+00 + 1.0405e-02 =  1.4541e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  1.0940e-01 + 7.1465e-05 =  1.0947e-01 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  1.9080e+00 + 7.8484e-03 =  1.9159e+00 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [  1.6999e-01 + 2.4017e-05 =  1.7002e-01 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [  1.6817e+00 + 2.9667e-03 =  1.6847e+00 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
 ----------------------------------------------------------
 Input file with saved parameters: optimize.sav
 #========================================================#
@@ -2159,225 +2126,222 @@ Input file with saved parameters: optimize.sav
 #========================================================#
 
 #======================================================================================================================#
-#| [92m                                         optgeo, Objective =  1.47662e+00                                         [0m |#
+#| [92m                                         optgeo, Objective =  1.47099e+00                                         [0m |#
 #| [92m  System                       Bonds            Angles           Dihedrals         Impropers               Term.  [0m |#
 #| [92m                            RMSD   denom      RMSD   denom      RMSD   denom      RMSD   denom                    [0m |#
 #======================================================================================================================#
-9HXanthene                    0.009    0.01     0.020    0.03     0.076    0.20     0.005    0.20             1.477 
+9HXanthene                    0.009    0.01     0.020    0.03     0.076    0.20     0.005    0.20             1.471 
 ------------------------------------------------------------------------------------------------------------------------
 
 #==========================================================================#
 #|                       Frequencies (wavenumbers)                        |#
-#|  Target: vibration  Type: Vibration_SMIRNOFF  Objective = 2.32045e+00  |#
+#|  Target: vibration  Type: Vibration_SMIRNOFF  Objective = 2.32283e+00  |#
 #|  Mode #            Reference   Calculated   Difference   Ref(dot)Calc  |#
 #==========================================================================#
-    0                   31.1817      54.4408      23.2591         0.9915 
-    1                  127.2863     140.4399      13.1536         0.9960 
-    2                  200.5311     231.3739      30.8428         0.9370 
-    3                  245.4174     232.7053     -12.7121         0.9370 
-    4                  258.8788     251.0979      -7.7809         0.9951 
-    5                  295.5887     329.1513      33.5626         0.0300 
-    6                  385.5805     329.2290     -56.3515         0.0192 
-    7                  413.3227     421.3164       7.9937         0.9692 
-    8                  461.1571     459.9517      -1.2054         0.9817 
-    9                  468.4759     478.4757       9.9998         0.9894 
-    10                 553.9686     536.3937     -17.5749         0.9560 
-    11                 557.9183     542.4938     -15.4245         0.1058 
-    12                 559.2968     562.5964       3.2996         0.1397 
-    13                 609.7540     599.4021     -10.3519         0.0013 
-    14                 650.9588     611.5542     -39.4046         0.0039 
-    15                 691.9021     624.5629     -67.3392         0.5931 
-    16                 731.3959     689.7888     -41.6071         0.1041 
-    17                 748.6224     716.1265     -32.4959         0.0297 
-    18                 757.4865     736.9463     -20.5402         0.0017 
-    19                 793.4162     752.6970     -40.7192         0.0334 
-    20                 796.3137     765.9190     -30.3947         0.8073 
-    21                 829.9391     774.0307     -55.9084         0.0015 
-    22                 886.2937     849.0638     -37.2299         0.0056 
-    23                 898.9488     859.4488     -39.5000         0.3072 
-    24                 905.1053     882.5378     -22.5675         0.0752 
-    25                 931.8180     907.6878     -24.1302         0.0016 
-    26                 972.6908     921.9506     -50.7402         0.0018 
-    27                 981.1443     924.4704     -56.6739         0.0849 
-    28                1002.3531     956.2097     -46.1434         0.2269 
-    29                1002.6108    1019.8740      17.2632         0.0180 
-    30                1006.9971    1033.2925      26.2954         0.0259 
-    31                1043.4229    1057.1959      13.7730         0.0109 
-    32                1045.2039    1060.8552      15.6513         0.0182 
-    33                1101.4212    1099.2962      -2.1250         0.0029 
-    34                1122.1664    1110.6110     -11.5554         0.0009 
-    35                1175.8590    1134.3856     -41.4734         0.0170 
-    36                1177.5535    1134.9226     -42.6309         0.0164 
-    37                1180.0345    1148.1020     -31.9325         0.0098 
-    38                1198.0738    1161.9999     -36.0739         0.0147 
-    39                1209.4283    1179.3389     -30.0894         0.4164 
-    40                1213.4868    1237.6864      24.1996         0.2206 
-    41                1233.7197    1263.8429      30.1232         0.4278 
-    42                1248.6007    1280.4527      31.8520         0.0075 
-    43                1296.1008    1334.7561      38.6553         0.0316 
-    44                1311.1904    1343.6976      32.5072         0.0098 
-    45                1325.6114    1407.4147      81.8033         0.0060 
-    46                1351.5363    1423.9809      72.4446         0.0008 
-    47                1456.1390    1490.1134      33.9744         0.6133 
-    48                1461.1551    1494.1485      32.9934         0.1887 
-    49                1467.0845    1525.0383      57.9538         0.0139 
-    50                1486.3167    1553.0295      66.7128         0.3169 
-    51                1498.4933    1563.3096      64.8163         0.0669 
-    52                1571.5221    1610.7718      39.2497         0.5326 
-    53                1591.5923    1626.4832      34.8909         0.6207 
-    54                1597.5166    1650.2412      52.7246         0.0541 
-    55                1620.6702    1725.3408     104.6706         0.0240 
-    56                2881.8985    2877.5841      -4.3144         0.8738 
-    57                2918.3100    2931.4168      13.1068         0.8790 
-    58                3057.8158    3083.0127      25.1969         0.2672 
-    59                3058.9610    3083.1485      24.1875         0.2230 
-    60                3076.7507    3083.6474       6.8967         0.2742 
-    61                3076.9099    3083.7113       6.8014         0.2764 
-    62                3093.3546    3084.5733      -8.7813         0.1544 
-    63                3093.7472    3084.6391      -9.1081         0.1980 
-    64                3108.9905    3085.6275     -23.3630         0.8150 
-    65                3109.6289    3085.9775     -23.6514         0.8282 
+    0                   31.1817      54.4462      23.2645         0.9915 
+    1                  127.2863     140.4424      13.1561         0.9959 
+    2                  200.5311     231.3718      30.8407         0.9370 
+    3                  245.4174     232.7045     -12.7129         0.9370 
+    4                  258.8788     251.0855      -7.7933         0.9951 
+    5                  295.5887     329.1475      33.5588         0.0300 
+    6                  385.5805     329.2302     -56.3503         0.0192 
+    7                  413.3227     421.2953       7.9726         0.9693 
+    8                  461.1571     459.9399      -1.2172         0.9817 
+    9                  468.4759     478.4607       9.9848         0.9894 
+    10                 553.9686     536.3785     -17.5901         0.9560 
+    11                 557.9183     542.5088     -15.4095         0.1058 
+    12                 559.2968     562.5873       3.2905         0.1397 
+    13                 609.7540     599.4236     -10.3304         0.0013 
+    14                 650.9588     611.5660     -39.3928         0.0039 
+    15                 691.9021     624.5470     -67.3551         0.5935 
+    16                 731.3959     689.8105     -41.5854         0.1041 
+    17                 748.6224     716.1256     -32.4968         0.0297 
+    18                 757.4865     736.9637     -20.5228         0.0017 
+    19                 793.4162     752.6887     -40.7275         0.0334 
+    20                 796.3137     765.9049     -30.4088         0.8079 
+    21                 829.9391     774.0263     -55.9128         0.0015 
+    22                 886.2937     849.0871     -37.2066         0.0056 
+    23                 898.9488     859.4616     -39.4872         0.3072 
+    24                 905.1053     882.5487     -22.5566         0.0752 
+    25                 931.8180     907.7091     -24.1089         0.0016 
+    26                 972.6908     921.9711     -50.7197         0.0018 
+    27                 981.1443     924.4742     -56.6701         0.0849 
+    28                1002.3531     956.2050     -46.1481         0.2269 
+    29                1002.6108    1019.9161      17.3053         0.0180 
+    30                1006.9971    1033.3374      26.3403         0.0259 
+    31                1043.4229    1057.2071      13.7842         0.0109 
+    32                1045.2039    1060.8660      15.6621         0.0182 
+    33                1101.4212    1099.3640      -2.0572         0.0029 
+    34                1122.1664    1110.6857     -11.4807         0.0009 
+    35                1175.8590    1134.3949     -41.4641         0.0170 
+    36                1177.5535    1134.9316     -42.6219         0.0164 
+    37                1180.0345    1148.1457     -31.8888         0.0098 
+    38                1198.0738    1162.0529     -36.0209         0.0147 
+    39                1209.4283    1179.4012     -30.0271         0.4164 
+    40                1213.4868    1237.7128      24.2260         0.2209 
+    41                1233.7197    1263.8867      30.1670         0.4278 
+    42                1248.6007    1280.5439      31.9432         0.0075 
+    43                1296.1008    1334.8764      38.7756         0.0315 
+    44                1311.1904    1343.7844      32.5940         0.0098 
+    45                1325.6114    1407.5299      81.9185         0.0061 
+    46                1351.5363    1424.0969      72.5606         0.0008 
+    47                1456.1390    1490.2082      34.0692         0.6134 
+    48                1461.1551    1494.2582      33.1031         0.1887 
+    49                1467.0845    1525.0788      57.9943         0.0139 
+    50                1486.3167    1553.0872      66.7705         0.3173 
+    51                1498.4933    1563.3513      64.8580         0.0669 
+    52                1571.5221    1610.8231      39.3010         0.5326 
+    53                1591.5923    1626.5042      34.9119         0.6210 
+    54                1597.5166    1650.2955      52.7789         0.0540 
+    55                1620.6702    1725.3774     104.7072         0.0240 
+    56                2881.8985    2877.5868      -4.3117         0.8738 
+    57                2918.3100    2931.4412      13.1312         0.8790 
+    58                3057.8158    3083.0113      25.1955         0.2673 
+    59                3058.9610    3083.1472      24.1862         0.2232 
+    60                3076.7507    3083.6464       6.8957         0.2743 
+    61                3076.9099    3083.7104       6.8005         0.2766 
+    62                3093.3546    3084.5737      -8.7809         0.1541 
+    63                3093.7472    3084.6394      -9.1078         0.1975 
+    64                3108.9905    3085.6261     -23.3644         0.8148 
+    65                3109.6289    3085.9761     -23.6528         0.8281 
 ----------------------------------------------------------------------------
 #===================================================================================#
 #| [94m                         Objective Function Breakdown                          [0m |#
 #| [94m  Target Name              Residual  x  Weight  =  Contribution (Current-Prev) [0m |#
 #===================================================================================#
-optgeo                         1.47662      1.000 [91m     1.47662e+00[0m ( +1.834e-01 ) 
-vibration                      2.32045      1.000 [92m     2.32045e+00[0m ( -3.288e+00 ) 
-Regularization                 0.06848      1.000 [91m     6.84827e-02[0m ( +4.515e-02 ) 
-Total                                             [92m     3.86555e+00[0m ( -3.059e+00 ) 
+optgeo                         1.47099      1.000 [91m     1.47099e+00[0m ( +1.781e-01 ) 
+vibration                      2.32283      1.000 [92m     2.32283e+00[0m ( -3.285e+00 ) 
+Regularization                 0.06841      1.000 [91m     6.84052e-02[0m ( +4.508e-02 ) 
+Total                                             [92m     3.86223e+00[0m ( -3.062e+00 ) 
 -------------------------------------------------------------------------------------
-Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_33.offxml
+Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_44.offxml
 #========================================================================#
 #|  The force field has been written to the result/optimize directory.  |#
 #|    Input file with optimization parameters saved to optimize.sav.    |#
 #========================================================================#
 
   Step       |k|        |dk|       |grad|       -=X2=-     Delta(X2)    StepQual
-     8   2.617e-01   1.223e-01   8.216e+01[92m   3.86555e+00[0m  -3.059e+00      1.000
+     8   2.615e-01   1.221e-01   8.184e+01[92m   3.86223e+00[0m  -3.062e+00      1.000
 
 #========================================================#
 #| [94m                   Total Gradient                   [0m |#
 #========================================================#
-   0 [  9.42865008e+00 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
-   1 [  2.98670165e+01 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [  2.16693914e+00 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [ -3.90208049e+01 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [  8.28733396e-01 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
-   5 [  4.02923823e+01 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
-   6 [ -7.32745469e-02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
-   7 [ -4.52598802e+01 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
-   8 [ -1.68378233e+00 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [  1.48108822e+00 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [ -1.89937396e+00 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [  8.56641589e-01 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [ -1.79560463e+01 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [  1.37687849e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [  2.60923155e+00 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [ -2.04872706e-01 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [ -6.43456976e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
-  17 [  7.22399390e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [  2.52455120e-01 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
-  19 [  4.32475276e-01 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [  9.72539261e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
-  21 [  1.04603238e-01 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [ -3.81963426e-02 ] : vdW/Atom/epsilon/[#6X4:1]
-  23 [ -3.75680105e-01 ] : vdW/Atom/rmin_half/[#6X4:1]
-  24 [ -4.87981478e-03 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
-  25 [ -1.93623505e-02 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+   0 [  9.45039076e+00 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [  2.93560631e+01 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [  2.16863819e+00 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [ -3.88112135e+01 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [  8.31458212e-01 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  4.01866910e+01 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [ -7.40861004e-02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [ -4.52651864e+01 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [ -1.66909638e+00 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [  1.48524446e+00 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [ -1.92420102e+00 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [  8.61864688e-01 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [ -1.79531897e+01 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [  1.38124158e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [  2.59877458e+00 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [ -2.04773099e-01 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [ -6.44526141e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  2.41720873e-18 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [  2.53098406e-01 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [  4.32238111e-01 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [  1.00534834e-01 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [  1.08746072e-01 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [ -3.85313251e-02 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [ -3.76096000e-01 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [ -4.87573684e-03 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [ -1.84198514e-02 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
 ----------------------------------------------------------
 Calculating nonlinear optimization step
-Finding trust radius: H+0.0000*I, length 4.7654e-01 (target 1.2231e-01)
-Finding trust radius: H+9.0000*I, length 2.1798e-01 (target 1.2231e-01)
-Finding trust radius: H+61.6869*I, length 8.7751e-02 (target 1.2231e-01)
-Finding trust radius: H+31.3650*I, length 1.2015e-01 (target 1.2231e-01)
-Finding trust radius: H+31.3650*I, length 1.2015e-01 (target 1.2231e-01)
-Finding trust radius: H+21.2260*I, length 1.4521e-01 (target 1.2231e-01)
-Finding trust radius: H+41.7480*I, length 1.0493e-01 (target 1.2231e-01)
-Finding trust radius: H+32.0617*I, length 1.1889e-01 (target 1.2231e-01)
-Finding trust radius: H+29.5526*I, length 1.2364e-01 (target 1.2231e-01)
-Finding trust radius: H+26.2099*I, length 1.3103e-01 (target 1.2231e-01)
-Finding trust radius: H+30.2244*I, length 1.2231e-01 (target 1.2231e-01)
-Finding trust radius: H+30.2382*I, length 1.2228e-01 (target 1.2231e-01)
-Finding trust radius: H+30.2172*I, length 1.2232e-01 (target 1.2231e-01)
-Starting Hessian diagonal search with step size 1.2231e-01
-Hessian diagonal search: H+30.2244*I, length 1.2231e-01, result  2.0089e+01
-Hessian diagonal search: H+624.5340*I, length 3.1701e-02, result  4.3158e-01
-Hessian diagonal search: H+3195.7571*I, length 1.3529e-02, result -4.8642e-01
-Hessian diagonal search: H+1723.8446*I, length 1.9107e-02, result -3.7683e-01
-Hessian diagonal search: H+11570.0974*I, length 5.5563e-03, result -3.4636e-01
-Hessian diagonal search: H+3195.7571*I, length 1.3529e-02, result -4.8642e-01
-Hessian diagonal search: H+5779.6541*I, length 9.2767e-03, result -4.6018e-01
-Hessian diagonal search: H+1978.7984*I, length 1.7746e-02, result -4.1733e-01
-Hessian diagonal search: H+4004.2522*I, length 1.1792e-02, result -4.8820e-01
-Hessian diagonal search: H+3714.9651*I, length 1.2353e-02, result -4.8945e-01
-Hessian diagonal search: H+3676.6908*I, length 1.2432e-02, result -4.8948e-01
-Hessian diagonal search: H+3654.4909*I, length 1.2478e-02, result -4.8949e-01
-Hessian diagonal search: H+3657.9304*I, length 1.2471e-02, result -4.8949e-01
-Hessian diagonal search: H+3658.6741*I, length 1.2469e-02, result -4.8949e-01
-Hessian diagonal search: H+3665.5507*I, length 1.2455e-02, result -4.8949e-01
-Hessian diagonal search: H+3661.3000*I, length 1.2464e-02, result -4.8949e-01
-Hessian diagonal search: H+3659.6770*I, length 1.2467e-02, result -4.8949e-01
-Optimization step found (length 1.2469e-02)
+Finding trust radius: H+0.0000*I, length 4.7708e-01 (target 1.2212e-01)
+Finding trust radius: H+9.0000*I, length 2.1800e-01 (target 1.2212e-01)
+Finding trust radius: H+61.6869*I, length 8.7723e-02 (target 1.2212e-01)
+Finding trust radius: H+31.3691*I, length 1.2010e-01 (target 1.2212e-01)
+Finding trust radius: H+31.3691*I, length 1.2010e-01 (target 1.2212e-01)
+Finding trust radius: H+21.2280*I, length 1.4516e-01 (target 1.2212e-01)
+Finding trust radius: H+41.7509*I, length 1.0489e-01 (target 1.2212e-01)
+Finding trust radius: H+32.1318*I, length 1.1872e-01 (target 1.2212e-01)
+Finding trust radius: H+29.6435*I, length 1.2341e-01 (target 1.2212e-01)
+Finding trust radius: H+26.2636*I, length 1.3085e-01 (target 1.2212e-01)
+Finding trust radius: H+30.2942*I, length 1.2212e-01 (target 1.2212e-01)
+Finding trust radius: H+30.3067*I, length 1.2210e-01 (target 1.2212e-01)
+Finding trust radius: H+30.2870*I, length 1.2214e-01 (target 1.2212e-01)
+Starting Hessian diagonal search with step size 1.2212e-01
+Hessian diagonal search: H+30.2942*I, length 1.2212e-01, result  2.0110e+01
+Hessian diagonal search: H+625.8038*I, length 3.1659e-02, result  4.2600e-01
+Hessian diagonal search: H+3202.1151*I, length 1.3485e-02, result -4.8484e-01
+Hessian diagonal search: H+1726.7019*I, length 1.9064e-02, result -3.7721e-01
+Hessian diagonal search: H+11592.9262*I, length 5.5297e-03, result -3.4382e-01
+Hessian diagonal search: H+3202.1151*I, length 1.3485e-02, result -4.8484e-01
+Hessian diagonal search: H+5791.1014*I, length 9.2388e-03, result -4.5761e-01
+Hessian diagonal search: H+1982.7537*I, length 1.7700e-02, result -4.1728e-01
+Hessian diagonal search: H+3993.6133*I, length 1.1783e-02, result -4.8626e-01
+Hessian diagonal search: H+3690.7496*I, length 1.2374e-02, result -4.8757e-01
+Hessian diagonal search: H+3658.7174*I, length 1.2441e-02, result -4.8759e-01
+Hessian diagonal search: H+3638.9116*I, length 1.2482e-02, result -4.8759e-01
+Hessian diagonal search: H+3639.6515*I, length 1.2481e-02, result -4.8759e-01
+Hessian diagonal search: H+3637.6782*I, length 1.2485e-02, result -4.8759e-01
+Optimization step found (length 1.2482e-02)
 #========================================================#
 #| [95m  Mathematical Parameters (Current + Step = Next)   [0m |#
 #========================================================#
-   0 [ -1.0445e-01 - 2.3121e-03 = -1.0677e-01 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
-   1 [ -5.7117e-03 - 4.8454e-03 = -1.0557e-02 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [ -2.5311e-02 - 5.2194e-04 = -2.5833e-02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [  3.7971e-02 + 5.4651e-03 =  4.3436e-02 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [ -2.1158e-02 - 2.1092e-04 = -2.1369e-02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
-   5 [  2.2860e-02 - 4.8735e-03 =  1.7987e-02 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
-   6 [  1.1179e-02 + 7.4608e-06 =  1.1186e-02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
-   7 [ -2.2229e-04 + 6.1944e-03 =  5.9721e-03 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
-   8 [ -4.1814e-02 + 4.8838e-04 = -4.1326e-02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [ -2.9312e-02 - 4.4526e-04 = -2.9758e-02 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [  3.4513e-02 + 7.7614e-04 =  3.5289e-02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [ -8.4507e-03 - 1.9217e-04 = -8.6429e-03 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [ -3.5101e-03 + 4.5607e-03 =  1.0507e-03 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [ -2.1974e-01 - 3.0508e-03 = -2.2279e-01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [ -4.5887e-02 - 5.5713e-04 = -4.6445e-02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [  2.4435e-03 + 5.1347e-05 =  2.4949e-03 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [ -6.8385e-03 + 1.6801e-03 = -5.1584e-03 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
-  17 [  3.6120e-19 - 1.0471e-20 =  3.5073e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [ -1.6867e-03 - 6.0888e-05 = -1.7476e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
-  19 [ -2.3788e-03 - 9.5179e-05 = -2.4740e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [ -1.2557e-03 + 2.6338e-05 = -1.2294e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
-  21 [ -2.5180e-03 + 4.4997e-05 = -2.4730e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [  4.1943e-04 + 1.2353e-05 =  4.3178e-04 ] : vdW/Atom/epsilon/[#6X4:1]
-  23 [  4.1399e-03 + 1.2174e-04 =  4.2617e-03 ] : vdW/Atom/rmin_half/[#6X4:1]
-  24 [  9.0130e-05 + 2.3114e-06 =  9.2441e-05 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
-  25 [  5.4611e-04 + 1.6937e-05 =  5.6304e-04 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+   0 [ -1.0444e-01 - 2.3261e-03 = -1.0677e-01 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [ -5.7431e-03 - 4.7970e-03 = -1.0540e-02 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [ -2.5283e-02 - 5.2476e-04 = -2.5808e-02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  3.8050e-02 + 5.4571e-03 =  4.3507e-02 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [ -2.1151e-02 - 2.1261e-04 = -2.1364e-02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  2.2831e-02 - 4.8779e-03 =  1.7953e-02 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [  1.1178e-02 + 7.9451e-06 =  1.1186e-02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [ -2.1772e-04 + 6.2229e-03 =  6.0052e-03 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [ -4.1743e-02 + 4.8692e-04 = -4.1256e-02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [ -2.9282e-02 - 4.4866e-04 = -2.9731e-02 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [  3.4483e-02 + 7.8774e-04 =  3.5270e-02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [ -8.5023e-03 - 1.9316e-04 = -8.6955e-03 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [ -3.5134e-03 + 4.5845e-03 =  1.0712e-03 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [ -2.1961e-01 - 3.0727e-03 = -2.2268e-01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [ -4.5786e-02 - 5.5809e-04 = -4.6344e-02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [  2.4356e-03 + 5.1687e-05 =  2.4873e-03 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [ -6.7991e-03 + 1.6923e-03 = -5.1068e-03 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  1.2086e-18 - 2.7045e-20 =  1.1816e-18 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [ -1.6914e-03 - 6.1317e-05 = -1.7527e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [ -2.3904e-03 - 9.5539e-05 = -2.4859e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [ -1.2916e-03 + 2.6105e-05 = -1.2655e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [ -2.5702e-03 + 4.4818e-05 = -2.5254e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  4.1809e-04 + 1.2529e-05 =  4.3062e-04 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  4.1182e-03 + 1.2263e-04 =  4.2408e-03 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [  9.0625e-05 + 2.3334e-06 =  9.2958e-05 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [  5.3007e-04 + 1.6995e-05 =  5.4706e-04 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
 ----------------------------------------------------------
 #========================================================#
 #| [95m    Physical Parameters (Current + Step = Next)     [0m |#
 #========================================================#
-   0 [  7.2599e+02 - 2.0809e+00 =  7.2391e+02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
-   1 [  1.3920e+00 - 6.7835e-03 =  1.3852e+00 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [  8.7722e+02 - 4.6974e-01 =  8.7675e+02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [  1.3762e+00 + 7.6512e-03 =  1.3838e+00 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [  6.6096e+02 - 1.8983e-01 =  6.6077e+02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
-   5 [  1.1220e+00 - 6.8229e-03 =  1.1152e+00 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
-   6 [  7.4406e+02 + 6.7147e-03 =  7.4407e+02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
-   7 [  1.0797e+00 + 8.6721e-03 =  1.0884e+00 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
-   8 [  1.0448e+02 + 5.8606e-02 =  1.0454e+02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [  6.5896e+01 - 6.2336e-02 =  6.5834e+01 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [  1.2414e+02 + 9.3137e-02 =  1.2423e+02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [  1.3882e+02 - 2.6904e-02 =  1.3879e+02 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [  1.1958e+02 + 5.4728e-01 =  1.2013e+02 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [  6.9236e+01 - 4.2711e-01 =  6.8809e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [  1.1449e+02 - 6.6856e-02 =  1.1443e+02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [  1.4034e+02 + 7.1886e-03 =  1.4035e+02 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [  3.6002e+00 + 6.0904e-03 =  3.6063e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+   0 [  7.2600e+02 - 2.0935e+00 =  7.2391e+02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [  1.3920e+00 - 6.7158e-03 =  1.3852e+00 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [  8.7724e+02 - 4.7229e-01 =  8.7677e+02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  1.3763e+00 + 7.6399e-03 =  1.3839e+00 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [  6.6096e+02 - 1.9135e-01 =  6.6077e+02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  1.1220e+00 - 6.8290e-03 =  1.1151e+00 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [  7.4406e+02 + 7.1506e-03 =  7.4407e+02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  1.0797e+00 + 8.7121e-03 =  1.0884e+00 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [  1.0449e+02 + 5.8431e-02 =  1.0455e+02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [  6.5901e+01 - 6.2812e-02 =  6.5838e+01 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [  1.2414e+02 + 9.4529e-02 =  1.2423e+02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [  1.3881e+02 - 2.7042e-02 =  1.3878e+02 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [  1.1958e+02 + 5.5014e-01 =  1.2013e+02 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [  6.9255e+01 - 4.3018e-01 =  6.8825e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [  1.1451e+02 - 6.6970e-02 =  1.1444e+02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [  1.4034e+02 + 7.2362e-03 =  1.4035e+02 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [  3.6004e+00 + 6.1346e-03 =  3.6065e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
   17 [  1.0500e+00 + 0.0000e+00 =  1.0500e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [  1.5413e-02 - 1.0351e-05 =  1.5403e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
-  19 [  1.4825e+00 - 1.8160e-04 =  1.4823e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [  1.4787e-02 + 4.4775e-06 =  1.4791e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
-  21 [  1.4542e+00 + 8.5854e-05 =  1.4543e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [  1.0947e-01 + 2.1000e-06 =  1.0947e-01 ] : vdW/Atom/epsilon/[#6X4:1]
-  23 [  1.9159e+00 + 2.3228e-04 =  1.9161e+00 ] : vdW/Atom/rmin_half/[#6X4:1]
-  24 [  1.7002e-01 + 3.9293e-07 =  1.7002e-01 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
-  25 [  1.6847e+00 + 3.2315e-05 =  1.6848e+00 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+  18 [  1.5412e-02 - 1.0424e-05 =  1.5402e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [  1.4824e+00 - 1.8229e-04 =  1.4823e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [  1.4780e-02 + 4.4379e-06 =  1.4785e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [  1.4541e+00 + 8.5513e-05 =  1.4542e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  1.0947e-01 + 2.1299e-06 =  1.0947e-01 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  1.9159e+00 + 2.3398e-04 =  1.9161e+00 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [  1.7002e-01 + 3.9669e-07 =  1.7002e-01 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [  1.6847e+00 + 3.2426e-05 =  1.6847e+00 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
 ----------------------------------------------------------
 Input file with saved parameters: optimize.sav
 #========================================================#
@@ -2386,437 +2350,438 @@ Input file with saved parameters: optimize.sav
 #========================================================#
 
 #======================================================================================================================#
-#| [92m                                         optgeo, Objective =  1.11306e+00                                         [0m |#
+#| [92m                                         optgeo, Objective =  1.11037e+00                                         [0m |#
 #| [92m  System                       Bonds            Angles           Dihedrals         Impropers               Term.  [0m |#
 #| [92m                            RMSD   denom      RMSD   denom      RMSD   denom      RMSD   denom                    [0m |#
 #======================================================================================================================#
-9HXanthene                    0.007    0.01     0.020    0.03     0.076    0.20     0.005    0.20             1.113 
+9HXanthene                    0.007    0.01     0.020    0.03     0.076    0.20     0.005    0.20             1.110 
 ------------------------------------------------------------------------------------------------------------------------
 
 #==========================================================================#
 #|                       Frequencies (wavenumbers)                        |#
-#|  Target: vibration  Type: Vibration_SMIRNOFF  Objective = 2.19222e+00  |#
+#|  Target: vibration  Type: Vibration_SMIRNOFF  Objective = 2.19355e+00  |#
 #|  Mode #            Reference   Calculated   Difference   Ref(dot)Calc  |#
 #==========================================================================#
-    0                   31.1817      54.3070      23.1253         0.9916 
-    1                  127.2863     140.7489      13.4626         0.9959 
-    2                  200.5311     232.0617      31.5306         0.9374 
-    3                  245.4174     233.5015     -11.9159         0.9370 
-    4                  258.8788     252.0595      -6.8193         0.9950 
-    5                  295.5887     329.2408      33.6521         0.0304 
-    6                  385.5805     329.5500     -56.0305         0.0194 
-    7                  413.3227     420.9492       7.6265         0.9705 
-    8                  461.1571     462.3325       1.1754         0.9819 
-    9                  468.4759     480.7671      12.2912         0.9896 
-    10                 553.9686     539.0822     -14.8864         0.9562 
-    11                 557.9183     545.3380     -12.5803         0.1060 
-    12                 559.2968     564.4417       5.1449         0.1399 
-    13                 609.7540     602.6686      -7.0854         0.0013 
-    14                 650.9588     613.3100     -37.6488         0.0039 
-    15                 691.9021     624.2351     -67.6670         0.6267 
-    16                 731.3959     692.7276     -38.6683         0.1041 
-    17                 748.6224     718.6456     -29.9768         0.0296 
-    18                 757.4865     738.5547     -18.9318         0.0017 
-    19                 793.4162     755.0669     -38.3493         0.0366 
-    20                 796.3137     768.0311     -28.2826         0.7502 
-    21                 829.9391     775.3618     -54.5773         0.0015 
-    22                 886.2937     851.7119     -34.5818         0.0055 
-    23                 898.9488     861.3291     -37.6197         0.3067 
-    24                 905.1053     883.3428     -21.7625         0.0761 
-    25                 931.8180     905.7281     -26.0899         0.0015 
-    26                 972.6908     918.9560     -53.7348         0.0018 
-    27                 981.1443     925.4664     -55.6779         0.0847 
-    28                1002.3531     958.5347     -43.8184         0.2335 
-    29                1002.6108    1015.0174      12.4066         0.0186 
-    30                1006.9971    1027.5252      20.5281         0.0255 
-    31                1043.4229    1057.1786      13.7557         0.0108 
-    32                1045.2039    1060.9008      15.6969         0.0182 
-    33                1101.4212    1092.4018      -9.0194         0.0027 
-    34                1122.1664    1103.3298     -18.8366         0.0000 
-    35                1175.8590    1134.1404     -41.7186         0.0167 
-    36                1177.5535    1134.7185     -42.8350         0.0161 
-    37                1180.0345    1147.6067     -32.4278         0.0079 
-    38                1198.0738    1157.1966     -40.8772         0.0150 
-    39                1209.4283    1175.7682     -33.6601         0.4067 
-    40                1213.4868    1234.5341      21.0473         0.1844 
-    41                1233.7197    1272.7057      38.9860         0.4277 
-    42                1248.6007    1275.5509      26.9502         0.0059 
-    43                1296.1008    1326.2541      30.1533         0.0320 
-    44                1311.1904    1348.4358      37.2454         0.0063 
-    45                1325.6114    1402.3464      76.7350         0.0045 
-    46                1351.5363    1416.4094      64.8731         0.0004 
-    47                1456.1390    1485.0672      28.9282         0.5883 
-    48                1461.1551    1487.0537      25.8986         0.1919 
-    49                1467.0845    1521.8633      54.7788         0.0130 
-    50                1486.3167    1551.7826      65.4659         0.2813 
-    51                1498.4933    1558.2013      59.7080         0.0656 
-    52                1571.5221    1608.9196      37.3975         0.5262 
-    53                1591.5923    1624.6815      33.0892         0.5989 
-    54                1597.5166    1648.2125      50.6959         0.0563 
-    55                1620.6702    1725.7658     105.0956         0.0237 
-    56                2881.8985    2877.2819      -4.6166         0.8737 
-    57                2918.3100    2931.0608      12.7508         0.8789 
-    58                3057.8158    3083.0460      25.2302         0.2660 
-    59                3058.9610    3083.1843      24.2233         0.2238 
-    60                3076.7507    3083.6924       6.9417         0.2791 
-    61                3076.9099    3083.7596       6.8497         0.2852 
-    62                3093.3546    3084.7357      -8.6189         0.1389 
-    63                3093.7472    3084.7999      -8.9473         0.1782 
-    64                3108.9905    3085.7331     -23.2574         0.8031 
-    65                3109.6289    3086.0796     -23.5493         0.8177 
+    0                   31.1817      54.3104      23.1287         0.9916 
+    1                  127.2863     140.7479      13.4616         0.9959 
+    2                  200.5311     232.0590      31.5279         0.9374 
+    3                  245.4174     233.4897     -11.9277         0.9370 
+    4                  258.8788     252.0475      -6.8313         0.9950 
+    5                  295.5887     329.2288      33.6401         0.0304 
+    6                  385.5805     329.5493     -56.0312         0.0194 
+    7                  413.3227     420.9180       7.5953         0.9706 
+    8                  461.1571     462.3069       1.1498         0.9819 
+    9                  468.4759     480.7383      12.2624         0.9896 
+    10                 553.9686     539.0534     -14.9152         0.9563 
+    11                 557.9183     545.3217     -12.5966         0.1060 
+    12                 559.2968     564.4225       5.1257         0.1399 
+    13                 609.7540     602.6505      -7.1035         0.0013 
+    14                 650.9588     613.2975     -37.6613         0.0039 
+    15                 691.9021     624.2040     -67.6981         0.6268 
+    16                 731.3959     692.7071     -38.6888         0.1042 
+    17                 748.6224     718.6404     -29.9820         0.0296 
+    18                 757.4865     738.5436     -18.9429         0.0017 
+    19                 793.4162     755.0590     -38.3572         0.0366 
+    20                 796.3137     768.0099     -28.3038         0.7514 
+    21                 829.9391     775.3593     -54.5798         0.0015 
+    22                 886.2937     851.7003     -34.5934         0.0055 
+    23                 898.9488     861.3101     -37.6387         0.3067 
+    24                 905.1053     883.3550     -21.7503         0.0761 
+    25                 931.8180     905.7215     -26.0965         0.0015 
+    26                 972.6908     918.9478     -53.7430         0.0018 
+    27                 981.1443     925.4718     -55.6725         0.0847 
+    28                1002.3531     958.5335     -43.8196         0.2335 
+    29                1002.6108    1015.0215      12.4107         0.0186 
+    30                1006.9971    1027.5287      20.5316         0.0255 
+    31                1043.4229    1057.1888      13.7659         0.0108 
+    32                1045.2039    1060.9110      15.7071         0.0182 
+    33                1101.4212    1092.4247      -8.9965         0.0027 
+    34                1122.1664    1103.3542     -18.8122         0.0000 
+    35                1175.8590    1134.1493     -41.7097         0.0167 
+    36                1177.5535    1134.7272     -42.8263         0.0161 
+    37                1180.0345    1147.6140     -32.4205         0.0079 
+    38                1198.0738    1157.2068     -40.8670         0.0150 
+    39                1209.4283    1175.7921     -33.6362         0.4066 
+    40                1213.4868    1234.5332      21.0464         0.1846 
+    41                1233.7197    1272.7502      39.0305         0.4277 
+    42                1248.6007    1275.5820      26.9813         0.0059 
+    43                1296.1008    1326.3151      30.2143         0.0320 
+    44                1311.1904    1348.5200      37.3296         0.0063 
+    45                1325.6114    1402.4083      76.7969         0.0045 
+    46                1351.5363    1416.4636      64.9273         0.0004 
+    47                1456.1390    1485.1150      28.9760         0.5883 
+    48                1461.1551    1487.1052      25.9501         0.1919 
+    49                1467.0845    1521.8791      54.7946         0.0130 
+    50                1486.3167    1551.8101      65.4934         0.2815 
+    51                1498.4933    1558.2142      59.7209         0.0656 
+    52                1571.5221    1608.9359      37.4138         0.5261 
+    53                1591.5923    1624.6702      33.0779         0.5991 
+    54                1597.5166    1648.2206      50.7040         0.0563 
+    55                1620.6702    1725.7686     105.0984         0.0237 
+    56                2881.8985    2877.2808      -4.6177         0.8737 
+    57                2918.3100    2931.0814      12.7714         0.8789 
+    58                3057.8158    3083.0439      25.2281         0.2660 
+    59                3058.9610    3083.1823      24.2213         0.2239 
+    60                3076.7507    3083.6904       6.9397         0.2792 
+    61                3076.9099    3083.7576       6.8477         0.2853 
+    62                3093.3546    3084.7353      -8.6193         0.1386 
+    63                3093.7472    3084.7995      -8.9477         0.1779 
+    64                3108.9905    3085.7304     -23.2601         0.8029 
+    65                3109.6289    3086.0769     -23.5520         0.8176 
 ----------------------------------------------------------------------------
 #===================================================================================#
 #| [94m                         Objective Function Breakdown                          [0m |#
 #| [94m  Target Name              Residual  x  Weight  =  Contribution (Current-Prev) [0m |#
 #===================================================================================#
-optgeo                         1.11306      1.000 [92m     1.11306e+00[0m ( -3.636e-01 ) 
-vibration                      2.19222      1.000 [92m     2.19222e+00[0m ( -1.282e-01 ) 
-Regularization                 0.07078      1.000 [91m     7.07822e-02[0m ( +2.299e-03 ) 
-Total                                             [92m     3.37606e+00[0m ( -4.895e-01 ) 
+optgeo                         1.11037      1.000 [92m     1.11037e+00[0m ( -3.606e-01 ) 
+vibration                      2.19355      1.000 [92m     2.19355e+00[0m ( -1.293e-01 ) 
+Regularization                 0.07072      1.000 [91m     7.07179e-02[0m ( +2.313e-03 ) 
+Total                                             [92m     3.37464e+00[0m ( -4.876e-01 ) 
 -------------------------------------------------------------------------------------
-Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_34.offxml
+Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_45.offxml
 #========================================================================#
 #|  The force field has been written to the result/optimize directory.  |#
 #|    Input file with optimization parameters saved to optimize.sav.    |#
 #========================================================================#
 
   Step       |k|        |dk|       |grad|       -=X2=-     Delta(X2)    StepQual
-     9   2.660e-01   1.247e-02   6.808e+01[92m   3.37606e+00[0m  -4.895e-01      1.000
+     9   2.659e-01   1.248e-02   6.801e+01[92m   3.37464e+00[0m  -4.876e-01      1.000
 
 #========================================================#
 #| [94m                   Total Gradient                   [0m |#
 #========================================================#
-   0 [  9.05709042e+00 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
-   1 [ -4.31091737e+01 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [  1.91467412e+00 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [ -2.33831723e+01 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [  7.69434636e-01 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
-   5 [  2.46344433e+01 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
-   6 [ -4.77954960e-02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
-   7 [  3.28383985e+01 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
-   8 [ -1.70268841e+00 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [  1.69398030e+00 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [ -1.70804887e+00 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [  8.42661698e-01 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [ -1.72450055e+01 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [  1.05067430e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [  1.66062970e+00 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [ -1.77329700e-01 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [ -6.15479868e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
-  17 [  7.01457702e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [  2.30202411e-01 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
-  19 [  3.48813240e-01 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [ -1.38788654e-01 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
-  21 [ -2.50968063e-01 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [ -5.16472878e-02 ] : vdW/Atom/epsilon/[#6X4:1]
-  23 [ -5.32591857e-01 ] : vdW/Atom/rmin_half/[#6X4:1]
-  24 [ -1.02897694e-02 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
-  25 [ -1.24444296e-01 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+   0 [  9.05874835e+00 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [ -4.28707634e+01 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [  1.91437775e+00 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [ -2.32103913e+01 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [  7.71145704e-01 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  2.45188203e+01 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [ -4.90968589e-02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  3.32056422e+01 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [ -1.68793054e+00 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [  1.69869458e+00 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [ -1.74809450e+00 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [  8.41951562e-01 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [ -1.72404287e+01 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [  1.05224766e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [  1.66097245e+00 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [ -1.77178806e-01 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [ -6.15475722e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  2.36311917e-18 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [  2.30218039e-01 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [  3.48421776e-01 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [ -1.36347154e-01 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [ -2.46004366e-01 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [ -5.17601362e-02 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [ -5.31363410e-01 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [ -1.01360584e-02 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [ -1.22904654e-01 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
 ----------------------------------------------------------
 Calculating nonlinear optimization step
-Finding trust radius: H+0.0000*I, length 3.9364e-01 (target 1.2469e-02)
-Finding trust radius: H+9.0000*I, length 1.9438e-01 (target 1.2469e-02)
-Finding trust radius: H+61.6869*I, length 7.3052e-02 (target 1.2469e-02)
-Finding trust radius: H+38.2732*I, length 9.5626e-02 (target 1.2469e-02)
-Finding trust radius: H+246.7477*I, length 3.5946e-02 (target 1.2469e-02)
-Finding trust radius: H+149.4922*I, length 4.5605e-02 (target 1.2469e-02)
-Finding trust radius: H+807.4923*I, length 2.0565e-02 (target 1.2469e-02)
-Finding trust radius: H+536.2394*I, length 2.5090e-02 (target 1.2469e-02)
-Finding trust radius: H+2398.9145*I, length 1.1706e-02 (target 1.2469e-02)
-Finding trust radius: H+1615.8007*I, length 1.4439e-02 (target 1.2469e-02)
-Finding trust radius: H+6764.9351*I, length 6.3286e-03 (target 1.2469e-02)
-Finding trust radius: H+2398.9145*I, length 1.1706e-02 (target 1.2469e-02)
-Finding trust radius: H+3805.2759*I, length 9.0423e-03 (target 1.2469e-02)
-Finding trust radius: H+1691.2338*I, length 1.4098e-02 (target 1.2469e-02)
-Finding trust radius: H+2249.2025*I, length 1.2120e-02 (target 1.2469e-02)
-Finding trust radius: H+2165.4685*I, length 1.2369e-02 (target 1.2469e-02)
-Finding trust radius: H+2123.5313*I, length 1.2499e-02 (target 1.2469e-02)
-Finding trust radius: H+2132.5591*I, length 1.2471e-02 (target 1.2469e-02)
-Finding trust radius: H+2133.1368*I, length 1.2469e-02 (target 1.2469e-02)
-Finding trust radius: H+2133.5727*I, length 1.2468e-02 (target 1.2469e-02)
-Starting Hessian diagonal search with step size 1.2469e-02
-Hessian diagonal search: H+2133.1368*I, length 1.2469e-02, result -2.6035e-01
-Hessian diagonal search: H+35247.6505*I, length 1.7215e-03, result -1.0327e-01
-Hessian diagonal search: H+33437.5049*I, length 1.8043e-03, result -1.0752e-01
-Hessian diagonal search: H+2133.1368*I, length 1.2469e-02, result -2.6035e-01
-Hessian diagonal search: H+1705.8191*I, length 1.4035e-02, result -2.5237e-01
-Hessian diagonal search: H+10051.2888*I, length 4.8060e-03, result -2.2018e-01
-Hessian diagonal search: H+103.6450*I, length 5.4981e-02, result  6.5789e-02
-Hessian diagonal search: H+4467.4359*I, length 8.2236e-03, result -2.6691e-01
-Hessian diagonal search: H+6336.6580*I, length 6.6068e-03, result -2.5347e-01
-Hessian diagonal search: H+3645.9572*I, length 9.2693e-03, result -2.6932e-01
-Hessian diagonal search: H+3572.5581*I, length 9.3785e-03, result -2.6936e-01
-Hessian diagonal search: H+3540.2000*I, length 9.4276e-03, result -2.6936e-01
-Hessian diagonal search: H+3544.0207*I, length 9.4218e-03, result -2.6936e-01
-Hessian diagonal search: H+2960.9056*I, length 1.0429e-02, result -2.6802e-01
-Hessian diagonal search: H+3428.5855*I, length 9.6021e-03, result -2.6931e-01
-Hessian diagonal search: H+3539.4801*I, length 9.4287e-03, result -2.6936e-01
-Hessian diagonal search: H+3523.9068*I, length 9.4526e-03, result -2.6936e-01
-Hessian diagonal search: H+3533.5276*I, length 9.4378e-03, result -2.6936e-01
-Hessian diagonal search: H+3537.2058*I, length 9.4322e-03, result -2.6936e-01
-Hessian diagonal search: H+3538.7603*I, length 9.4298e-03, result -2.6936e-01
-Optimization step found (length 9.4287e-03)
+Finding trust radius: H+0.0000*I, length 3.9279e-01 (target 1.2482e-02)
+Finding trust radius: H+9.0000*I, length 1.9434e-01 (target 1.2482e-02)
+Finding trust radius: H+61.6869*I, length 7.3115e-02 (target 1.2482e-02)
+Finding trust radius: H+38.3279*I, length 9.5611e-02 (target 1.2482e-02)
+Finding trust radius: H+246.7477*I, length 3.5964e-02 (target 1.2482e-02)
+Finding trust radius: H+149.5235*I, length 4.5636e-02 (target 1.2482e-02)
+Finding trust radius: H+807.4923*I, length 2.0555e-02 (target 1.2482e-02)
+Finding trust radius: H+536.2089*I, length 2.5088e-02 (target 1.2482e-02)
+Finding trust radius: H+2398.9145*I, length 1.1688e-02 (target 1.2482e-02)
+Finding trust radius: H+1614.7558*I, length 1.4426e-02 (target 1.2482e-02)
+Finding trust radius: H+6764.9351*I, length 6.3175e-03 (target 1.2482e-02)
+Finding trust radius: H+2398.9145*I, length 1.1688e-02 (target 1.2482e-02)
+Finding trust radius: H+3805.2759*I, length 9.0265e-03 (target 1.2482e-02)
+Finding trust radius: H+1691.2338*I, length 1.4080e-02 (target 1.2482e-02)
+Finding trust radius: H+2234.3521*I, length 1.2145e-02 (target 1.2482e-02)
+Finding trust radius: H+2155.3273*I, length 1.2382e-02 (target 1.2482e-02)
+Finding trust radius: H+2113.4583*I, length 1.2512e-02 (target 1.2482e-02)
+Finding trust radius: H+2122.5731*I, length 1.2484e-02 (target 1.2482e-02)
+Finding trust radius: H+2123.1263*I, length 1.2482e-02 (target 1.2482e-02)
+Finding trust radius: H+2123.5602*I, length 1.2481e-02 (target 1.2482e-02)
+Starting Hessian diagonal search with step size 1.2482e-02
+Hessian diagonal search: H+2123.1263*I, length 1.2482e-02, result -2.5965e-01
+Hessian diagonal search: H+35084.8791*I, length 1.7264e-03, result -1.0338e-01
+Hessian diagonal search: H+33284.7488*I, length 1.8092e-03, result -1.0762e-01
+Hessian diagonal search: H+2123.1263*I, length 1.2482e-02, result -2.5965e-01
+Hessian diagonal search: H+1698.1729*I, length 1.4050e-02, result -2.5174e-01
+Hessian diagonal search: H+10004.6582*I, length 4.8142e-03, result -2.1994e-01
+Hessian diagonal search: H+103.6157*I, length 5.5039e-02, result  8.5679e-02
+Hessian diagonal search: H+4446.6081*I, length 8.2321e-03, result -2.6623e-01
+Hessian diagonal search: H+6307.1853*I, length 6.6151e-03, result -2.5295e-01
+Hessian diagonal search: H+3634.3045*I, length 9.2702e-03, result -2.6858e-01
+Hessian diagonal search: H+3561.4352*I, length 9.3790e-03, result -2.6861e-01
+Hessian diagonal search: H+3530.1847*I, length 9.4266e-03, result -2.6862e-01
+Hessian diagonal search: H+3531.8500*I, length 9.4241e-03, result -2.6862e-01
+Hessian diagonal search: H+2950.7395*I, length 1.0432e-02, result -2.6729e-01
+Hessian diagonal search: H+3302.7291*I, length 9.7917e-03, result -2.6842e-01
+Hessian diagonal search: H+3442.4105*I, length 9.5635e-03, result -2.6859e-01
+Hessian diagonal search: H+3496.5275*I, length 9.4785e-03, result -2.6861e-01
+Hessian diagonal search: H+3517.3098*I, length 9.4464e-03, result -2.6862e-01
+Hessian diagonal search: H+3525.9826*I, length 9.4331e-03, result -2.6862e-01
+Hessian diagonal search: H+3529.3881*I, length 9.4278e-03, result -2.6862e-01
+Hessian diagonal search: H+3530.9027*I, length 9.4255e-03, result -2.6862e-01
+Optimization step found (length 9.4266e-03)
 #========================================================#
 #| [95m  Mathematical Parameters (Current + Step = Next)   [0m |#
 #========================================================#
-   0 [ -1.0677e-01 - 2.3517e-03 = -1.0912e-01 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
-   1 [ -1.0557e-02 + 5.3759e-03 = -5.1812e-03 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [ -2.5833e-02 - 4.9721e-04 = -2.6330e-02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [  4.3436e-02 + 3.0374e-03 =  4.6474e-02 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [ -2.1369e-02 - 1.9518e-04 = -2.1564e-02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
-   5 [  1.7987e-02 - 2.3747e-03 =  1.5612e-02 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
-   6 [  1.1186e-02 + 3.5037e-05 =  1.1221e-02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
-   7 [  5.9721e-03 - 3.9220e-03 =  2.0500e-03 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
-   8 [ -4.1326e-02 + 4.7940e-04 = -4.0846e-02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [ -2.9758e-02 - 5.0493e-04 = -3.0263e-02 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [  3.5289e-02 + 8.4852e-04 =  3.6138e-02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [ -8.6429e-03 - 1.2375e-04 = -8.7667e-03 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [  1.0507e-03 + 3.5408e-03 =  4.5914e-03 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [ -2.2279e-01 - 2.8648e-03 = -2.2566e-01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [ -4.6445e-02 - 3.9111e-04 = -4.6836e-02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [  2.4949e-03 + 5.1901e-05 =  2.5468e-03 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [ -5.1584e-03 + 1.3326e-03 = -3.8257e-03 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
-  17 [  3.5073e-19 + 1.4550e-21 =  3.5218e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [ -1.7476e-03 - 5.6007e-05 = -1.8036e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
-  19 [ -2.4740e-03 - 8.0315e-05 = -2.5543e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [ -1.2294e-03 + 4.1239e-05 = -1.1882e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
-  21 [ -2.4730e-03 + 6.4159e-05 = -2.4088e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [  4.3178e-04 + 1.5326e-05 =  4.4711e-04 ] : vdW/Atom/epsilon/[#6X4:1]
-  23 [  4.2617e-03 + 1.5370e-04 =  4.4154e-03 ] : vdW/Atom/rmin_half/[#6X4:1]
-  24 [  9.2441e-05 + 3.3765e-06 =  9.5817e-05 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
-  25 [  5.6304e-04 + 3.5467e-05 =  5.9851e-04 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+   0 [ -1.0677e-01 - 2.3603e-03 = -1.0913e-01 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [ -1.0540e-02 + 5.3488e-03 = -5.1913e-03 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [ -2.5808e-02 - 4.9884e-04 = -2.6307e-02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  4.3507e-02 + 3.0146e-03 =  4.6522e-02 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [ -2.1364e-02 - 1.9609e-04 = -2.1560e-02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  1.7953e-02 - 2.3549e-03 =  1.5598e-02 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [  1.1186e-02 + 3.5185e-05 =  1.1221e-02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  6.0052e-03 - 3.9633e-03 =  2.0419e-03 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [ -4.1256e-02 + 4.7622e-04 = -4.0780e-02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [ -2.9731e-02 - 5.0740e-04 = -3.0238e-02 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [  3.5270e-02 + 8.5792e-04 =  3.6128e-02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [ -8.6955e-03 - 1.2472e-04 = -8.8202e-03 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [  1.0712e-03 + 3.5418e-03 =  4.6130e-03 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [ -2.2268e-01 - 2.8802e-03 = -2.2556e-01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [ -4.6344e-02 - 3.9320e-04 = -4.6738e-02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [  2.4873e-03 + 5.2017e-05 =  2.5393e-03 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [ -5.1068e-03 + 1.3329e-03 = -3.7739e-03 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  1.1816e-18 - 5.0306e-21 =  1.1765e-18 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [ -1.7527e-03 - 5.6182e-05 = -1.8089e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [ -2.4859e-03 - 8.0464e-05 = -2.5664e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [ -1.2655e-03 + 4.0479e-05 = -1.2250e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [ -2.5254e-03 + 6.2753e-05 = -2.4627e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  4.3062e-04 + 1.5400e-05 =  4.4602e-04 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  4.2408e-03 + 1.5383e-04 =  4.3946e-03 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [  9.2958e-05 + 3.3439e-06 =  9.6302e-05 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [  5.4706e-04 + 3.5248e-05 =  5.8231e-04 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
 ----------------------------------------------------------
 #========================================================#
 #| [95m    Physical Parameters (Current + Step = Next)     [0m |#
 #========================================================#
-   0 [  7.2391e+02 - 2.1166e+00 =  7.2179e+02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
-   1 [  1.3852e+00 + 7.5263e-03 =  1.3927e+00 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [  8.7675e+02 - 4.4749e-01 =  8.7630e+02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [  1.3838e+00 + 4.2524e-03 =  1.3881e+00 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [  6.6077e+02 - 1.7566e-01 =  6.6059e+02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
-   5 [  1.1152e+00 - 3.3246e-03 =  1.1119e+00 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
-   6 [  7.4407e+02 + 3.1534e-02 =  7.4410e+02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
-   7 [  1.0884e+00 - 5.4908e-03 =  1.0829e+00 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
-   8 [  1.0454e+02 + 5.7528e-02 =  1.0460e+02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [  6.5834e+01 - 7.0691e-02 =  6.5763e+01 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [  1.2423e+02 + 1.0182e-01 =  1.2434e+02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [  1.3879e+02 - 1.7325e-02 =  1.3877e+02 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [  1.2013e+02 + 4.2489e-01 =  1.2055e+02 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [  6.8809e+01 - 4.0107e-01 =  6.8408e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [  1.1443e+02 - 4.6933e-02 =  1.1438e+02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [  1.4035e+02 + 7.2662e-03 =  1.4036e+02 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [  3.6063e+00 + 4.8308e-03 =  3.6111e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+   0 [  7.2391e+02 - 2.1243e+00 =  7.2179e+02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [  1.3852e+00 + 7.4884e-03 =  1.3927e+00 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [  8.7677e+02 - 4.4896e-01 =  8.7632e+02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  1.3839e+00 + 4.2204e-03 =  1.3881e+00 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [  6.6077e+02 - 1.7648e-01 =  6.6060e+02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  1.1151e+00 - 3.2969e-03 =  1.1118e+00 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [  7.4407e+02 + 3.1666e-02 =  7.4410e+02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [  1.0884e+00 - 5.5486e-03 =  1.0829e+00 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [  1.0455e+02 + 5.7147e-02 =  1.0461e+02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [  6.5838e+01 - 7.1037e-02 =  6.5767e+01 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [  1.2423e+02 + 1.0295e-01 =  1.2434e+02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [  1.3878e+02 - 1.7460e-02 =  1.3877e+02 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [  1.2013e+02 + 4.2502e-01 =  1.2055e+02 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [  6.8825e+01 - 4.0323e-01 =  6.8421e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [  1.1444e+02 - 4.7184e-02 =  1.1439e+02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [  1.4035e+02 + 7.2823e-03 =  1.4036e+02 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [  3.6065e+00 + 4.8319e-03 =  3.6113e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
   17 [  1.0500e+00 + 0.0000e+00 =  1.0500e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [  1.5403e-02 - 9.5212e-06 =  1.5393e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
-  19 [  1.4823e+00 - 1.5324e-04 =  1.4821e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [  1.4791e-02 + 7.0107e-06 =  1.4798e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
-  21 [  1.4543e+00 + 1.2242e-04 =  1.4544e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [  1.0947e-01 + 2.6055e-06 =  1.0948e-01 ] : vdW/Atom/epsilon/[#6X4:1]
-  23 [  1.9161e+00 + 2.9326e-04 =  1.9164e+00 ] : vdW/Atom/rmin_half/[#6X4:1]
-  24 [  1.7002e-01 + 5.7400e-07 =  1.7002e-01 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
-  25 [  1.6848e+00 + 6.7672e-05 =  1.6848e+00 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+  18 [  1.5402e-02 - 9.5510e-06 =  1.5392e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [  1.4823e+00 - 1.5353e-04 =  1.4821e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [  1.4785e-02 + 6.8813e-06 =  1.4792e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [  1.4542e+00 + 1.1973e-04 =  1.4543e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  1.0947e-01 + 2.6179e-06 =  1.0948e-01 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  1.9161e+00 + 2.9351e-04 =  1.9164e+00 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [  1.7002e-01 + 5.6846e-07 =  1.7002e-01 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [  1.6847e+00 + 6.7254e-05 =  1.6848e+00 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
 ----------------------------------------------------------
 Input file with saved parameters: optimize.sav
-Setting finite difference step to 9.4287e-04
+Setting finite difference step to 9.4266e-04
 #========================================================#
 #| [94m    Iteration 10: Evaluating objective function     [0m |#
 #| [94m        and derivatives through second order        [0m |#
 #========================================================#
 
 #======================================================================================================================#
-#| [92m                                         optgeo, Objective =  9.02688e-01                                         [0m |#
+#| [92m                                         optgeo, Objective =  9.01156e-01                                         [0m |#
 #| [92m  System                       Bonds            Angles           Dihedrals         Impropers               Term.  [0m |#
 #| [92m                            RMSD   denom      RMSD   denom      RMSD   denom      RMSD   denom                    [0m |#
 #======================================================================================================================#
-9HXanthene                    0.006    0.01     0.019    0.03     0.076    0.20     0.005    0.20             0.903 
+9HXanthene                    0.006    0.01     0.019    0.03     0.076    0.20     0.005    0.20             0.901 
 ------------------------------------------------------------------------------------------------------------------------
 
 #==========================================================================#
 #|                       Frequencies (wavenumbers)                        |#
-#|  Target: vibration  Type: Vibration_SMIRNOFF  Objective = 2.13123e+00  |#
+#|  Target: vibration  Type: Vibration_SMIRNOFF  Objective = 2.13213e+00  |#
 #|  Mode #            Reference   Calculated   Difference   Ref(dot)Calc  |#
 #==========================================================================#
-    0                   31.1817      53.7518      22.5701         0.9916 
-    1                  127.2863     140.2567      12.9704         0.9958 
-    2                  200.5311     231.7272      31.1961         0.9377 
-    3                  245.4174     232.4935     -12.9239         0.9370 
-    4                  258.8788     251.8852      -6.9936         0.9950 
-    5                  295.5887     328.0108      32.4221         0.0305 
-    6                  385.5805     328.5412     -57.0393         0.0200 
-    7                  413.3227     419.4837       6.1610         0.9696 
-    8                  461.1571     460.7592      -0.3979         0.9820 
-    9                  468.4759     479.3047      10.8288         0.9895 
-    10                 553.9686     537.1613     -16.8073         0.9559 
-    11                 557.9183     541.8797     -16.0386         0.1059 
-    12                 559.2968     562.7821       3.4853         0.1397 
-    13                 609.7540     598.1391     -11.6149         0.0013 
-    14                 650.9588     610.7039     -40.2549         0.0039 
-    15                 691.9021     621.4524     -70.4497         0.5908 
-    16                 731.3959     687.7758     -43.6201         0.1050 
-    17                 748.6224     719.9565     -28.6659         0.0297 
-    18                 757.4865     735.3356     -22.1509         0.0017 
-    19                 793.4162     757.4535     -35.9627         0.0234 
-    20                 796.3137     772.1516     -24.1621         0.9242 
-    21                 829.9391     780.6133     -49.3258         0.0015 
-    22                 886.2937     847.8353     -38.4584         0.0055 
-    23                 898.9488     857.6094     -41.3394         0.3071 
-    24                 905.1053     887.8268     -17.2785         0.0731 
-    25                 931.8180     904.1254     -27.6926         0.0015 
-    26                 972.6908     918.0399     -54.6509         0.0018 
-    27                 981.1443     933.2692     -47.8751         0.0842 
-    28                1002.3531     962.7816     -39.5715         0.2253 
-    29                1002.6108    1014.7684      12.1576         0.0184 
-    30                1006.9971    1027.4678      20.4707         0.0259 
-    31                1043.4229    1066.4592      23.0363         0.0108 
-    32                1045.2039    1070.0377      24.8338         0.0180 
-    33                1101.4212    1092.8251      -8.5961         0.0028 
-    34                1122.1664    1104.0715     -18.0949         0.0001 
-    35                1175.8590    1144.3058     -31.5532         0.0166 
-    36                1177.5535    1144.8601     -32.6934         0.0161 
-    37                1180.0345    1146.1357     -33.8988         0.0076 
-    38                1198.0738    1156.7993     -41.2745         0.0149 
-    39                1209.4283    1175.8001     -33.6282         0.4035 
-    40                1213.4868    1233.0965      19.6097         0.1932 
-    41                1233.7197    1274.9617      41.2420         0.0224 
-    42                1248.6007    1276.2068      27.6061         0.0097 
-    43                1296.1008    1326.3750      30.2742         0.0321 
-    44                1311.1904    1350.7641      39.5737         0.0064 
-    45                1325.6114    1402.7450      77.1336         0.0041 
-    46                1351.5363    1415.6680      64.1317         0.0005 
-    47                1456.1390    1484.4894      28.3504         0.5799 
-    48                1461.1551    1486.0226      24.8675         0.1926 
-    49                1467.0845    1520.6490      53.5645         0.0125 
-    50                1486.3167    1550.8237      64.5070         0.2747 
-    51                1498.4933    1556.7509      58.2576         0.0650 
-    52                1571.5221    1607.0761      35.5540         0.5163 
-    53                1591.5923    1621.3126      29.7203         0.5974 
-    54                1597.5166    1644.9782      47.4616         0.0566 
-    55                1620.6702    1722.9839     102.3137         0.0237 
-    56                2881.8985    2876.8206      -5.0779         0.8737 
-    57                2918.3100    2930.6592      12.3492         0.8789 
-    58                3057.8158    3082.9921      25.1763         0.2620 
-    59                3058.9610    3083.1276      24.1666         0.2182 
-    60                3076.7507    3083.6220       6.8713         0.2831 
-    61                3076.9099    3083.6859       6.7760         0.2875 
-    62                3093.3546    3084.5889      -8.7657         0.1476 
-    63                3093.7472    3084.6545      -9.0927         0.1893 
-    64                3108.9905    3085.5886     -23.4019         0.8102 
-    65                3109.6289    3085.9340     -23.6949         0.8238 
+    0                   31.1817      53.7585      22.5768         0.9916 
+    1                  127.2863     140.2604      12.9741         0.9958 
+    2                  200.5311     231.7308      31.1997         0.9377 
+    3                  245.4174     232.4879     -12.9295         0.9370 
+    4                  258.8788     251.8830      -6.9958         0.9950 
+    5                  295.5887     328.0049      32.4162         0.0305 
+    6                  385.5805     328.5534     -57.0271         0.0200 
+    7                  413.3227     419.4627       6.1400         0.9696 
+    8                  461.1571     460.7579      -0.3992         0.9820 
+    9                  468.4759     479.3015      10.8256         0.9895 
+    10                 553.9686     537.1604     -16.8082         0.9559 
+    11                 557.9183     541.8791     -16.0392         0.1059 
+    12                 559.2968     562.7894       3.4926         0.1397 
+    13                 609.7540     598.1403     -11.6137         0.0013 
+    14                 650.9588     610.7022     -40.2566         0.0039 
+    15                 691.9021     621.4347     -70.4674         0.5910 
+    16                 731.3959     687.7769     -43.6190         0.1050 
+    17                 748.6224     719.9755     -28.6469         0.0297 
+    18                 757.4865     735.3357     -22.1508         0.0017 
+    19                 793.4162     757.4671     -35.9491         0.0234 
+    20                 796.3137     772.1882     -24.1255         0.9248 
+    21                 829.9391     780.6532     -49.2859         0.0015 
+    22                 886.2937     847.8390     -38.4547         0.0055 
+    23                 898.9488     857.6063     -41.3425         0.3071 
+    24                 905.1053     887.8620     -17.2433         0.0730 
+    25                 931.8180     904.1317     -27.6863         0.0015 
+    26                 972.6908     918.0470     -54.6438         0.0018 
+    27                 981.1443     933.3240     -47.8203         0.0842 
+    28                1002.3531     962.8174     -39.5357         0.2252 
+    29                1002.6108    1014.7954      12.1846         0.0184 
+    30                1006.9971    1027.4979      20.5008         0.0259 
+    31                1043.4229    1066.5254      23.1025         0.0108 
+    32                1045.2039    1070.1033      24.8994         0.0180 
+    33                1101.4212    1092.8763      -8.5449         0.0028 
+    34                1122.1664    1104.1282     -18.0382         0.0001 
+    35                1175.8590    1144.3755     -31.4835         0.0166 
+    36                1177.5535    1144.9297     -32.6238         0.0161 
+    37                1180.0345    1146.1566     -33.8779         0.0076 
+    38                1198.0738    1156.8354     -41.2384         0.0149 
+    39                1209.4283    1175.8430     -33.5853         0.4035 
+    40                1213.4868    1233.1141      19.6273         0.1935 
+    41                1233.7197    1275.0238      41.3041         0.0224 
+    42                1248.6007    1276.2217      27.6210         0.0097 
+    43                1296.1008    1326.4708      30.3700         0.0321 
+    44                1311.1904    1350.8268      39.6364         0.0064 
+    45                1325.6114    1402.8278      77.2164         0.0041 
+    46                1351.5363    1415.7519      64.2156         0.0005 
+    47                1456.1390    1484.5558      28.4168         0.5799 
+    48                1461.1551    1486.1004      24.9453         0.1926 
+    49                1467.0845    1520.6664      53.5819         0.0125 
+    50                1486.3167    1550.8536      64.5369         0.2750 
+    51                1498.4933    1556.7709      58.2776         0.0650 
+    52                1571.5221    1607.1020      35.5799         0.5163 
+    53                1591.5923    1621.3130      29.7207         0.5977 
+    54                1597.5166    1645.0023      47.4857         0.0566 
+    55                1620.6702    1722.9968     102.3266         0.0237 
+    56                2881.8985    2876.8180      -5.0805         0.8737 
+    57                2918.3100    2930.6782      12.3682         0.8789 
+    58                3057.8158    3082.9912      25.1754         0.2621 
+    59                3058.9610    3083.1267      24.1657         0.2183 
+    60                3076.7507    3083.6213       6.8706         0.2832 
+    61                3076.9099    3083.6852       6.7753         0.2876 
+    62                3093.3546    3084.5894      -8.7652         0.1473 
+    63                3093.7472    3084.6550      -9.0922         0.1889 
+    64                3108.9905    3085.5876     -23.4029         0.8101 
+    65                3109.6289    3085.9328     -23.6961         0.8237 
 ----------------------------------------------------------------------------
 #===================================================================================#
 #| [94m                         Objective Function Breakdown                          [0m |#
 #| [94m  Target Name              Residual  x  Weight  =  Contribution (Current-Prev) [0m |#
 #===================================================================================#
-optgeo                         0.90269      1.000 [92m     9.02688e-01[0m ( -2.104e-01 ) 
-vibration                      2.13123      1.000 [92m     2.13123e+00[0m ( -6.099e-02 ) 
-Regularization                 0.07279      1.000 [91m     7.27869e-02[0m ( +2.005e-03 ) 
-Total                                             [92m     3.10670e+00[0m ( -2.694e-01 ) 
+optgeo                         0.90116      1.000 [92m     9.01156e-01[0m ( -2.092e-01 ) 
+vibration                      2.13213      1.000 [92m     2.13213e+00[0m ( -6.142e-02 ) 
+Regularization                 0.07273      1.000 [91m     7.27315e-02[0m ( +2.014e-03 ) 
+Total                                             [92m     3.10602e+00[0m ( -2.686e-01 ) 
 -------------------------------------------------------------------------------------
-Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_35.offxml
+Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_46.offxml
 #========================================================================#
 #|  The force field has been written to the result/optimize directory.  |#
 #|    Input file with optimization parameters saved to optimize.sav.    |#
 #========================================================================#
 
   Step       |k|        |dk|       |grad|       -=X2=-     Delta(X2)    StepQual
-    10   2.698e-01   9.429e-03   5.217e+01[92m   3.10670e+00[0m  -2.694e-01      1.000
+    10   2.697e-01   9.427e-03   5.204e+01[92m   3.10602e+00[0m  -2.686e-01      1.000
 
 #========================================================#
 #| [94m                   Total Gradient                   [0m |#
 #========================================================#
-   0 [  7.69735260e+00 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
-   1 [  3.80155030e+01 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [  1.84832759e+00 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [ -1.57125527e+01 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [  6.87517417e-01 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
-   5 [  1.78698038e+01 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
-   6 [ -1.08926262e-01 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
-   7 [ -1.79954390e+01 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
-   8 [ -1.38142004e+00 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [  1.85891111e+00 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [ -1.52386008e+00 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [  5.44202032e-01 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [ -1.32816722e+01 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [  1.07357747e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [  1.02501983e+00 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [ -1.68723447e-01 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [ -4.71840658e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
-  17 [  7.04367654e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [  1.50361261e-01 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
-  19 [  2.53347281e-01 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [ -8.20571822e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
-  21 [ -1.02874678e-01 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [ -3.53867763e-02 ] : vdW/Atom/epsilon/[#6X4:1]
-  23 [ -3.32233187e-01 ] : vdW/Atom/rmin_half/[#6X4:1]
-  24 [  8.34647289e-04 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
-  25 [  1.12656304e-01 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+   0 [  7.70746316e+00 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [  3.78373720e+01 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [  1.84934347e+00 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [ -1.56004105e+01 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [  6.89102543e-01 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  1.77986434e+01 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   6 [ -1.09070915e-01 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
+   7 [ -1.81606693e+01 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [ -1.36606635e+00 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [  1.86213841e+00 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [ -1.52262526e+00 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [  5.46416820e-01 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [ -1.32545545e+01 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [  1.07669028e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [  1.02963281e+00 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [ -1.68744110e-01 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [ -4.70676125e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  2.35305792e-18 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [  1.50515774e-01 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [  2.53220825e-01 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [ -7.99689836e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [ -9.98954799e-02 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [ -3.53658844e-02 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [ -3.32235993e-01 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [  8.66856858e-04 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [  1.13360805e-01 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
 ----------------------------------------------------------
 Convergence criterion reached in step size (1.00e-02)
 #========================================================#
 #| [92m               [0m[1mOptimization Converged[0m               [0m |#
 #| [92m           Final objective function value           [0m |#
-#| [92m  Full:  3.106704e+00  Un-penalized:  3.033917e+00  [0m |#
+#| [92m  Full:  3.106018e+00  Un-penalized:  3.033286e+00  [0m |#
 #========================================================#
 #========================================================#
 #| [94m           Final optimization parameters:           [0m |#
 #========================================================#
-   0 [ -1.0912e-01 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
-   1 [ -5.1812e-03 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [ -2.6330e-02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
-   3 [  4.6474e-02 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [ -2.1564e-02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
-   5 [  1.5612e-02 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   0 [ -1.0913e-01 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
+   1 [ -5.1913e-03 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
+   2 [ -2.6307e-02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   3 [  4.6522e-02 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
+   4 [ -2.1560e-02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  1.5598e-02 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
    6 [  1.1221e-02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
-   7 [  2.0500e-03 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
-   8 [ -4.0846e-02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [ -3.0263e-02 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
-  10 [  3.6138e-02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
-  11 [ -8.7667e-03 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
-  12 [  4.5914e-03 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [ -2.2566e-01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [ -4.6836e-02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  15 [  2.5468e-03 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [ -3.8257e-03 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
-  17 [  3.5218e-19 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [ -1.8036e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
-  19 [ -2.5543e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [ -1.1882e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
-  21 [ -2.4088e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
-  22 [  4.4711e-04 ] : vdW/Atom/epsilon/[#6X4:1]
-  23 [  4.4154e-03 ] : vdW/Atom/rmin_half/[#6X4:1]
-  24 [  9.5817e-05 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
-  25 [  5.9851e-04 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
+   7 [  2.0419e-03 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
+   8 [ -4.0780e-02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [ -3.0238e-02 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+  10 [  3.6128e-02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
+  11 [ -8.8202e-03 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
+  12 [  4.6130e-03 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
+  13 [ -2.2556e-01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [ -4.6738e-02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  15 [  2.5393e-03 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  16 [ -3.7739e-03 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  17 [  1.1765e-18 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
+  18 [ -1.8089e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  19 [ -2.5664e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
+  20 [ -1.2250e-03 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [ -2.4627e-03 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  22 [  4.4602e-04 ] : vdW/Atom/epsilon/[#6X4:1]
+  23 [  4.3946e-03 ] : vdW/Atom/rmin_half/[#6X4:1]
+  24 [  9.6302e-05 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
+  25 [  5.8231e-04 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
 #========================================================#
 #| [94m             Final physical parameters:             [0m |#
 #========================================================#
    0 [  7.2179e+02 ] : Bonds/Bond/k/[#6X3:1]-[#6X3:2]
    1 [  1.3927e+00 ] : Bonds/Bond/length/[#6X3:1]:[#6X3:2]
-   2 [  8.7630e+02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
+   2 [  8.7632e+02 ] : Bonds/Bond/k/[#6X3a:1]-[#8X2H0:2]
    3 [  1.3881e+00 ] : Bonds/Bond/length/[#6X3a:1]-[#8X2H0:2]
-   4 [  6.6059e+02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
-   5 [  1.1119e+00 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
+   4 [  6.6060e+02 ] : Bonds/Bond/k/[#6X4:1]-[#1:2]
+   5 [  1.1118e+00 ] : Bonds/Bond/length/[#6X4:1]-[#1:2]
    6 [  7.4410e+02 ] : Bonds/Bond/k/[#6X3:1]-[#1:2]
    7 [  1.0829e+00 ] : Bonds/Bond/length/[#6X3:1]-[#1:2]
-   8 [  1.0460e+02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
-   9 [  6.5763e+01 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
+   8 [  1.0461e+02 ] : Angles/Angle/angle/[#1:1]-[#6X4:2]-[#1:3]
+   9 [  6.5767e+01 ] : Angles/Angle/k/[#1:1]-[#6X4:2]-[#1:3]
   10 [  1.2434e+02 ] : Angles/Angle/angle/[*:1]~[#6X3:2]~[*:3]
   11 [  1.3877e+02 ] : Angles/Angle/k/[*:1]~[#6X3:2]~[*:3]
   12 [  1.2055e+02 ] : Angles/Angle/angle/[#1:1]-[#6X3:2]~[*:3]
-  13 [  6.8408e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
-  14 [  1.1438e+02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
+  13 [  6.8421e+01 ] : Angles/Angle/k/[#1:1]-[#6X3:2]~[*:3]
+  14 [  1.1439e+02 ] : Angles/Angle/angle/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
   15 [  1.4036e+02 ] : Angles/Angle/k/[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]
-  16 [  3.6111e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
+  16 [  3.6113e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]:[#6X3:3]~[*:4]
   17 [  1.0500e+00 ] : ProperTorsions/Proper/k1/[*:1]~[#6X3:2]-[#8X2:3]-[*:4]
-  18 [  1.5393e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
+  18 [  1.5392e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X4]
   19 [  1.4821e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X4]
-  20 [  1.4798e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
-  21 [  1.4544e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
+  20 [  1.4792e-02 ] : vdW/Atom/epsilon/[#1:1]-[#6X3]
+  21 [  1.4543e+00 ] : vdW/Atom/rmin_half/[#1:1]-[#6X3]
   22 [  1.0948e-01 ] : vdW/Atom/epsilon/[#6X4:1]
   23 [  1.9164e+00 ] : vdW/Atom/rmin_half/[#6X4:1]
   24 [  1.7002e-01 ] : vdW/Atom/epsilon/[#8X2H0+0:1]
   25 [  1.6848e+00 ] : vdW/Atom/rmin_half/[#8X2H0+0:1]
 ----------------------------------------------------------
-Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_36.offxml
+Backing up result/optimize/smirnoff99Frosst_experimental.offxml -> result/optimize/smirnoff99Frosst_experimental_47.offxml
 #========================================================================#
 #|  The force field has been written to the result/optimize directory.  |#
 #|    Input file with optimization parameters saved to optimize.sav.    |#


### PR DESCRIPTION
This PR uses the OpenFF API to apply changes to parameters in the SMIRNOFF (and all OpenFF-style) force fields.  This should work with all parameter types, "free" as well as "evaluated" parameters, and all targets.

One "todo" is to identify which hacks in `smirnoff_hack.py` are no longer necessary; @yudongqiu might want to take a look. Also tagging @j-wags .