### PR TITLE
Run tests nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,11 @@ on:
   pull_request:
     branches:
       - "master"
+  schedule:
+    # Nightly tests run on main by default:
+    #   Scheduled workflows run on the latest commit on the default or base branch.
+    #   (from https://help.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule)
+    - cron: "0 0 * * *"
 
 defaults:
   run:


### PR DESCRIPTION
This PR changes CI to run nightly tests run on main by default. This is a useful way to catch upstream changes before releases or other changes.

More here: https://help.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule)
