### PR TITLE
Add option to delete micro outputs

### DIFF
--- a/src/optimizer.py
+++ b/src/optimizer.py
@@ -10,6 +10,7 @@ contained inside.
 from __future__ import division
 from __future__ import print_function
 
+import shutil
 from builtins import str
 from builtins import range
 from builtins import object
@@ -147,6 +148,8 @@ class Optimizer(forcebalance.BaseClass):
         self.set_option(options,'read_pvals')
         ## Whether to make backup files
         self.set_option(options, 'backup')
+        ## Whether to retain the output files of completed iterations
+        self.set_option(options, 'retain_micro_outputs')
         ## Name of the original input file
         self.set_option(options, 'input_file')
         ## Number of convergence criteria that must be met
@@ -882,6 +885,10 @@ class Optimizer(forcebalance.BaseClass):
             # This is our trial step.
             xk_ = dx + xk
             Result = self.Objective.Full(xk_,0,verbose=False,customdir="micro_%02i" % search_fun.micro)['X'] - data['X']
+
+            if not self.retain_micro_outputs:
+                shutil.rmtree("micro_%02i" % search_fun.micro)
+
             logger.info("Hessian diagonal search: H%+.4f*I, length %.4e, result % .4e\n" % ((L-1)**2,np.linalg.norm(dx),Result))
             search_fun.micro += 1
             return Result

--- a/src/parser.py
+++ b/src/parser.py
@@ -91,6 +91,7 @@ gen_opts_types = {
                  },
     'bools'   : {"backup"           : (1,  10,  'Write temp directories to backup before wiping them'),
                  "writechk_step"    : (1, -50,  'Write the checkpoint file at every optimization step'),
+                 "retain_micro_outputs"   : (1,  10,  'Whether to retain the output files of completed micro iterations'),
                  "converge_lowq"    : (0, -50,  'Allow convergence on "low quality" steps'),
                  "have_vsite"       : (0, -150, 'Specify whether there are virtual sites in the simulation (being fitted or not).  Enforces calculation of vsite positions.', 'Experimental feature in ESP fitting', ['ABINITIO']),
                  "constrain_charge" : (0,  10,  'Specify whether to constrain the charges on the molecules.', 'Printing the force field (all calculations)'),


### PR DESCRIPTION
## Description

When fitting against a large number of targets the number of `micro` directories created in `output.tmp`, and the number of files they contain, can grow quite large. This is especially true when the full optimisation takes many iterations >=20 to converge, and each individual iteration can require ~20-40 micro iterations before selecting a step size.

This PR adds an option to delete these `micro` directories after they are finished with, thus reducing the total number of files produced by an optimization. By default they are retained to preserve previous behaviour.