### PR TITLE
Remove support for deprecated `simtk` namespace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,6 @@ jobs:
           - macOS-latest
           - ubuntu-latest
         python-version:
-          - "3.6"
-          - "3.7"
           - "3.8"
           - "3.9"
 
@@ -93,11 +91,6 @@ jobs:
         cd studies/001_water_tutorial
         tar xvjf targets.tar.bz2
         cd ../../
-
-    - name: Install backport of dataclasses
-      if: ${{ matrix.python-version == 3.6}}
-      run: |
-        pip install dataclasses
 
     - name: Install package
       run: |

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -17,7 +17,7 @@ dependencies:
   - zlib
   - swig
   - future
-  - pymbar
+  - pymbar <4
   - openmm >7.6
   - ambertools
   - ndcctools

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -18,7 +18,7 @@ dependencies:
   - swig
   - future
   - pymbar
-  - openmm
+  - openmm >7.6
   - ambertools
   - ndcctools
   - geometric

--- a/src/data/md_ism_hfe.py
+++ b/src/data/md_ism_hfe.py
@@ -89,14 +89,9 @@ engname = TgtOpts['engname']
 # Import modules and create the correct Engine object.
 if engname == "openmm":
     try:
-        try:
-            from openmm.unit import *
-            from openmm import *
-            from openmm.app import *
-        except ImportError:
-            from simtk.unit import *
-            from simtk.openmm import *
-            from simtk.openmm.app import *
+        from openmm.unit import *
+        from openmm import *
+        from openmm.app import *
     except:
         traceback.print_exc()
         raise Exception("Cannot import OpenMM modules")

--- a/src/data/npt.py
+++ b/src/data/npt.py
@@ -52,14 +52,9 @@ engname          = args.engine.lower()     # Name of the engine
 
 if engname == "openmm":
     try:
-        try:
-            from openmm.unit import *
-            from openmm import *
-            from openmm.app import *
-        except ImportError:
-            from simtk.unit import *
-            from simtk.openmm import *
-            from simtk.openmm.app import *
+        from openmm.unit import *
+        from openmm import *
+        from openmm.app import *
 
     except:
         traceback.print_exc()

--- a/src/data/npt_lipid.py
+++ b/src/data/npt_lipid.py
@@ -52,14 +52,9 @@ engname          = args.engine.lower()     # Name of the engine
 
 if engname == "openmm":
     try:
-        try:
-            from openmm.unit import *
-            from openmm import *
-            from openmm.app import *
-        except ImportError:
-            from simtk.unit import *
-            from simtk.openmm import *
-            from simtk.openmm.app import *
+        from openmm.unit import *
+        from openmm import *
+        from openmm.app import *
 
     except:
         traceback.print_exc()

--- a/src/data/nvt.py
+++ b/src/data/nvt.py
@@ -76,14 +76,9 @@ engname          = args.engine.lower()     # Name of the engine
 
 if engname == "openmm":
     try:
-        try:
-            from openmm.unit import *
-            from openmm import *
-            from openmm.app import *
-        except ImportError:
-            from simtk.unit import *
-            from simtk.openmm import *
-            from simtk.openmm.app import *
+        from openmm.unit import *
+        from openmm import *
+        from openmm.app import *
 
     except:
         traceback.print_exc()

--- a/src/evaluator_io.py
+++ b/src/evaluator_io.py
@@ -308,10 +308,7 @@ class Evaluator_SMIRNOFF(Target):
         bool
             Returns True if the parameter is a cosmetic one.
         """
-        try:
-            import openmm.unit as simtk_unit
-        except ImportError:
-            import simtk.unit as simtk_unit
+        import openmm.unit as openmm_unit
 
         parameter_handler = self.FF.openff_forcefield.get_parameter_handler(
             gradient_key.tag
@@ -350,8 +347,8 @@ class Evaluator_SMIRNOFF(Target):
         ):
             is_cosmetic = True
 
-        if not isinstance(parameter_value, simtk_unit.Quantity):
-            parameter_value = parameter_value * simtk_unit.dimensionless
+        if not isinstance(parameter_value, openmm_unit.Quantity):
+            parameter_value = parameter_value * openmm_unit.dimensionless
 
         return openmm_quantity_to_pint(parameter_value), is_cosmetic
 

--- a/src/molecule.py
+++ b/src/molecule.py
@@ -341,14 +341,9 @@ if "forcebalance" in __name__:
     #| OpenMM interface functions |#
     #==============================#
     try:
-        try:
-            from openmm.unit import *
-            from openmm import *
-            from openmm.app import *
-        except ImportError:
-            from simtk.unit import *
-            from simtk.openmm import *
-            from simtk.openmm.app import *
+        from openmm.unit import *
+        from openmm import *
+        from openmm.app import *
     except ImportError:
         logger.debug('Note: Cannot import optional OpenMM module.\n')
 
@@ -364,14 +359,9 @@ elif "geometric" in __name__:
     #| OpenMM interface functions |#
     #==============================#
     try:
-        try:
-            from openmm.unit import *
-            from openmm import *
-            from openmm.app import *
-        except ImportError:
-            from simtk.unit import *
-            from simtk.openmm import *
-            from simtk.openmm.app import *
+        from openmm.unit import *
+        from openmm import *
+        from openmm.app import *
     except ImportError:
         logger.debug('Note: Failed to import optional OpenMM module.\n')
 

--- a/src/openmmio.py
+++ b/src/openmmio.py
@@ -33,20 +33,11 @@ from collections import OrderedDict
 from forcebalance.output import getLogger
 logger = getLogger(__name__)
 
-# Handle simtk namespace change around 7.6 release
 try:
-    try:
-        # Try importing openmm using >=7.6 namespace
-        from openmm.app import *
-        from openmm import *
-        from openmm.unit import *
-        import openmm._openmm as _openmm
-    except ImportError:
-        # Try importing openmm using <7.6 namespace
-        from simtk.openmm.app import *
-        from simtk.openmm import *
-        from simtk.unit import *
-        import simtk.openmm._openmm as _openmm
+    from openmm.app import *
+    from openmm import *
+    from openmm.unit import *
+    import openmm._openmm as _openmm
 except ImportError:
     # Need to have "pass" conditional if neither is installed so that non-openmm builds can parse this file
     pass
@@ -474,7 +465,7 @@ def MTSVVVRIntegrator(temperature, collision_rate, timestep, system, ninnersteps
     temperature (Quantity compatible with kelvin) - the temperature
     collision_rate (Quantity compatible with 1/picoseconds) - the collision rate
     timestep (Quantity compatible with femtoseconds) - the integration timestep
-    system (simtk.openmm.System) - system whose forces will be partitioned
+    system (openmm.System) - system whose forces will be partitioned
     ninnersteps (int) - number of inner timesteps (default: 4)
 
     RETURNS

--- a/src/smirnoffio.py
+++ b/src/smirnoffio.py
@@ -38,10 +38,10 @@ import json
 
 logger = getLogger(__name__)
 try:
-    from simtk.openmm.app import *
-    from simtk.openmm import *
-    from simtk.unit import *
-    import simtk.openmm._openmm as _openmm
+    from openmm.app import *
+    from openmm import *
+    from openmm.unit import *
+    import openmm._openmm as _openmm
 except:
     pass
 

--- a/src/tests/__init__.py
+++ b/src/tests/__init__.py
@@ -30,16 +30,8 @@ class ForceBalanceTestCase(object):
 
 def check_for_openmm():
     try:
-        try:
-            # Try importing openmm using >=7.6 namespace
-            from openmm import app
-            import openmm as mm
-            from openmm import unit
-        except ImportError:
-            # Try importing openmm using <7.6 namespace
-            import simtk.openmm as mm
-            from simtk.openmm import app
-            from simtk import unit
+        import openmm
+        from openmm import app, unit
         return True
     except ImportError:
         # If OpenMM classes cannot be imported, then set this flag 

--- a/src/tests/files/XmlScript_out/TIP3G2w_out_ref.xml
+++ b/src/tests/files/XmlScript_out/TIP3G2w_out_ref.xml
@@ -38,14 +38,8 @@
 
 from math import pi
 import numpy as np
-try:
-    import openmm as mm
-    from openmm import app
-    from openmm import unit as u
-except ImportError:
-    from simtk import openmm as mm
-    from simtk.openmm import app
-    from simtk import unit as u
+import openmm as mm
+from openmm import app, unit as u
 
 epsilon = 8.854187817620E-12*u.farad/u.meter
 COULOMB_CONSTANT = (u.AVOGADRO_CONSTANT_NA/(4.0*pi*epsilon)).value_in_unit_system(u.md_unit_system)

--- a/src/tests/files/forcefield/TIP3G2w.xml
+++ b/src/tests/files/forcefield/TIP3G2w.xml
@@ -38,14 +38,9 @@
 
 from math import pi
 import numpy as np
-try:
-    import openmm as mm
-    from openmm import app
-    from openmm import unit as u
-except ImportError:
-    from simtk import openmm as mm
-    from simtk.openmm import app
-    from simtk import unit as u
+import openmm as mm
+from openmm import app, unit as u
+from openmm import unit as u
 
 epsilon = 8.854187817620E-12*u.farad/u.meter
 COULOMB_CONSTANT = (u.AVOGADRO_CONSTANT_NA/(4.0*pi*epsilon)).value_in_unit_system(u.md_unit_system)

--- a/src/tests/test_engine.py
+++ b/src/tests/test_engine.py
@@ -94,10 +94,7 @@ class TestAmber99SB(ForceBalanceTestCase):
             logger.warning("TINKER cannot be found, skipping TINKER tests.")
         # Set up OpenMM engine
         try:
-            try:
-                import openmm
-            except ImportError:
-                import simtk.openmm
+            import openmm
             cls.engines['OpenMM'] = OpenMM(coords="all.gro", pdb="conf.pdb", ffxml="a99sb.xml", platname="Reference", precision="double")
         except:
             logger.warning("OpenMM cannot be imported, skipping OpenMM tests.")

--- a/src/tests/test_openmmio.py
+++ b/src/tests/test_openmmio.py
@@ -5,16 +5,8 @@ from forcebalance.openmmio import PrepareVirtualSites, ResetVirtualSites_fast
 import numpy as np
 
 try:
-    try:
-        # Try importing openmm using >=7.6 namespace
-        from openmm import app
-        import openmm as mm
-        from openmm import unit
-    except ImportError:
-        # Try importing openmm using <7.6 namespace
-        import simtk.openmm as mm
-        from simtk.openmm import app
-        from simtk import unit
+    from openmm import app, unit
+    import openmm as mm
     no_openmm = False
 except ImportError:
     # If OpenMM classes cannot be imported, then set this flag 


### PR DESCRIPTION
This PR removes soft checks for the `simtk` namespace, which was deprecated last fall and will presumably be removed at some point. This decreases the likelihood that errant warnings will be printed out to the user. 