### PR TITLE
Update global parameters in a `CustomBondForce`

### DIFF
--- a/src/openmmio.py
+++ b/src/openmmio.py
@@ -410,7 +410,7 @@ def UpdateSimulationParameters(src_system, dest_simulation):
     for i in range(src_system.getNumForces()):
         if hasattr(dest_simulation.system.getForce(i),'updateParametersInContext'):
             dest_simulation.system.getForce(i).updateParametersInContext(dest_simulation.context)
-        if isinstance(dest_simulation.system.getForce(i), CustomNonbondedForce):
+        if isinstance(dest_simulation.system.getForce(i), (CustomNonbondedForce, CustomBondForce)):
             force = src_system.getForce(i)
             for j in range(force.getNumGlobalParameters()):
                 pName = force.getGlobalParameterName(j)


### PR DESCRIPTION
A `CustomBondForce` is commonly used to implement scaled14 interactions excluded from a `CustomNonbondedForce` and can contain different global parameters, for example, the scale parameter to scale the interactions by. This PR also checks the custom bond force for global parameters when copying forces to a new openmm system. See this issue https://github.com/openforcefield/smirnoff-plugins/issues/36