### PR TITLE
[WIP] OpenFF Toolkit 0.11 compatibility (without pymbar update)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,6 @@ jobs:
           - macOS-latest
           - ubuntu-latest
         python-version:
-          - "3.6"
-          - "3.7"
           - "3.8"
           - "3.9"
 

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -17,10 +17,10 @@ dependencies:
   - zlib
   - swig
   - future
-  - pymbar
+  - pymbar <4
   - openmm
   - ambertools
   - ndcctools
   - geometric
   - gromacs =2019.1
-  - openff-toolkit >=0.10.3|<=0.10.0
+  - openff-toolkit >0.11


### PR DESCRIPTION
This is an attempt to more cleanly separate the OFFTK 0.11 changes (#259) from the pymbar update PR (#260). I think #259 didn't run the full test suite because it came from a fork. So if this works, this PR should supersede #259. 