### PR TITLE
Use OpenMM.System instead of OpenMM.Forcefield to check for Drude force

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       shell: bash -l {0}
       run: |
         # This will not install double precision, needs to be replaced with a fresh build
-        conda install gromacs=2020.5 -c bioconda -c conda-forge -y
+        conda install gromacs=4.6.5 -c bioconda -c conda-forge -y
 
     - name: Install Tinker
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       shell: bash -l {0}
       run: |
         # This will not install double precision, needs to be replaced with a fresh build
-        conda install gromacs -c bioconda -c conda-forge -y
+        conda install gromacs=2020.5 -c bioconda -c conda-forge -y
 
     - name: Install Tinker
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       shell: bash -l {0}
       run: |
         # This will not install double precision, needs to be replaced with a fresh build
-        conda install gromacs=4.6.5 -c bioconda -c conda-forge -y
+        conda install gromacs=2019.1 -c bioconda -c conda-forge -y
 
     - name: Install Tinker
       run: |

--- a/src/openmmio.py
+++ b/src/openmmio.py
@@ -842,10 +842,10 @@ class OpenMM(Engine):
                     logger.info("Creating RPMD integrator with %i beads.\n" % rpmd_beads)
                     self.tdiv = rpmd_beads
                     integrator = RPMDIntegrator(rpmd_beads, temperature*kelvin, collision/picosecond, timestep*femtosecond)
-                elif any(['Drude' in f.__class__.__name__ for f in self.forcefield._forces]): integrator = DrudeLangevinIntegrator(temperature*kelvin, collision/picosecond, 1*kelvin, collision/picosecond, 0.1*femtoseconds)
+                elif any(['Drude' in f.__class__.__name__ for f in self.system.getForces()]): integrator = DrudeLangevinIntegrator(temperature*kelvin, collision/picosecond, 1*kelvin, collision/picosecond, 0.1*femtoseconds)
                 else:
                     integrator = LangevinIntegrator(temperature*kelvin, collision/picosecond, timestep*femtosecond)
-        elif any(['Drude' in f.__class__.__name__ for f in self.forcefield._forces]): integrator = DrudeSCFIntegrator(0.1*femtoseconds)
+        elif any(['Drude' in f.__class__.__name__ for f in self.system.getForces()]): integrator = DrudeSCFIntegrator(0.1*femtoseconds)
         else:
             ## If no temperature control, default to the Verlet integrator.
             if rpmd_beads > 0:
@@ -969,7 +969,7 @@ class OpenMM(Engine):
         #have changed then the positions must be recomputed and
         #the simulation object must be remade.
         #----
-        if any(['Drude' in f.__class__.__name__ for f in self.forcefield._forces]):
+        if any(['Drude' in f.__class__.__name__ for f in self.system.getForces()]):
             drude_particle, drude_screen = GetDrudeParameters(self.system)
             if hasattr(self, 'simulation'):
                 if hasattr(self, 'drude_particle') and len(self.drude_particle)>0 and np.max(np.abs(self.drude_particle - drude_particle)) != 0:


### PR DESCRIPTION
Resolves https://github.com/leeping/forcebalance/issues/209 .

The problem was that the `SMIRNOFF` class calls `OpenMM.create_simulation()`, and the recently added Drude feature was checking for `OpenMM.forcefield._forces`, which is something not possessed by `SMIRNOFF.forcefield`.  The issue is fixed by checking for the presence of Drude forces using `OpenMM.system.getForces()` instead.