### PR TITLE
Update all simtk imports to also be forward-compatible with OpenMM >7.6, and keep soft imports soft

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,7 @@ jobs:
         # python setup.py install
         python -m pip install --no-deps .
         python -c "import forcebalance; print(forcebalance.__version__)"
+        conda remove --force openmm
 
     - name: Run water study
       shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,6 @@ jobs:
         # python setup.py install
         python -m pip install --no-deps .
         python -c "import forcebalance; print(forcebalance.__version__)"
-        conda remove --force openmm
 
     - name: Run water study
       shell: bash -l {0}

--- a/src/data/md_ism_hfe.py
+++ b/src/data/md_ism_hfe.py
@@ -89,9 +89,14 @@ engname = TgtOpts['engname']
 # Import modules and create the correct Engine object.
 if engname == "openmm":
     try:
-        from simtk.unit import *
-        from simtk.openmm import *
-        from simtk.openmm.app import *
+        try:
+            from openmm.unit import *
+            from openmm import *
+            from openmm.app import *
+        except ImportError:
+            from simtk.unit import *
+            from simtk.openmm import *
+            from simtk.openmm.app import *
     except:
         traceback.print_exc()
         raise Exception("Cannot import OpenMM modules")

--- a/src/data/npt.py
+++ b/src/data/npt.py
@@ -52,9 +52,15 @@ engname          = args.engine.lower()     # Name of the engine
 
 if engname == "openmm":
     try:
-        from simtk.unit import *
-        from simtk.openmm import *
-        from simtk.openmm.app import *
+        try:
+            from openmm.unit import *
+            from openmm import *
+            from openmm.app import *
+        except ImportError:
+            from simtk.unit import *
+            from simtk.openmm import *
+            from simtk.openmm.app import *
+
     except:
         traceback.print_exc()
         raise Exception("Cannot import OpenMM modules")

--- a/src/data/npt_lipid.py
+++ b/src/data/npt_lipid.py
@@ -52,9 +52,15 @@ engname          = args.engine.lower()     # Name of the engine
 
 if engname == "openmm":
     try:
-        from simtk.unit import *
-        from simtk.openmm import *
-        from simtk.openmm.app import *
+        try:
+            from openmm.unit import *
+            from openmm import *
+            from openmm.app import *
+        except ImportError:
+            from simtk.unit import *
+            from simtk.openmm import *
+            from simtk.openmm.app import *
+
     except:
         traceback.print_exc()
         raise Exception("Cannot import OpenMM modules")

--- a/src/data/nvt.py
+++ b/src/data/nvt.py
@@ -76,9 +76,15 @@ engname          = args.engine.lower()     # Name of the engine
 
 if engname == "openmm":
     try:
-        from simtk.unit import *
-        from simtk.openmm import *
-        from simtk.openmm.app import *
+        try:
+            from openmm.unit import *
+            from openmm import *
+            from openmm.app import *
+        except ImportError:
+            from simtk.unit import *
+            from simtk.openmm import *
+            from simtk.openmm.app import *
+
     except:
         traceback.print_exc()
         raise Exception("Cannot import OpenMM modules")

--- a/src/evaluator_io.py
+++ b/src/evaluator_io.py
@@ -308,7 +308,10 @@ class Evaluator_SMIRNOFF(Target):
         bool
             Returns True if the parameter is a cosmetic one.
         """
-        import simtk.unit as simtk_unit
+        try:
+            import openmm.unit as simtk_unit
+        except ImportError:
+            import simtk.unit as simtk_unit
 
         parameter_handler = self.FF.openff_forcefield.get_parameter_handler(
             gradient_key.tag

--- a/src/molecule.py
+++ b/src/molecule.py
@@ -341,9 +341,14 @@ if "forcebalance" in __name__:
     #| OpenMM interface functions |#
     #==============================#
     try:
-        from simtk.unit import *
-        from simtk.openmm import *
-        from simtk.openmm.app import *
+        try:
+            from openmm.unit import *
+            from openmm import *
+            from openmm.app import *
+        except ImportError:
+            from simtk.unit import *
+            from simtk.openmm import *
+            from simtk.openmm.app import *
     except ImportError:
         logger.debug('Note: Cannot import optional OpenMM module.\n')
 
@@ -359,9 +364,14 @@ elif "geometric" in __name__:
     #| OpenMM interface functions |#
     #==============================#
     try:
-        from simtk.unit import *
-        from simtk.openmm import *
-        from simtk.openmm.app import *
+        try:
+            from openmm.unit import *
+            from openmm import *
+            from openmm.app import *
+        except ImportError:
+            from simtk.unit import *
+            from simtk.openmm import *
+            from simtk.openmm.app import *
     except ImportError:
         logger.debug('Note: Failed to import optional OpenMM module.\n')
 

--- a/src/openmmio.py
+++ b/src/openmmio.py
@@ -33,18 +33,19 @@ from collections import OrderedDict
 from forcebalance.output import getLogger
 logger = getLogger(__name__)
 
-from simtk.unit import *
 # Handle simtk namespace change around 7.6 release
 try:
     try:
         # Try importing openmm using >=7.6 namespace
         from openmm.app import *
         from openmm import *
+        from openmm.unit import *
         import openmm._openmm as _openmm
     except ImportError:
         # Try importing openmm using <7.6 namespace
         from simtk.openmm.app import *
         from simtk.openmm import *
+        from simtk.unit import *
         import simtk.openmm._openmm as _openmm
 except ImportError:
     # Need to have "pass" conditional if neither is installed so that non-openmm builds can parse this file

--- a/src/openmmio.py
+++ b/src/openmmio.py
@@ -32,19 +32,22 @@ from forcebalance.nifty import _exec
 from collections import OrderedDict
 from forcebalance.output import getLogger
 logger = getLogger(__name__)
+
+from simtk.unit import *
+# Handle simtk namespace change around 7.6 release
 try:
-    # Try importing openmm using >=7.6 namespace
-    from openmm.app import *
-    from openmm import *
-    from simtk.unit import *
-    import openmm._openmm as _openmm
+    try:
+        # Try importing openmm using >=7.6 namespace
+        from openmm.app import *
+        from openmm import *
+        import openmm._openmm as _openmm
+    except ImportError:
+        # Try importing openmm using <7.6 namespace
+        from simtk.openmm.app import *
+        from simtk.openmm import *
+        import simtk.openmm._openmm as _openmm
 except ImportError:
-    # Try importing openmm using <7.6 namespace
-    from simtk.openmm.app import *
-    from simtk.openmm import *
-    from simtk.unit import *
-    import simtk.openmm._openmm as _openmm
-except:
+    # Need to have "pass" conditional if neither is installed so that non-openmm builds can parse this file
     pass
 
 def get_mask(grps):

--- a/src/tests/files/XmlScript_out/TIP3G2w_out_ref.xml
+++ b/src/tests/files/XmlScript_out/TIP3G2w_out_ref.xml
@@ -38,9 +38,14 @@
 
 from math import pi
 import numpy as np
-from simtk import openmm as mm
-from simtk.openmm import app
-from simtk import unit as u
+try:
+    import openmm as mm
+    from openmm import app
+    from openmm import unit as u
+except ImportError:
+    from simtk import openmm as mm
+    from simtk.openmm import app
+    from simtk import unit as u
 
 epsilon = 8.854187817620E-12*u.farad/u.meter
 COULOMB_CONSTANT = (u.AVOGADRO_CONSTANT_NA/(4.0*pi*epsilon)).value_in_unit_system(u.md_unit_system)

--- a/src/tests/files/forcefield/TIP3G2w.xml
+++ b/src/tests/files/forcefield/TIP3G2w.xml
@@ -38,9 +38,14 @@
 
 from math import pi
 import numpy as np
-from simtk import openmm as mm
-from simtk.openmm import app
-from simtk import unit as u
+try:
+    import openmm as mm
+    from openmm import app
+    from openmm import unit as u
+except ImportError:
+    from simtk import openmm as mm
+    from simtk.openmm import app
+    from simtk import unit as u
 
 epsilon = 8.854187817620E-12*u.farad/u.meter
 COULOMB_CONSTANT = (u.AVOGADRO_CONSTANT_NA/(4.0*pi*epsilon)).value_in_unit_system(u.md_unit_system)

--- a/src/tests/test_engine.py
+++ b/src/tests/test_engine.py
@@ -94,7 +94,10 @@ class TestAmber99SB(ForceBalanceTestCase):
             logger.warn("TINKER cannot be found, skipping TINKER tests.")
         # Set up OpenMM engine
         try:
-            import simtk.openmm
+            try:
+                import openmm
+            except ImportError:
+                import simtk.openmm
             cls.engines['OpenMM'] = OpenMM(coords="all.gro", pdb="conf.pdb", ffxml="a99sb.xml", platname="Reference", precision="double")
         except:
             logger.warn("OpenMM cannot be imported, skipping OpenMM tests.")

--- a/src/tests/test_openmmio.py
+++ b/src/tests/test_openmmio.py
@@ -3,16 +3,17 @@ import forcebalance
 from forcebalance.openmmio import PrepareVirtualSites, ResetVirtualSites_fast
 
 import numpy as np
-from simtk import unit
 
 try:
     # Try importing openmm using >=7.6 namespace
     from openmm import app
     import openmm as mm
+    from openmm import unit
 except ImportError:
     # Try importing openmm using <7.6 namespace
     import simtk.openmm as mm
     from simtk.openmm import app
+    from simtk import unit
 
 
 import os

--- a/src/tests/test_openmmio.py
+++ b/src/tests/test_openmmio.py
@@ -1,10 +1,20 @@
 from __future__ import absolute_import
 import forcebalance
 from forcebalance.openmmio import PrepareVirtualSites, ResetVirtualSites_fast
-import simtk.openmm as mm
-from simtk.openmm import app
+
 import numpy as np
 from simtk import unit
+
+try:
+    # Try importing openmm using >=7.6 namespace
+    from openmm import app
+    import openmm as mm
+except ImportError:
+    # Try importing openmm using <7.6 namespace
+    import simtk.openmm as mm
+    from simtk.openmm import app
+
+
 import os
 import shutil
 from .test_target import TargetTests # general targets tests defined in test_target.py

--- a/studies/018_improper_angle/targets/dimethylamine.2D-scan/make-labels.py
+++ b/studies/018_improper_angle/targets/dimethylamine.2D-scan/make-labels.py
@@ -5,9 +5,15 @@ import numpy as np
 import sys
 
 # Import OpenMM tools
-from simtk import openmm, unit
-from simtk.openmm import Platform
-from simtk.openmm.app import *
+try:
+    import openmm
+    from openmm import unit
+    from openmm import Platform
+    from openmm.app import *
+except ImportError:
+    from simtk import openmm, unit
+    from simtk.openmm import Platform
+    from simtk.openmm.app import *
 
 # Use MDTraj to write simulation trajectories
 from mdtraj.reporters import NetCDFReporter


### PR DESCRIPTION
My changes in #237 made ForceBalance work with EITHER openmm >=7.6 OR <7.6. However, I didn't take into consideration builds with no openmm at all. Since openmmio is imported even in the absense of an installed openmm package, the imports need to allow parsing of the file regardless of whether openmm is installed.

Since there are many variables here ({hard vs. soft imports}, {openmm 7.5 vs. 7.6 vs. no openmm}, {tests vs. studies}...) we should be pretty thorough in our checks. I propose the following:

- [x] Ensure vanilla CI passes and doesn't skip openmmio tests ([done](https://github.com/leeping/forcebalance/runs/3637497811#step:12:75))
- [x] Ensure CI that's forced to use OpenMM 7.5 (with the old namespace) passes and doesn't skip openmmio tests ([done](https://github.com/leeping/forcebalance/runs/3637495901#step:12:75))
- [ ] Ensure that studies still run with OpenMM 7.5
- [ ] Ensure that studies still run with OpenMM 7.6
- [ ] Ensure that non-openMM-requiring ForceBalance functionality is available without installing OpenMM