### PR TITLE
Fix #225

### DIFF
--- a/src/smirnoffio.py
+++ b/src/smirnoffio.py
@@ -518,6 +518,7 @@ class SMIRNOFF(OpenMM):
             self.create_simulation(**self.simkwargs)
 
     def _update_positions(self, X1, disable_vsite):
+        # X1 is a numpy ndarray not vec3
 
         if disable_vsite:
             super(SMIRNOFF, self)._update_positions(X1, disable_vsite)
@@ -526,9 +527,10 @@ class SMIRNOFF(OpenMM):
         n_v_sites = (
             self.mod.getTopology().getNumAtoms() - self.pdb.topology.getNumAtoms()
         )
-        if n_v_sites > 0:
-            # Add placeholder positions for any v-sites.
-            X1 = (X1 + [Vec3(0.0, 0.0, 0.0)] * n_v_sites)
+
+        # Add placeholder positions for any v-sites.
+        sites = np.zeros((n_v_sites, 3))
+        X1 = np.vstack((X1, sites))
 
         self.simulation.context.setPositions(X1 * angstrom)
         self.simulation.context.computeVirtualSites()

--- a/src/smirnoffio.py
+++ b/src/smirnoffio.py
@@ -526,9 +526,9 @@ class SMIRNOFF(OpenMM):
         n_v_sites = (
             self.mod.getTopology().getNumAtoms() - self.pdb.topology.getNumAtoms()
         )
-
-        # Add placeholder positions for an v-sites.
-        X1 = (X1 + [Vec3(0.0, 0.0, 0.0)] * n_v_sites) * angstrom
+        if n_v_sites > 0:
+            # Add placeholder positions for any v-sites.
+            X1 = (X1 + [Vec3(0.0, 0.0, 0.0)] * n_v_sites) * angstrom
 
         self.simulation.context.setPositions(X1)
         self.simulation.context.computeVirtualSites()

--- a/src/smirnoffio.py
+++ b/src/smirnoffio.py
@@ -528,9 +528,9 @@ class SMIRNOFF(OpenMM):
         )
         if n_v_sites > 0:
             # Add placeholder positions for any v-sites.
-            X1 = (X1 + [Vec3(0.0, 0.0, 0.0)] * n_v_sites) * angstrom
+            X1 = (X1 + [Vec3(0.0, 0.0, 0.0)] * n_v_sites)
 
-        self.simulation.context.setPositions(X1)
+        self.simulation.context.setPositions(X1 * angstrom)
         self.simulation.context.computeVirtualSites()
 
     def interaction_energy(self, fraga, fragb):


### PR DESCRIPTION
This PR fixes #225 by updating the `SMIRNOFF` engine to use the molecule object to work out the path to the pdb file inline with the `OPENMM` engine. 