### PR TITLE
Do not use `numpy.asfarray` which is removed in 2.0

### DIFF
--- a/src/molecule.py
+++ b/src/molecule.py
@@ -3170,7 +3170,7 @@ class Molecule(object):
             elif result == -1:
                 break
             #npa    = np.array(xyzvec)
-            xyz    = np.asfarray(xyzvec)
+            xyz    = np.asarray(xyzvec, dtype=float)
             xyzs.append(xyz.reshape(-1, 3))
             boxes.append(BuildLatticeFromLengthsAngles(ts.A, ts.B, ts.C, 90.0, 90.0, 90.0))
         _dcdlib.close_file_read(dcd)


### PR DESCRIPTION
https://numpy.org/devdocs/release/2.0.0-notes.html#numpy-2-0-python-api-removals

```
$ git checkout upstream/master && ruff check --preview --select NPY201 . --exclude tools
HEAD is now at b395fd4b Replace &> run.log with > run.log 2>&1 (dash compatible)
src/molecule.py:3173:22: NPY201 `np.asfarray` will be removed in NumPy 2.0. Use `np.asarray` with a `float` dtype instead.
Found 1 error.
```