### PR TITLE
Move crash criteria after convergence criteria in optimization code

### DIFF
--- a/src/optimizer.py
+++ b/src/optimizer.py
@@ -647,6 +647,15 @@ class Optimizer(forcebalance.BaseClass):
                     logger.info("Convergence criterion reached for objective function (%.2e)\n" % self.convergence_objective)
                     ncrit += 1
             if ncrit >= self.criteria: break
+            # Either of these conditions could cause a convergence failure:
+            # Check for whether the maximum number of optimization cycles is reached.
+            if ITERATION == self.maxstep:
+                logger.info("Maximum number of optimization steps reached (%i)\n" % ITERATION)
+                break
+            # Check for whether the step size is too small to continue.
+            if ITERATION > self.iterinit and ndx < self.step_lowerbound:
+                logger.info("Step size is too small to continue (%.3e < %.3e)\n" % (ndx, self.step_lowerbound))
+                break
             #================================#
             #| Save optimization variables  |#
             #| before taking the next step. |#
@@ -695,14 +704,6 @@ class Optimizer(forcebalance.BaseClass):
                 self.writechk()           
             outfnm = self.save_mvals_to_input(xk)
             logger.info("Input file with saved parameters: %s\n" % outfnm)
-            # Check for whether the maximum number of optimization cycles is reached.
-            if ITERATION == self.maxstep:
-                logger.info("Maximum number of optimization steps reached (%i)\n" % ITERATION)
-                break
-            # Check for whether the step size is too small to continue.
-            if ndx < self.step_lowerbound:
-                logger.info("Step size is too small to continue (%.3e < %.3e)\n" % (ndx, self.step_lowerbound))
-                break
 
         cnvgd = ncrit >= self.criteria
         bar = printcool("\x1b[0m%s\x1b[0m\nFinal objective function value\nFull: % .6e  Un-penalized: % .6e" % 

--- a/src/optimizer.py
+++ b/src/optimizer.py
@@ -466,6 +466,7 @@ class Optimizer(forcebalance.BaseClass):
                       bold=0, color=0, center=[True, False, False, False, False])
         # Optimization steps before this one are ineligible for consideration for "best step".
         Best_Start = 0
+        criteria_satisfied = {'step' : False, 'grad' : False, 'obj' : False}
 
         def print_progress(itn, nx, nd, ng, clr, x, std, qual):
             # Step number, norm of parameter vector / step / gradient, objective function value, change from previous steps, step quality.
@@ -631,7 +632,6 @@ class Optimizer(forcebalance.BaseClass):
             #================================#
             #|  Check convergence criteria. |#
             #================================#
-            ncrit = 0
             # Three conditions for checking convergence criteria:
             # 1) If any of the targets contain statistical uncertainty
             # 2) If the step quality is above the "low quality" threshold, -or- if we allow convergence on low quality steps
@@ -639,23 +639,17 @@ class Optimizer(forcebalance.BaseClass):
             if self.uncert or (self.converge_lowq or Quality > ThreLQ) or (ITERATION == self.iterinit and self.iterinit > 0):
                 if ngd < self.convergence_gradient:
                     logger.info("Convergence criterion reached for gradient norm (%.2e)\n" % self.convergence_gradient)
-                    ncrit += 1
+                    criteria_satisfied['grad'] = True
+                else: criteria_satisfied['grad'] = False
                 if ndx < self.convergence_step and ndx >= 0.0 and ITERATION > self.iterinit:
                     logger.info("Convergence criterion reached in step size (%.2e)\n" % self.convergence_step)
-                    ncrit += 1
+                    criteria_satisfied['step'] = True
+                else: criteria_satisfied['step'] = False
                 if stdfront < self.convergence_objective and len(X_hist) >= self.hist:
                     logger.info("Convergence criterion reached for objective function (%.2e)\n" % self.convergence_objective)
-                    ncrit += 1
-            if ncrit >= self.criteria: break
-            # Either of these conditions could cause a convergence failure:
-            # Check for whether the maximum number of optimization cycles is reached.
-            if ITERATION == self.maxstep:
-                logger.info("Maximum number of optimization steps reached (%i)\n" % ITERATION)
-                break
-            # Check for whether the step size is too small to continue.
-            if ITERATION > self.iterinit and ndx < self.step_lowerbound:
-                logger.info("Step size is too small to continue (%.3e < %.3e)\n" % (ndx, self.step_lowerbound))
-                break
+                    criteria_satisfied['obj'] = True
+                else: criteria_satisfied['obj'] = False
+            if sum(criteria_satisfied.values()) >= self.criteria: break
             #================================#
             #| Save optimization variables  |#
             #| before taking the next step. |#
@@ -680,6 +674,27 @@ class Optimizer(forcebalance.BaseClass):
             # Increment the parameters.
             xk += dx
             ndx = np.linalg.norm(dx)
+            #===============================#
+            #|  Second convergence check.  |#
+            #===============================#
+            # At this point in the optimization cycle, we have G(i) --> dx(i) but not dx(i) --> G(i+1).
+            # Here we check if the step size is below threshold and decide to converge before
+            # evaluating the next gradient.
+            if self.uncert or (self.converge_lowq or Quality > ThreLQ) or (ITERATION == self.iterinit and self.iterinit > 0):
+                if ndx < self.convergence_step and ndx >= 0.0 and ITERATION > self.iterinit:
+                    logger.info("Convergence criterion reached in step size (%.2e)\n" % self.convergence_step)
+                    criteria_satisfied['step'] = True
+                else: criteria_satisfied['step'] = False
+            if sum(criteria_satisfied.values()) >= self.criteria: break
+            # Either of these conditions could cause a convergence failure:
+            # The maximum number of optimization cycles is reached.
+            if ITERATION == self.maxstep:
+                logger.info("Maximum number of optimization steps reached (%i)\n" % ITERATION)
+                break
+            # The step size is too small to continue. Sometimes happens for very rough objective functions.
+            if ITERATION > self.iterinit and ndx < self.step_lowerbound:
+                logger.info("Step size is too small to continue (%.3e < %.3e)\n" % (ndx, self.step_lowerbound))
+                break
             #================================#
             #|  Increase iteration number.  |#
             #================================#
@@ -705,7 +720,7 @@ class Optimizer(forcebalance.BaseClass):
             outfnm = self.save_mvals_to_input(xk)
             logger.info("Input file with saved parameters: %s\n" % outfnm)
 
-        cnvgd = ncrit >= self.criteria
+        cnvgd = sum(criteria_satisfied.values()) >= self.criteria
         bar = printcool("\x1b[0m%s\x1b[0m\nFinal objective function value\nFull: % .6e  Un-penalized: % .6e" % 
                         ("\x1b[1mOptimization Converged" if cnvgd else "\x1b[1;91mConvergence Failure",
                          data['X'],data['X0']), color=2)


### PR DESCRIPTION
The optimization loop currently looks like:

1) calculate obj,grad
2) check convergence(obj, grad, step)
3) take step
4) check failure(step) (this is where the unintended convergence failure occurs)
5) calculate obj,grad (next cycle)

Step (4) above involves checking two "failure criteria". One of these criteria is that the step size is below a very small threshold `Optimizer.lowerbound`. The intended purpose is to quit when the objective function is very rough and it is not productive to perform further gradient-based optimization. The reason why "check failure" is located after (3), and not after (2), is because we don't need to evaluate the objective function and gradient again to know whether a failure has occurred.

The current implementation caused some unintended behavior. In an example that Mark Mackey provided, the optimization was performed with `criteria 2` which meant that two out of three convergence criteria needed to be met for the optimization to converge. At (2), if the gradient met the convergence criterion but the step has not (i.e. the optimization takes a large step and is now at the minimum), it may take a very small step in (3). Step (4) would then trigger if the step size was below `Optimizer.lowerbound`. However, if the optimization had been allowed to continue for one more loop iteration to (2), it would have converged.

This PR modifies the behavior so that step (2) and (4) from the same loop iteration could be used to check convergence, i.e. if the step that either *proceeds from or follows* a converged gradient is converged, the optimization can converge. This amounts to relaxing the convergence criteria a bit, but I think it makes the most sense.