### PR TITLE
Use double-precision GROMACS builds from `conda-forge`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,24 +82,6 @@ jobs:
 
         echo "$GITHUB_WORKSPACE/opt/tinker/8.8.3/bin" >> $GITHUB_PATH
 
-    - name: Install Gromacs
-      run: |
-        wget http://ftp.gromacs.org/pub/gromacs/gromacs-5.1.5.tar.gz
-        tar xvzf gromacs-5.1.5.tar.gz
-        cd gromacs-5.1.5
-        cp -r cmake cmake_s
-        cd cmake
-        cmake -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/opt/gromacs/5.1.5 -DGMX_DOUBLE=ON -DGMX_BUILD_OWN_FFTW=ON -DGMX_USE_RDTSCP=OFF ..
-        make -j 8 && make install
-        cd ../cmake_s
-        cmake -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/opt/gromacs/5.1.5 -DGMX_BUILD_OWN_FFTW=ON -DGMX_USE_RDTSCP=OFF ..
-        make -j 8 && make install
-        cd ..
-        . $GITHUB_WORKSPACE/opt/gromacs/5.1.5/bin/GMXRC.bash
-        echo "$GITHUB_WORKSPACE/opt/gromacs/5.1.5/bin" >> $GITHUB_PATH
-        which gmx
-        which gmx_d
-
     - name: Extract data archives
       run: |
         cd studies/001_water_tutorial

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -23,7 +23,7 @@ dependencies:
   - ambertools
   - ndcctools
   - geometric
-  # - gromacs =2019.1
+  - gromacs =2023.3=nompi_dblprec*_3
   - openff-toolkit >=0.11.3
   - openff-evaluator-base >= 0.4.1
   - pint =0.20

--- a/src/gmxio.py
+++ b/src/gmxio.py
@@ -602,7 +602,7 @@ class GMX(Engine):
 
         self.gmx_defs = OrderedDict([("integrator", "md"), ("dt", "0.001"), ("nsteps", "0"),
                                      ("nstxout", "0"), ("nstfout", "0"), ("nstenergy", "1"), 
-                                     ("nstxtcout", "0"), ("constraints", "none"), ("cutoff-scheme", "group")])
+                                     ("nstxtcout", "0"), ("constraints", "none"), ("cutoff-scheme", "Verlet")])
         gmx_opts = OrderedDict([])
         warnings = []
         self.pbc = pbc
@@ -1250,9 +1250,7 @@ class GMX(Engine):
             md_opts["comm_mode"] = "None"
             md_opts["nstcomm"] = 0
 
-        # In gromacs version 5, default cutoff scheme becomes verlet. 
-        # Need to set to group for backwards compatibility
-        md_defs["cutoff-scheme"] = 'group'
+        md_defs["cutoff-scheme"] = "Verlet"
         md_opts["nstenergy"] = nsave
         md_opts["nstcalcenergy"] = nsave
         md_opts["nstxout"] = nsave

--- a/src/gmxio.py
+++ b/src/gmxio.py
@@ -580,7 +580,10 @@ class GMX(Engine):
                 havegmx = True
             else:
                 warn_press_key("Please add GROMACS executables to the PATH or specify gmxpath.")
-                logger.error("Cannot find the GROMACS executables!\n")
+                logger.error(
+                    "Cannot find the GROMACS executables!\n"
+                    f"\tTried 'gmx{self.gmxsuffix}' and 'mdrun{self.gmxsuffix}'\n"
+                )
                 raise RuntimeError
 
     def readsrc(self, **kwargs):

--- a/src/tests/test_continue.py
+++ b/src/tests/test_continue.py
@@ -45,6 +45,7 @@ class TestWaterTutorial(ForceBalanceTestCase):
         self.logger.debug("Parsing inputs...\n")
         options, tgt_opts = parse_inputs(input_file)
         options['continue'] = True
+        options['gmxsuffix'] = '_d'
         self.logger.debug("options:\n%s\n\ntgt_opts:\n%s\n\n" % (str(options), str(tgt_opts)))
 
         assert isinstance(options, dict), "Parser gave incorrect type for options"


### PR DESCRIPTION
Some context: https://github.com/conda-forge/gromacs-feedstock/blob/cde675cda173295466795a1e8d69940d4343723e/recipe/meta.yaml#L19-L24