### PR TITLE
Try reinitializing context if updateParametersInContext fails

### DIFF
--- a/src/openmmio.py
+++ b/src/openmmio.py
@@ -442,7 +442,15 @@ def UpdateSimulationParameters(src_system, dest_simulation):
     CopySystemParameters(src_system, dest_simulation.system)
     for i in range(src_system.getNumForces()):
         if hasattr(dest_simulation.system.getForce(i),'updateParametersInContext'):
-            dest_simulation.system.getForce(i).updateParametersInContext(dest_simulation.context)
+            try:
+                dest_simulation.system.getForce(i).updateParametersInContext(dest_simulation.context)
+            except OpenMMException:
+                # if this fails for any reason, such as the issue below, then we reinitialize instead
+                # https://github.com/openmm/openmm/issues/5204
+                dest_simulation.context.reinitialize(preserveState=True)
+                raise e # try to raise for now to see if this triggers CI errors
+                break
+
         if isinstance(dest_simulation.system.getForce(i), (CustomNonbondedForce, CustomBondForce)):
             force = src_system.getForce(i)
             for j in range(force.getNumGlobalParameters()):

--- a/src/openmmio.py
+++ b/src/openmmio.py
@@ -444,11 +444,10 @@ def UpdateSimulationParameters(src_system, dest_simulation):
         if hasattr(dest_simulation.system.getForce(i),'updateParametersInContext'):
             try:
                 dest_simulation.system.getForce(i).updateParametersInContext(dest_simulation.context)
-            except OpenMMException as e:
+            except OpenMMException:
                 # if this fails for any reason, such as the issue below, then we reinitialize instead
                 # https://github.com/openmm/openmm/issues/5204
                 dest_simulation.context.reinitialize(preserveState=True)
-                raise e # try to raise for now to see if this triggers CI errors
                 break
 
         if isinstance(dest_simulation.system.getForce(i), (CustomNonbondedForce, CustomBondForce)):

--- a/src/openmmio.py
+++ b/src/openmmio.py
@@ -444,7 +444,7 @@ def UpdateSimulationParameters(src_system, dest_simulation):
         if hasattr(dest_simulation.system.getForce(i),'updateParametersInContext'):
             try:
                 dest_simulation.system.getForce(i).updateParametersInContext(dest_simulation.context)
-            except OpenMMException:
+            except OpenMMException as e:
                 # if this fails for any reason, such as the issue below, then we reinitialize instead
                 # https://github.com/openmm/openmm/issues/5204
                 dest_simulation.context.reinitialize(preserveState=True)

--- a/src/tests/test_openmmio.py
+++ b/src/tests/test_openmmio.py
@@ -106,3 +106,24 @@ def test_local_coord_sites():
     vsinfo = PrepareVirtualSites(system=system)
     new_pos = ResetVirtualSites_fast(positions=modeller.positions, vsinfo=vsinfo)[-1]
     assert np.allclose(vs_pos._value, np.array([new_pos.x, new_pos.y, new_pos.z]))
+
+def test_update_simulation_twice_water_box():
+    """Ensure update_simulation can be called repeatedly on the test_liquid water box fixture."""
+    if no_openmm: pytest.skip("No OpenMM modules found.")
+
+    test_root = os.path.join(os.path.dirname(os.path.realpath(__file__)), "files")
+    liquid_pdb = os.path.join(test_root, "liquid.pdb")
+    ffxml = os.path.join(test_root, "forcefield", "spce36a.xml")
+
+    engine = forcebalance.openmmio.OpenMM(
+        coords=liquid_pdb,
+        pdb=liquid_pdb,
+        ffxml=ffxml,
+        platname="CUDA",
+        precision="double",
+        pbc=True,
+    )
+
+    engine.update_simulation()
+    engine.update_simulation()
+

--- a/src/tests/test_openmmio.py
+++ b/src/tests/test_openmmio.py
@@ -110,6 +110,10 @@ def test_local_coord_sites():
 def test_update_simulation_twice_water_box():
     """Ensure update_simulation can be called repeatedly on the test_liquid water box fixture."""
     if no_openmm: pytest.skip("No OpenMM modules found.")
+    try:
+        mm.Platform.getPlatformByName("CUDA")
+    except mm.OpenMMException:
+        pytest.skip("CUDA platform not available.")
 
     test_root = os.path.join(os.path.dirname(os.path.realpath(__file__)), "files")
     liquid_pdb = os.path.join(test_root, "liquid.pdb")


### PR DESCRIPTION
This PR addresses the [issue in OpenMM](https://github.com/openmm/openmm/issues/5204) where trying to update a simulation without actually changing parameters triggers a pretty esoteric error. This arose for me during Iteration 0 of trying to reproduce a past TIP4P-FB fit, because update_simulation is called even though the FF has not been optimized yet.

Opening as a draft PR for now to see if existing tests trigger the error -- if not, I'll come up with my own test :-)

I ran a timing test and reinitializing the context is about an order of magnitude slower than updateParametersInContext -- reinitializing takes ~35 ms compared to 4.6 ms for updateParametersInContext. So I think the try/except is much more preferable than reinitializing every time.

**Code below, and notebook PDF**
```python
from openmm.app import *
from openmm import *
from openmm.unit import *
from sys import stdout
import random

pdb = PDBFile('liquid.pdb')
forcefield = ForceField('amber14/tip3pfb.xml')
system = forcefield.createSystem(pdb.topology, nonbondedMethod=PME,
        nonbondedCutoff=0.9*nanometer, constraints=HBonds)
integrator = LangevinMiddleIntegrator(300*kelvin, 1/picosecond, 0.004*picoseconds)
simulation = Simulation(pdb.topology, system, integrator)
simulation.context.setPositions(pdb.positions)

def update_parameters():
    for i in range(simulation.system.getNumForces()):
        if hasattr(simulation.system.getForce(i),'updateParametersInContext'):
            simulation.system.getForce(i).updateParametersInContext(simulation.context)

def reinitialize_context():
    simulation.context.reinitialize(preserveState=True)

def randomize_parameters_and_update(func):
    for fc in simulation.system.getForces():
        if "Nonbond" in type(fc).__name__:
            units = [x.unit for x in fc.getParticleParameters(0)]
            for i in range(fc.getNumParticles()):
                q_ = random.random()
                sigma_ = random.random()
                eps_ = random.random()
                fc.setParticleParameters(i, q_ * units[0], sigma_ * units[1], eps_ * units[2])
    func()

%timeit randomize_parameters_and_update(update_parameters)
%timeit randomize_parameters_and_update(reinitialize_context)
```

[time-reinitialization.pdf](https://github.com/user-attachments/files/25408053/time-reinitialization.pdf)
