### PR TITLE
Include conditional imports for openmm 7.6 compatibility

### DIFF
--- a/src/openmmio.py
+++ b/src/openmmio.py
@@ -33,6 +33,13 @@ from collections import OrderedDict
 from forcebalance.output import getLogger
 logger = getLogger(__name__)
 try:
+    # Try importing openmm using >=7.6 namespace
+    from openmm.app import *
+    from openmm import *
+    from simtk.unit import *
+    import openmm._openmm as _openmm
+except ImportError:
+    # Try importing openmm using <7.6 namespace
     from simtk.openmm.app import *
     from simtk.openmm import *
     from simtk.unit import *


### PR DESCRIPTION
CI is failing due to the openmm namespace change in OpenMM version 7.6. This PR will support importing from either namespace. I've tested this locally using `openmm=7.6.0` and `openmm=7.5.1`. I will merge this when CI passes.