### PR TITLE
Unpin pymbar version

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -20,7 +20,7 @@ dependencies:
   - zlib
   - swig
   - future
-  - pymbar=3.0.3
+  - pymbar
   - openmm
   - ambertools
   # The following two are not compatible with python 2.7 and 3.5, so they are conditionally installed in .travis.yml


### PR DESCRIPTION
Now that pymbar has removed the API-breaking change in version 3.0.5, we can unpin the version and hopefully all tests will run normally.