### PR TITLE
Trim un-used dependencies

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -1,7 +1,6 @@
 name: forcebalance-test
 channels:
   - conda-forge
-  - bioconda
   - openeye
 dependencies:
     # Base depends
@@ -10,7 +9,6 @@ dependencies:
     # Testing
   - pytest
   - pytest-cov
-  - codecov
   - numpy
   - scipy
   - lxml
@@ -23,7 +21,6 @@ dependencies:
   - ambertools
   - ndcctools
   - geometric
-  # - gromacs =2019.1
   - openff-toolkit >=0.11.3
   - openff-evaluator-base >= 0.4.1
   - pint =0.20


### PR DESCRIPTION
There are a couple of things brought in that are no longer needed - trimming them out of the test environment will make it run (even) faster