### PR TITLE
Improve normal_modes() for OpenMM/SMIRNOFF Engine and Vibration_SMIRNOFF

### DIFF
--- a/src/forcefield.py
+++ b/src/forcefield.py
@@ -1506,7 +1506,7 @@ class FF(forcebalance.BaseClass):
                     # Arrows point from successors to predecessors in the plot representation
                     self.pTree.add_edge(pid, src_nodes[0])
                 else:
-                    raise RuntimeError('Evaluated parameter refers to a source parameter that does not exist')
+                    raise RuntimeError('Evaluated parameter refers to a source parameter that does not exist:\n%s'%cmd)
                 
         self.pfields.append([pid,fnm,ln,pfld,mult,cmd])
 

--- a/src/openmmio.py
+++ b/src/openmmio.py
@@ -1100,16 +1100,8 @@ class OpenMM(Engine):
         negatives = (eigvals >= 0).astype(int) * 2 - 1 # record the negative ones
         freqs = np.sqrt(np.abs(eigvals)) * coef * negatives
         # step 4: convert eigenvectors to normal modes
-        massList = np.array(self.AtomLists['Mass'])[self.realAtomIdxs] # unit in dalton
-        if not noa == len(massList) == len(eigvecs)/3:
-            error('number of the real atoms not consistent bewteen massList and hessian')
-        # scale the eigenvectors by mass^-1/2
-        normal_modes = (eigvecs.reshape(noa, -1) / np.sqrt(massList)[:, np.newaxis]).reshape(noa*3, noa*3)
         # re-arange to row index and shape
-        normal_modes = normal_modes.T.reshape(noa*3, noa, 3)
-        # nomalize the scaled normal modes
-        norm_factors = np.sqrt(np.sum(np.square(normal_modes), axis=(1,2)))
-        normal_modes /= norm_factors[:, np.newaxis, np.newaxis]
+        normal_modes = eigvecs.T.reshape(noa*3, noa, 3)
         # step 5: remove the 6 freqs with smallest abs value and corresponding normal modes
         n_remove = 5 if len(self.realAtomIdxs) == 2 else 6
         larger_freq_idxs = np.sort(np.argpartition(np.abs(freqs), n_remove)[n_remove:])

--- a/src/smirnoffio.py
+++ b/src/smirnoffio.py
@@ -533,6 +533,7 @@ class AbInitio_SMIRNOFF(AbInitio):
         """
         orig_pgrad_set = set(self.pgrad)
         # smirks to param_idxs map
+        smirks_params_map = defaultdict(list)
         for pname in self.FF.pTree:
             smirks = pname.rsplit('/',maxsplit=1)[-1]
             for pidx in self.FF.get_mathid(pname):
@@ -580,6 +581,7 @@ class Vibration_SMIRNOFF(Vibration):
         """
         orig_pgrad_set = set(self.pgrad)
         # smirks to param_idxs map
+        smirks_params_map = defaultdict(list)
         for pname in self.FF.pTree:
             smirks = pname.rsplit('/',maxsplit=1)[-1]
             for pidx in self.FF.get_mathid(pname):

--- a/src/smirnoffio.py
+++ b/src/smirnoffio.py
@@ -163,6 +163,8 @@ def assign_openff_parameter(ff, new_value, pid):
             unit = getattr(parameter, value_name).unit
             # Get the quantity of the parameter in the OpenFF forcefield object
             param_quantity = getattr(parameter, value_name)
+        elif value_name in parameter._cosmetic_attribs:
+            param_quantity = None
         else:
             # If the value name is a periodic attribute (say, k1) then we need to use
             # a regex to split the value name into 'k' and '1', then set the appropriate
@@ -170,7 +172,7 @@ def assign_openff_parameter(ff, new_value, pid):
             attribute_split = re.split(r'(\d+)', value_name)
             # print(attribute_split)
             # assert len(attribute_split) == 2
-            assert hasattr(parameter, attribute_split[0])
+            assert hasattr(parameter, attribute_split[0]), "%s.%s not exist" % (parameter, attribute_split[0])
             # attribute_split[0] is a string such as 'k'
             value_name = attribute_split[0]
             # parameter_index is the position of k1 in the values associated with 'k'
@@ -184,7 +186,8 @@ def assign_openff_parameter(ff, new_value, pid):
     else:
         param_quantity = ff._forcebalance_assign_parameter_map[pid]
     # set new_value directly in the quantity
-    param_quantity._value = new_value
+    if param_quantity != None:
+        param_quantity._value = new_value
 
 class SMIRNOFF(OpenMM):
 

--- a/src/smirnoffio.py
+++ b/src/smirnoffio.py
@@ -186,7 +186,7 @@ def assign_openff_parameter(ff, new_value, pid):
     else:
         param_quantity = ff._forcebalance_assign_parameter_map[pid]
     # set new_value directly in the quantity
-    if param_quantity != None:
+    if param_quantity is not None:
         param_quantity._value = new_value
 
 class SMIRNOFF(OpenMM):


### PR DESCRIPTION
This PR contains:

1. Previously the `normal_modes()` method in OpenMM Engine performs the mass-weight scaling on the eigenvectors of the mass-weighted hessian matrix. This is not consistent with the other engines because the mass-weight scaling of the eigenvectors is also done in the `process_vectors()` function in `Vibration` target. This PR will fix it by removing the step.

2. The `Vibration_SMIRNOFF` target is improved by `smirnoff_update_pgrads()` to skip the calculation of gradients on parameters not related to the molecule of the target.

3. The `smirnoff_update_pgrads()` is also improved in `AbInitio_SMIRNOFF` target, to correctly follow the relation of parameters defined in `parameter_eval` to find which parameter is related to the molecule of this target.