### PR TITLE
fix: evaluator unit bug

### DIFF
--- a/src/evaluator_io.py
+++ b/src/evaluator_io.py
@@ -308,10 +308,6 @@ class Evaluator_SMIRNOFF(Target):
         bool
             Returns True if the parameter is a cosmetic one.
         """
-        try:
-            import openmm.unit as simtk_unit
-        except ImportError:
-            import simtk.unit as simtk_unit
 
         parameter_handler = self.FF.openff_forcefield.get_parameter_handler(
             gradient_key.tag
@@ -350,10 +346,7 @@ class Evaluator_SMIRNOFF(Target):
         ):
             is_cosmetic = True
 
-        if not isinstance(parameter_value, simtk_unit.Quantity):
-            parameter_value = parameter_value * simtk_unit.dimensionless
-
-        return openmm_quantity_to_pint(parameter_value), is_cosmetic
+        return parameter_value, is_cosmetic
 
     def _extract_physical_parameter_values(self):
         """Extracts an array of the values of the physical parameters

--- a/src/smirnoffio.py
+++ b/src/smirnoffio.py
@@ -115,7 +115,7 @@ def smirnoff_analyze_parameter_coverage(forcefield, tgt_opts):
         logger.info('%4i %-100s : %10d\n' % (i, p, parameter_counter[smirks]))
         if parameter_counter[smirks] > 0:
             n_covered += 1
-    logger.info("SNIRNOFF Parameter Coverage Analysis result: %d/%d parameters are covered.\n" % (n_covered, len(forcefield.plist)))
+    logger.info("SMIRNOFF Parameter Coverage Analysis result: %d/%d parameters are covered.\n" % (n_covered, len(forcefield.plist)))
     logger.info("-"*118 + '\n')
 
 class SMIRNOFF_Reader(BaseReader):

--- a/studies/022_opt_geo_target/optimize.out
+++ b/studies/022_opt_geo_target/optimize.out
@@ -197,7 +197,7 @@ Force field assignment data written to /home2/qyd/projects/forcebalance-dev/stud
   24 vdW/Atom/rmin_half/[#6X4:1]                                                                          :          2
   25 vdW/Atom/epsilon/[#8X2H0+0:1]                                                                        :          2
   26 vdW/Atom/rmin_half/[#8X2H0+0:1]                                                                      :          2
-SNIRNOFF Parameter Coverage Analysis result: 27/27 parameters are covered.
+SMIRNOFF Parameter Coverage Analysis result: 27/27 parameters are covered.
 ----------------------------------------------------------------------------------------------------------------------
 Using parabolic regularization (Gaussian prior) with strength 1.0e+00 (+), 0.0e+00 (x)
 #========================================================#

--- a/studies/023_torsion_relaxed/optimize.out
+++ b/studies/023_torsion_relaxed/optimize.out
@@ -1621,7 +1621,7 @@ Force field assignment data written to /home/leeping/src/forcebalance/studies/02
  501 ProperTorsions/Proper/k1/[*:1]-[*:2]#[*:3]-[*:4]                                                     :          0
  502 ProperTorsions/Proper/k1/[*:1]~[*:2]-[*:3]#[*:4]                                                     :          0
  503 ProperTorsions/Proper/k1/[*:1]~[*:2]=[#6,#7,#16,#15;X2:3]=[*:4]                                      :          0
-SNIRNOFF Parameter Coverage Analysis result: 19/504 parameters are covered.
+SMIRNOFF Parameter Coverage Analysis result: 19/504 parameters are covered.
 ----------------------------------------------------------------------------------------------------------------------
 Using parabolic regularization (Gaussian prior) with strength 1.0e+00 (+), 0.0e+00 (x)
 #========================================================#

--- a/studies/024_openff_evaluator/output_ref/optimize.out
+++ b/studies/024_openff_evaluator/output_ref/optimize.out
@@ -145,7 +145,7 @@ Force field assignment data written to XXX/smirnoff_parameter_assignments.json
    7 vdW/Atom/rmin_half/[#6X4:1]                                                                          :          0
    8 vdW/Atom/epsilon/[#8X2H1+0:1]                                                                        :          0
    9 vdW/Atom/rmin_half/[#8X2H1+0:1]                                                                      :          0
-SNIRNOFF Parameter Coverage Analysis result: 0/10 parameters are covered.
+SMIRNOFF Parameter Coverage Analysis result: 0/10 parameters are covered.
 ----------------------------------------------------------------------------------------------------------------------
 Using parabolic regularization (Gaussian prior) with strength 1.0e+00 (+), 0.0e+00 (x)
 

--- a/studies/025_openff_recharge/output_ref/optimize.out
+++ b/studies/025_openff_recharge/output_ref/optimize.out
@@ -106,7 +106,7 @@ Force field assignment data written to /Users/boothros/PyCharmProjects/forcebala
  idx Parameter                                                                                                   Count
 ----------------------------------------------------------------------------------------------------------------------
    0 ChargeIncrementModel/ChargeIncrement/charge_increment1/[#6X4:1]-[#1:2]                               :          0
-SNIRNOFF Parameter Coverage Analysis result: 0/1 parameters are covered.
+SMIRNOFF Parameter Coverage Analysis result: 0/1 parameters are covered.
 ----------------------------------------------------------------------------------------------------------------------
 Using parabolic regularization (Gaussian prior) with strength 1.0e+00 (+), 0.0e+00 (x)
 #========================================================#

--- a/studies/026_smirnoff_14_scale/optimize.out
+++ b/studies/026_smirnoff_14_scale/optimize.out
@@ -105,7 +105,7 @@ Force field assignment data written to /Users/boothros/PyCharmProjects/forcebala
  idx Parameter                                                                                                   Count
 ----------------------------------------------------------------------------------------------------------------------
    0 /vdW/scale14                                                                                         :          0
-SNIRNOFF Parameter Coverage Analysis result: 0/1 parameters are covered.
+SMIRNOFF Parameter Coverage Analysis result: 0/1 parameters are covered.
 ----------------------------------------------------------------------------------------------------------------------
 Using parabolic regularization (Gaussian prior) with strength 1.0e+00 (+), 0.0e+00 (x)
 #========================================================#

--- a/studies/027_openff_hessian_target/optimize.out
+++ b/studies/027_openff_hessian_target/optimize.out
@@ -187,7 +187,7 @@ Force field assignment data written to /Users/hyesu/Project/git-repo/fb-factorie
   24 vdW/Atom/epsilon/[#6X4:1]                                                                            :          0
   25 vdW/Atom/rmin_half/[#8X2H0+0:1]                                                                      :          0
   26 vdW/Atom/epsilon/[#8X2H0+0:1]                                                                        :          0
-SNIRNOFF Parameter Coverage Analysis result: 6/27 parameters are covered.
+SMIRNOFF Parameter Coverage Analysis result: 6/27 parameters are covered.
 ----------------------------------------------------------------------------------------------------------------------
 Using parabolic regularization (Gaussian prior) with strength 1.0e+00 (+), 0.0e+00 (x)
 #========================================================#


### PR DESCRIPTION
the unit system of openff-evaluator 0.3.9 has been changed to openff-units based on pint. So this simple fix is necessary. 
Tested to work on openff-evaluator 0.4.1 / tutorial04

this PR fixes https://github.com/leeping/forcebalance/issues/276