### PR TITLE
Load SMIRNOFF plugins by default

### DIFF
--- a/src/evaluator_io.py
+++ b/src/evaluator_io.py
@@ -438,13 +438,13 @@ class Evaluator_SMIRNOFF(Target):
         self.FF.make(mvals)
 
         force_field = smirnoff.ForceField(
-            self.FF.offxml, allow_cosmetic_attributes=True
+            self.FF.offxml, allow_cosmetic_attributes=True, load_plugins=True
         )
 
         # strip out cosmetic attributes
         with tempfile.NamedTemporaryFile(mode="w", suffix=".offxml") as file:
             force_field.to_file(file.name, discard_cosmetic_attributes=True)
-            force_field = smirnoff.ForceField(file.name)
+            force_field = smirnoff.ForceField(file.name, load_plugins=True)
 
         # Determine which gradients (if any) we should be estimating.
         parameter_gradient_keys = []

--- a/src/forcefield.py
+++ b/src/forcefield.py
@@ -458,7 +458,7 @@ class FF(forcebalance.BaseClass):
                 from openff.toolkit.typing.engines.smirnoff import ForceField as OpenFF_ForceField
                 self.offxml = ffname
                 self.openff_forcefield = OpenFF_ForceField(os.path.join(self.root, self.ffdir, self.offxml),
-                                                           allow_cosmetic_attributes=True)
+                                                           allow_cosmetic_attributes=True, load_plugins=True)
 
         self.amber_mol2 = []
         if fftype == "mol2":

--- a/src/recharge_io.py
+++ b/src/recharge_io.py
@@ -83,7 +83,9 @@ class Recharge_SMIRNOFF(Target):
 
         # Determine which BCC parameters are being optimized.
         force_field = smirnoff.ForceField(
-            os.path.join(self.FF.ffdir, self.FF.offxml), allow_cosmetic_attributes=True
+            os.path.join(self.FF.ffdir, self.FF.offxml),
+            allow_cosmetic_attributes=True,
+            load_plugins=True
         )
 
         bcc_handler = force_field.get_parameter_handler("ChargeIncrementModel")

--- a/src/smirnoffio.py
+++ b/src/smirnoffio.py
@@ -324,7 +324,7 @@ class SMIRNOFF(OpenMM):
             self.forcefield = self.FF.openff_forcefield
         else:
             self.offxml = listfiles(kwargs.get('offxml'), 'offxml', err=True)
-            self.forcefield = OpenFF_ForceField(*self.offxml)
+            self.forcefield = OpenFF_ForceField(*self.offxml, load_plugins=True)
 
         ## Load mol2 files for smirnoff topology
         openff_mols = []


### PR DESCRIPTION
## Description

This PR ensures that SMIRNOFF plugins (e.g. custom parameter handlers and functional forms) are loaded by default.

## Status

- [ ] Ready to go