### PR TITLE
Update smirnoff_hack.py for OpenFF Toolkit 0.10.3

### DIFF
--- a/src/smirnoff_hack.py
+++ b/src/smirnoff_hack.py
@@ -128,7 +128,7 @@ if _SHOULD_CACHE:
     def oe_cached_generate_conformers(self, molecule, n_conformers=1, rms_cutoff=None, clear_existing=True, make_carboxylic_acids_cis=False):
         cache_key = hash((hash_molecule(molecule), n_conformers, str(rms_cutoff), clear_existing, make_carboxylic_acids_cis))
         if cache_key not in OE_TOOLKIT_CACHE_molecule_conformers:
-            oe_original_generate_conformers(self, molecule, n_conformers=n_conformers,                     rms_cutoff=rms_cutoff, clear_existing=clear_existing, make_carboxylic_acids_cis=make_carboxylic_acids_cis)
+            oe_original_generate_conformers(self, molecule, n_conformers=n_conformers, rms_cutoff=rms_cutoff, clear_existing=clear_existing, make_carboxylic_acids_cis=make_carboxylic_acids_cis)
             OE_TOOLKIT_CACHE_molecule_conformers[cache_key] = molecule._conformers
         molecule._conformers = OE_TOOLKIT_CACHE_molecule_conformers[cache_key]
     OpenEyeToolkitWrapper.generate_conformers = oe_cached_generate_conformers

--- a/src/smirnoff_hack.py
+++ b/src/smirnoff_hack.py
@@ -125,10 +125,10 @@ if _SHOULD_CACHE:
     # cache the OE generate_conformers function (save 15s)
     OE_TOOLKIT_CACHE_molecule_conformers = {}
     oe_original_generate_conformers = OpenEyeToolkitWrapper.generate_conformers
-    def oe_cached_generate_conformers(self, molecule, n_conformers=1, rms_cutoff=None, clear_existing=True):
-        cache_key = hash((hash_molecule(molecule), n_conformers, str(rms_cutoff), clear_existing))
+    def oe_cached_generate_conformers(self, molecule, n_conformers=1, rms_cutoff=None, clear_existing=True, make_carboxylic_acids_cis=False):
+        cache_key = hash((hash_molecule(molecule), n_conformers, str(rms_cutoff), clear_existing, make_carboxylic_acids_cis))
         if cache_key not in OE_TOOLKIT_CACHE_molecule_conformers:
-            oe_original_generate_conformers(self, molecule, n_conformers=n_conformers, rms_cutoff=rms_cutoff, clear_existing=clear_existing)
+            oe_original_generate_conformers(self, molecule, n_conformers=n_conformers,                     rms_cutoff=rms_cutoff, clear_existing=clear_existing, make_carboxylic_acids_cis=make_carboxylic_acids_cis)
             OE_TOOLKIT_CACHE_molecule_conformers[cache_key] = molecule._conformers
         molecule._conformers = OE_TOOLKIT_CACHE_molecule_conformers[cache_key]
     OpenEyeToolkitWrapper.generate_conformers = oe_cached_generate_conformers
@@ -137,10 +137,10 @@ if _SHOULD_CACHE:
     # cache the RDKit generate_conformers function
     RDK_TOOLKIT_CACHE_molecule_conformers = {}
     rdk_original_generate_conformers = RDKitToolkitWrapper.generate_conformers
-    def rdk_cached_generate_conformers(self, molecule, n_conformers=1, rms_cutoff=None, clear_existing=True):
-        cache_key = hash((hash_molecule(molecule), n_conformers, str(rms_cutoff), clear_existing))
+    def rdk_cached_generate_conformers(self, molecule, n_conformers=1, rms_cutoff=None, clear_existing=True, make_carboxylic_acids_cis=False):
+        cache_key = hash((hash_molecule(molecule), n_conformers, str(rms_cutoff), clear_existing, make_carboxylic_acids_cis))
         if cache_key not in RDK_TOOLKIT_CACHE_molecule_conformers:
-            rdk_original_generate_conformers(self, molecule, n_conformers=n_conformers, rms_cutoff=rms_cutoff, clear_existing=clear_existing)
+            rdk_original_generate_conformers(self, molecule, n_conformers=n_conformers, rms_cutoff=rms_cutoff, clear_existing=clear_existing, make_carboxylic_acids_cis=make_carboxylic_acids_cis)
             RDK_TOOLKIT_CACHE_molecule_conformers[cache_key] = molecule._conformers
         molecule._conformers = RDK_TOOLKIT_CACHE_molecule_conformers[cache_key]
     RDKitToolkitWrapper.generate_conformers = rdk_cached_generate_conformers

--- a/src/smirnoff_hack.py
+++ b/src/smirnoff_hack.py
@@ -125,10 +125,21 @@ if _SHOULD_CACHE:
     # cache the OE generate_conformers function (save 15s)
     OE_TOOLKIT_CACHE_molecule_conformers = {}
     oe_original_generate_conformers = OpenEyeToolkitWrapper.generate_conformers
-    def oe_cached_generate_conformers(self, molecule, n_conformers=1, rms_cutoff=None, clear_existing=True, make_carboxylic_acids_cis=False):
-        cache_key = hash((hash_molecule(molecule), n_conformers, str(rms_cutoff), clear_existing, make_carboxylic_acids_cis))
+    def oe_cached_generate_conformers(
+        self, molecule, n_conformers=1, rms_cutoff=None, clear_existing=True, make_carboxylic_acids_cis=False,
+    ):
+        cache_key = hash((
+            hash_molecule(molecule), n_conformers, str(rms_cutoff), clear_existing, make_carboxylic_acids_cis,
+        ))
         if cache_key not in OE_TOOLKIT_CACHE_molecule_conformers:
-            oe_original_generate_conformers(self, molecule, n_conformers=n_conformers, rms_cutoff=rms_cutoff, clear_existing=clear_existing, make_carboxylic_acids_cis=make_carboxylic_acids_cis)
+            oe_original_generate_conformers(
+                self,
+                molecule,
+                n_conformers=n_conformers,
+                rms_cutoff=rms_cutoff,
+                clear_existing=clear_existing,
+                make_carboxylic_acids_cis=make_carboxylic_acids_cis,
+            )
             OE_TOOLKIT_CACHE_molecule_conformers[cache_key] = molecule._conformers
         molecule._conformers = OE_TOOLKIT_CACHE_molecule_conformers[cache_key]
     OpenEyeToolkitWrapper.generate_conformers = oe_cached_generate_conformers
@@ -137,10 +148,21 @@ if _SHOULD_CACHE:
     # cache the RDKit generate_conformers function
     RDK_TOOLKIT_CACHE_molecule_conformers = {}
     rdk_original_generate_conformers = RDKitToolkitWrapper.generate_conformers
-    def rdk_cached_generate_conformers(self, molecule, n_conformers=1, rms_cutoff=None, clear_existing=True, make_carboxylic_acids_cis=False):
-        cache_key = hash((hash_molecule(molecule), n_conformers, str(rms_cutoff), clear_existing, make_carboxylic_acids_cis))
+    def rdk_cached_generate_conformers(
+        self, molecule, n_conformers=1, rms_cutoff=None, clear_existing=True, make_carboxylic_acids_cis=False,
+    ):
+        cache_key = hash((
+            hash_molecule(molecule), n_conformers, str(rms_cutoff), clear_existing, make_carboxylic_acids_cis,
+        ))
         if cache_key not in RDK_TOOLKIT_CACHE_molecule_conformers:
-            rdk_original_generate_conformers(self, molecule, n_conformers=n_conformers, rms_cutoff=rms_cutoff, clear_existing=clear_existing, make_carboxylic_acids_cis=make_carboxylic_acids_cis)
+            rdk_original_generate_conformers(
+                self,
+                molecule,
+                n_conformers=n_conformers,
+                rms_cutoff=rms_cutoff,
+                clear_existing=clear_existing,
+                make_carboxylic_acids_cis=make_carboxylic_acids_cis,
+            )
             RDK_TOOLKIT_CACHE_molecule_conformers[cache_key] = molecule._conformers
         molecule._conformers = RDK_TOOLKIT_CACHE_molecule_conformers[cache_key]
     RDKitToolkitWrapper.generate_conformers = rdk_cached_generate_conformers


### PR DESCRIPTION
We released a new version of the toolkit yesterday that broke `smirnoff_hack` by nature of adding a named argument to `generate_conformers` - fixing it should be a matter of string the new argument through the appropriate functions.