### PR TITLE
improve assign_openff_parameter performance by caching parameter search

### DIFF
--- a/src/parser.py
+++ b/src/parser.py
@@ -322,7 +322,7 @@ def read_mvals(fobj):
     for line in fobj:
         if re.match("(/read_mvals)|(^\$end)",line):
             break
-        Answer.append(float(line.split('[')[-1].split(']')[0].split()[-1]))
+        Answer.append(float(line.split('[', maxsplit=1)[-1].split(']', maxsplit=1)[0].split()[-1]))
     return Answer
 
 def read_pvals(fobj):
@@ -330,7 +330,7 @@ def read_pvals(fobj):
     for line in fobj:
         if re.match("(/read_pvals)|(^\$end)",line):
             break
-        Answer.append(float(line.split('[')[-1].split(']')[0].split()[-1]))
+        Answer.append(float(line.split('[', maxsplit=1)[-1].split(']', maxsplit=1)[0].split()[-1]))
     return Answer
 
 def read_priors(fobj):


### PR DESCRIPTION
The purpose of this PR is to improve the performance of the `smirnoffio. assign_openff_parameter()` function.

### Background
This function is introduced in recent PR #148. In theory, updating parameters the OpenFF ForceField object through the API should be faster, I found in my benchmark that it actually become a bit slower than the previous version that cached the ForceField initialization. (Still faster than the original version without cache).
The reason for the performance regression is that the `assign_openff_parameter()` function is called `n_param` times each time the ForceBalance forcefield is updated in `make()`, and numerical displacements require make() function to be called `2 x n_param` times. Therefore the total scaling of the time that the `assign_openff_parameter()` is called is `2 x n_param^2`. This become costly in my benchmark with 508 parameters.

### Method
In the PR we simply cache the parameter finding in `assign_openff_parameter()`, so this function become basically "free" after the initial parameter finding. This effectively reduce the total cost to `n_param`.

### Timing
Here are some timing numbers in my benchmark of one target evaluation.
```
                        [original]    [cached_FF_init]    [modify_api]   [cached_modify_api]
[update forcefield]      41.8             19.9              26.2             0.26
[create system]          10.7             10.8              10.5             10.5
[wall]                   78.7             56.1              62.4             35.5
```
The [create system] is the time cost of `create_openmm_system` after smirnoff_hack, shown here as a reference timing between runs.

### Note
Further performance optimization can be done by only call assign_openff_parameter() function for updated parameters. However since the cached `assign_openff_parameter()` is very fast, the further optimization is less useful.