### PR TITLE
Add .gitattributes file for _version.py

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+src/_version.py export-subst


### PR DESCRIPTION
Right now, `conda-forge` builds the conda package by downloading the tarball from GitHub (through the "Releases" tab here). This archive does not contain the `git` history and breaks something with the versioneer config as a result.

```
(openff-dev) [forcebalance] conda list | grep forcebalance 
forcebalance              1.7.4            py36h63ed162_0    conda-forge
(openff-dev) [forcebalance] python -c "import forcebalance; print(forcebalance.__version__)"
0+unknown
```
 This patch ensures this doesn't happen for future releases, but will not fix this specific issue with this released version. I don't personally think this is serious enough to warrant an entirely new release since the version is still known to conda and pip. If something needs `forcebalance.__version__` to print an accurate tag, there are some workarounds that can bypass the need for an entire release.

Also note that [geomeTRIC](https://github.com/leeping/geomeTRIC/blob/327fb9191fc6a9143b4e7fcde15599d5993cf4fa/.gitattributes) already has this set up the "right" way