### PR TITLE
Remove validate cache since the ChemicalEnvironment class is being dropped in OFFTK 0.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,10 +91,14 @@ jobs:
         cd gromacs-5.1.5/cmake
         cmake -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/opt/gromacs/5.1.5 -DGMX_DOUBLE=ON -DGMX_BUILD_OWN_FFTW=ON ..
         make -j 4 && make install
+        cd ..
+        mkdir cmake_s
+        cd cmake_s
+        cmake -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/opt/gromacs/5.1.5 -DGMX_BUILD_OWN_FFTW=ON ..
+        make -j 4 && make install
+        cd ..
         . $GITHUB_WORKSPACE/opt/gromacs/5.1.5/bin/GMXRC.bash
         echo "$GITHUB_WORKSPACE/opt/gromacs/5.1.5/bin" >> $GITHUB_PATH
-        which gmx
-        gmx mdrun -v 2>&1
 
     - name: Extract data archives
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,8 @@ jobs:
         make -j 4 && make install
         . $GITHUB_WORKSPACE/opt/gromacs/5.1.5/bin/GMXRC.bash
         echo "$GITHUB_WORKSPACE/opt/gromacs/5.1.5/bin" >> $GITHUB_PATH
+        which gmx
+        gmx mdrun -v 2>&1
 
     - name: Extract data archives
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
-    - name: Install dependencies with Minicondna
+    - name: Install dependencies with Miniconda
       uses: conda-incubator/setup-miniconda@v2
       with:
         python-version: ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
         wget http://ftp.gromacs.org/pub/gromacs/gromacs-5.1.5.tar.gz
         tar xvzf gromacs-5.1.5.tar.gz
         cd gromacs-5.1.5/cmake
-        cmake -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/opt/gromacs/5.1.5 -DGMX_DOUBLE=ON ..
+        cmake -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/opt/gromacs/5.1.5 -DGMX_DOUBLE=ON -DGMX_BUILD_OWN_FFTW=ON ..
         make -j 4 && make install
         . $GITHUB_WORKSPACE/opt/gromacs/5.1.5/bin/GMXRC.bash
         echo "$GITHUB_WORKSPACE/opt/gromacs/5.1.5/bin" >> $GITHUB_PATH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,17 +88,19 @@ jobs:
       run: |
         wget http://ftp.gromacs.org/pub/gromacs/gromacs-5.1.5.tar.gz
         tar xvzf gromacs-5.1.5.tar.gz
-        cd gromacs-5.1.5/cmake
+        cd gromacs-5.1.5
+        cp -r cmake cmake_s
+        cd cmake
         cmake -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/opt/gromacs/5.1.5 -DGMX_DOUBLE=ON -DGMX_BUILD_OWN_FFTW=ON ..
-        make -j 4 && make install
-        cd ..
-        mkdir cmake_s
-        cd cmake_s
+        make -j 8 && make install
+        cd ../cmake_s
         cmake -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/opt/gromacs/5.1.5 -DGMX_BUILD_OWN_FFTW=ON ..
-        make -j 4 && make install
+        make -j 8 && make install
         cd ..
         . $GITHUB_WORKSPACE/opt/gromacs/5.1.5/bin/GMXRC.bash
         echo "$GITHUB_WORKSPACE/opt/gromacs/5.1.5/bin" >> $GITHUB_PATH
+        which gmx
+        which gmx_d
 
     - name: Extract data archives
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,16 @@ jobs:
 
         echo "$GITHUB_WORKSPACE/opt/tinker/8.8.3/bin" >> $GITHUB_PATH
 
+    - name: Install Gromacs
+      run: |
+        wget http://ftp.gromacs.org/pub/gromacs/gromacs-5.1.5.tar.gz
+        tar xvzf gromacs-5.1.5.tar.gz
+        cd gromacs-5.1.5/cmake
+        cmake -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/opt/gromacs/5.1.5 -DGMX_DOUBLE=ON ..
+        make -j 4 && make install
+        . $GITHUB_WORKSPACE/opt/gromacs/5.1.5/bin/GMXRC.bash
+        echo "$GITHUB_WORKSPACE/opt/gromacs/5.1.5/bin" >> $GITHUB_PATH
+
     - name: Extract data archives
       run: |
         cd studies/001_water_tutorial

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -18,7 +18,6 @@ dependencies:
   - zlib
   - swig
   - future
-  - fftw
   - pymbar =3
   - openmm >= 8
   - ambertools

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -18,6 +18,7 @@ dependencies:
   - zlib
   - swig
   - future
+  - fftw
   - pymbar =3
   - openmm >= 8
   - ambertools

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ import subprocess
 #| doc/api_header.tex              |#
 #| bin/ForceBalance.py             |#
 #===================================#
-__version__ = "v1.9.5"
+__version__ = "1.9.5"
 # try:
 #     # use git to find current version
 #     git_describe = subprocess.check_output(["git", "describe", "--tags"]).strip()
@@ -46,8 +46,7 @@ __version__ = "v1.9.5"
 DCD = Extension('forcebalance/_dcdlib',
                 sources = [ "ext/molfile_plugin/dcdplugin_s.c" ],
                 libraries=['m'],
-                include_dirs = ["ext/molfile_plugin/include/","ext/molfile_plugin"] 
-                )
+                include_dirs = ["ext/molfile_plugin/include/","ext/molfile_plugin"])
 
 # Hungarian algorithm for permutations
 # Used for identifying normal modes
@@ -152,9 +151,9 @@ def main():
 
     ## Install options
     parser = argparse.ArgumentParser()
-    parser.add_argument('-d', '--dirty', action='store_true', help="don't remove previously installed forcebalance installation first")
-    parser.add_argument('-t', '--test', action='store_true', help='install forcebalance test suite')
-    parser.add_argument('-g', '--gui', action='store_true', help='install forcebalance gui module')
+    parser.add_argument('--dirty', action='store_true', help="don't remove previously installed forcebalance installation first")
+    parser.add_argument('--test', action='store_true', help='install forcebalance test suite')
+    parser.add_argument('--gui', action='store_true', help='install forcebalance gui module')
     args, sys.argv= parser.parse_known_args(sys.argv)
     setupKeywords=buildKeywordDictionary(args)
     ## Run setuptools command.

--- a/setup.py
+++ b/setup.py
@@ -22,11 +22,11 @@ import subprocess
 #| bin/ForceBalance.py             |#
 #===================================#
 __version__ = "v1.9.5"
-try:
-    # use git to find current version
-    git_describe = subprocess.check_output(["git", "describe", "--tags"]).strip()
-    __version__ = re.sub('-g[0-9a-f]*$','',git_describe)
-except: pass
+# try:
+#     # use git to find current version
+#     git_describe = subprocess.check_output(["git", "describe", "--tags"]).strip()
+#     __version__ = re.sub('-g[0-9a-f]*$','',git_describe)
+# except: pass
 
 # The versioning file logic does not work.  
 # Commenting out until further notice.

--- a/src/smirnoff_hack.py
+++ b/src/smirnoff_hack.py
@@ -73,15 +73,16 @@ if _SHOULD_CACHE:
 
 
     # cache for the validate function (save 94s)
-    from openff.toolkit.typing.chemistry.environment import ChemicalEnvironment
-    original_validate = ChemicalEnvironment.validate
-    TOOLKIT_CACHE_ChemicalEnvironment_validate = {}
-    def cached_validate(smirks, validate_valence_type=True, toolkit_registry=OpenEyeToolkitWrapper):
-        cache_key = hash((smirks, validate_valence_type, toolkit_registry))
-        if cache_key not in TOOLKIT_CACHE_ChemicalEnvironment_validate:
-            TOOLKIT_CACHE_ChemicalEnvironment_validate[cache_key] = original_validate(smirks, validate_valence_type=validate_valence_type, toolkit_registry=toolkit_registry)
-        return TOOLKIT_CACHE_ChemicalEnvironment_validate[cache_key]
-    ChemicalEnvironment.validate = cached_validate
+    # The ChemicalEnvironment class has been deprecated in the OpenFF Toolkit 0.14 release.
+    # from openff.toolkit.typing.chemistry.environment import ChemicalEnvironment
+    # original_validate = ChemicalEnvironment.validate
+    # TOOLKIT_CACHE_ChemicalEnvironment_validate = {}
+    # def cached_validate(smirks, validate_valence_type=True, toolkit_registry=OpenEyeToolkitWrapper):
+    #     cache_key = hash((smirks, validate_valence_type, toolkit_registry))
+    #     if cache_key not in TOOLKIT_CACHE_ChemicalEnvironment_validate:
+    #         TOOLKIT_CACHE_ChemicalEnvironment_validate[cache_key] = original_validate(smirks, validate_valence_type=validate_valence_type, toolkit_registry=toolkit_registry)
+    #     return TOOLKIT_CACHE_ChemicalEnvironment_validate[cache_key]
+    # ChemicalEnvironment.validate = cached_validate
 
 
     # cache for compute_partial_charges_am1bcc (save 69s)

--- a/src/smirnoffio.py
+++ b/src/smirnoffio.py
@@ -484,9 +484,9 @@ class SMIRNOFF(OpenMM):
         # Because self.forcefield is being updated in forcebalance.forcefield.FF.make()
         # there is no longer a need to create a new force field object here.
         try:
-            self.system, openff_topology = self.forcefield.create_openmm_system(
-                self.off_topology, return_topology=True
-            )
+            interchange = self.forcefield.create_interchange(self.off_topology)
+            self.system = interchange.to_openmm()
+            self.off_topology = interchange.topology
         except Exception as error:
             logger.error("Error when creating system for %s" % self.mol2)
             raise error


### PR DESCRIPTION
ForceBalance has a [cache for the `ChemicalEnvironment.validate` method](https://github.com/leeping/forcebalance/blob/10b9280cab9735634d25a4f9c8b3e84cb13a6bb1/src/smirnoff_hack.py#L75C1-L84). This hasn't been used for a while (we stopped validating SMARTS a while ago and now just treat them as strings instead of ChemicalEnvironments), and we're finally dropping the ChemicalEnvironment class in the 0.14.0 OpenFF Toolkit release. It should suffice to simply remove the cache here. 

- [x] Remove `ChemicalEnvironment.validate` cache
- [x] Fixes #286 by replacing usage of `return_topology` with Interchange equivalents


CI on GitHub seems to be broken, but I tested the changes locally and was able to run study 22 successfully. 