### PR TITLE
Re-raise exception when NumPy/SciPy imports fail

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ except ImportError as e:
         "Error importing numpy and scipy but these are required to install ForceBalance.\n"
         "Please make sure the numpy and scipy modules are installed and try again.\n"
     )
-    raise ImportError(msg) from e
+    raise ImportError(msg)
 
 #===================================#
 #|   ForceBalance version number   |#

--- a/setup.py
+++ b/setup.py
@@ -15,11 +15,13 @@ import subprocess
 try:
     import numpy
     import scipy
-except ImportError:
-    print("Error importing numpy and scipy but these are required to install ForceBalance")
-    print("Please make sure the numpy and scipy modules are installed and try again")
-    exit()
-    
+except ImportError as e:
+    msg = (
+        "Error importing numpy and scipy but these are required to install ForceBalance"
+        "Please make sure the numpy and scipy modules are installed and try again"
+    )
+    raise ImportError(msg) from e
+
 #===================================#
 #|   ForceBalance version number   |#
 #| Make sure to update the version |#

--- a/setup.py
+++ b/setup.py
@@ -16,9 +16,9 @@ try:
     import numpy
     import scipy
 except ImportError as e:
-    msg = (
-        "Error importing numpy and scipy but these are required to install ForceBalance"
-        "Please make sure the numpy and scipy modules are installed and try again"
+    msg = ("\n"
+        "Error importing numpy and scipy but these are required to install ForceBalance.\n"
+        "Please make sure the numpy and scipy modules are installed and try again.\n"
     )
     raise ImportError(msg) from e
 


### PR DESCRIPTION
The check for NumPy/SciPy installs in `setup.py` prints out a helpful message for the user and exits (so that the rest of the install attempt does not proceed) but raises exit code 0 when it should probably raise 1. This may cause some issues downstream when these packages are not installed properly but this error is only printed to stdout or a logfile but doesn't stop a conda build from happening.

Just to demonstrate this, since it can't easily be added to CI (`echo $?` prints the exit status of the last command, which I just learned by working on this)
```shell
bash-3.2$ python -c "exit()"
bash-3.2$ echo $?
0
bash-3.2$ python -c "raise Exception"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
Exception
bash-3.2$ echo $?
1

```

And here's what it looks like to the user before and after this patch
```shell
(omnia) [forcebalance] python setup.py install                                                                                                                                                                                        master
Error importing numpy and scipy but these are required to install ForceBalance
Please make sure the numpy and scipy modules are installed and try again
(omnia) [forcebalance] echo $?                                                                                                                                                                                                        master
0
(omnia) [forcebalance] git checkout loud-importerror                                                                                                                                                                                  master
Switched to branch 'loud-importerror'
(omnia) [forcebalance] python setup.py install                                                                                                                                                                              loud-importerror
Traceback (most recent call last):
  File "setup.py", line 16, in <module>
    import numpy
ModuleNotFoundError: No module named 'numpy'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "setup.py", line 23, in <module>
    raise ImportError(msg) from e
ImportError:
Error importing numpy and scipy but these are required to install ForceBalance.
Please make sure the numpy and scipy modules are installed and try again.

(omnia) [forcebalance] echo $?                                                                                                                                                                                              loud-importerror
1