### PR TITLE
Expand CI to Python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,8 @@ jobs:
     - name: Set up conda environment
       uses: mamba-org/setup-micromamba@v1
       with:
-        environment-file: devtools/conda-envs/test_env.yaml
+        # ambertools has no Python 3.9 builds; use a separate env file for 3.9
+        environment-file: ${{ matrix.python-version == '3.9' && 'devtools/conda-envs/test_env_py39.yaml' || 'devtools/conda-envs/test_env.yaml' }}
         create-args: >- # beware the >- instead of |, we don't split on newlines but on spaces
           python=${{ matrix.python-version }}
 
@@ -49,12 +50,6 @@ jobs:
       if: matrix.python-version == '3.9' || matrix.python-version == '3.10'
       shell: bash -l {0}
       run: pip install "setuptools<82"
-
-    - name: Install ambertools for Python > 3.9
-      # AmberTools is not available for Python 3.9, so we install it separately for Python 3.10 and above
-      if: matrix.python-version != '3.9'
-      shell: bash -l {0}
-      run: micromamba install -c conda-forge ambertools
           
     - name: Additional info about the build
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
           - macOS-latest
           - ubuntu-latest
         python-version:
+          - "3.9"
+          - "3.10"
           - "3.11"
           - "3.12"
           # pymbar 3 does not support Python 3.13

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       # AmberTools is not available for Python 3.9, so we install it separately for Python 3.10 and above
       if: matrix.python-version != '3.9'
       shell: bash -l {0}
-      run: mamba install -c conda-forge ambertools
+      run: micromamba install -c conda-forge ambertools
           
     - name: Additional info about the build
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,11 @@ jobs:
         environment-file: devtools/conda-envs/test_env.yaml
         create-args: >- # beware the >- instead of |, we don't split on newlines but on spaces
           python=${{ matrix.python-version }}
+
+    - name: Pin setuptools for Python < 3.10
+      if: matrix.python-version == '3.9' || matrix.python-version == '3.10'
+      shell: bash -l {0}
+      run: pip install "setuptools<82"
           
     - name: Additional info about the build
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,12 @@ jobs:
       if: matrix.python-version == '3.9' || matrix.python-version == '3.10'
       shell: bash -l {0}
       run: pip install "setuptools<82"
+
+    - name: Install ambertools for Python > 3.9
+      # AmberTools is not available for Python 3.9, so we install it separately for Python 3.10 and above
+      if: matrix.python-version != '3.9'
+      shell: bash -l {0}
+      run: mamba install -c conda-forge ambertools
           
     - name: Additional info about the build
       shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,12 @@ studies/*/targets/
 studies/*/*.tmp/
 studies/*/*.bak/
 sutdies/*/*.err
+
+# test files from running CI locally
+src/tests/files/XmlScript_out/TIP3G2w.xml
+src/tests/files/targets/dms-liquid/dms.xml
+src/tests/files/temp.bak/
+src/tests/files/test_liquid/targets/Liquid/TIP3G2w.xml
+src/tests/files/test_liquid/targets/Liquid/dms.xml
+src/tests/test.job
+studies/003d_evaluator_liquid_bromine/smirnoff_parameter_assignments.json

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -24,6 +24,6 @@ dependencies:
   - geometric
   # - gromacs =2019.1
   - openff-toolkit >=0.11.3
-  - openff-evaluator-base >= 0.4.1
+  - openff-evaluator-base >= 0.4.5
   # - openff-recharge
   # - openeye-toolkits (Don't have a license file to use with GH Actions.)

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -24,6 +24,6 @@ dependencies:
   - geometric
   # - gromacs =2019.1
   - openff-toolkit >=0.11.3
-  - openff-evaluator >= 0.4.1
+  - openff-evaluator-base >= 0.4.1
   # - openff-recharge
   # - openeye-toolkits (Don't have a license file to use with GH Actions.)

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -23,7 +23,7 @@ dependencies:
   - ndcctools
   - geometric
   # - gromacs =2019.1
-  - openff-toolkit >=0.11.3
+  - openff-toolkit-base >=0.11.3
   - openff-evaluator-base >= 0.4.5
   # - openff-recharge
   # - openeye-toolkits (Don't have a license file to use with GH Actions.)

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -19,7 +19,6 @@ dependencies:
   - future
   - pymbar =3
   - openmm >= 8
-  - ambertools
   - ndcctools
   - geometric
   # - gromacs =2019.1

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -21,7 +21,7 @@ dependencies:
   - openmm >= 8
   - ndcctools
   - geometric
-  - rdkit # needed for openff toolkit
+  - rdkit!=2024.03.6,<2025.09
   # - gromacs =2019.1
   - openff-toolkit-base >=0.11.3
   - openff-evaluator-base >= 0.4.5

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -21,6 +21,7 @@ dependencies:
   - openmm >= 8
   - ndcctools
   - geometric
+  - rdkit # needed for openff toolkit
   # - gromacs =2019.1
   - openff-toolkit-base >=0.11.3
   - openff-evaluator-base >= 0.4.5

--- a/devtools/conda-envs/test_env_py39.yaml
+++ b/devtools/conda-envs/test_env_py39.yaml
@@ -19,11 +19,12 @@ dependencies:
   - future
   - pymbar =3
   - openmm >= 8
-  - ambertools
+  # ambertools has no Python 3.9 builds on conda-forge
   - ndcctools
   - geometric
   # - gromacs =2019.1
-  - openff-toolkit >=0.11.3
-  - openff-evaluator-base >= 0.4.5
+  # openff packages require Python >= 3.10; tests are skipped on 3.9
+  # - openff-toolkit-base
+  # - openff-evaluator-base
   # - openff-recharge
   # - openeye-toolkits (Don't have a license file to use with GH Actions.)

--- a/src/tests/test_smirnoff_hack.py
+++ b/src/tests/test_smirnoff_hack.py
@@ -1,3 +1,4 @@
+import sys
 import pytest
 
 has_openff_toolkit = True
@@ -6,7 +7,10 @@ try:
 except ModuleNotFoundError:
     has_openff_toolkit = False
 
+from .test_system import skip_openff_py39
 
+
+@skip_openff_py39
 @pytest.mark.skipif(
     not has_openff_toolkit, reason="openff.toolkit module not found"
 )

--- a/src/tests/test_system.py
+++ b/src/tests/test_system.py
@@ -191,15 +191,26 @@ class TestEvaluatorBromineStudy(ForceBalanceSystemTest):
         targets = tarfile.open('targets.tar.gz','r')
         targets.extractall()
         targets.close()
-        ## Start the estimator server.
+        ## Start the estimator server, redirecting output to a log file to
+        ## avoid filling the OS pipe buffer (which would deadlock the server
+        ## when Dask workers inherit and write to the same pipe fd).
         import subprocess, socket, time
-        self.estimator_process = subprocess.Popen([
-            "python", "run_server.py", "-ngpus=0", "-ncpus=1"
-        ], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        self._server_log = open("server.log", "w")
+        self.estimator_process = subprocess.Popen(
+            ["python", "run_server.py", "-ngpus=0", "-ncpus=1"],
+            stdout=self._server_log, stderr=self._server_log,
+        )
         ## Poll until the server is accepting connections (or timeout after 120s).
         server_port = 8000
         deadline = time.time() + 120
         while time.time() < deadline:
+            if self.estimator_process.poll() is not None:
+                self._server_log.flush()
+                log_contents = open("server.log").read()
+                pytest.fail(
+                    "Evaluator server process exited prematurely (rc=%d). Log:\n%s"
+                    % (self.estimator_process.returncode, log_contents[-2000:])
+                )
             try:
                 with socket.create_connection(('localhost', server_port), timeout=1):
                     break
@@ -208,11 +219,17 @@ class TestEvaluatorBromineStudy(ForceBalanceSystemTest):
         else:
             self.estimator_process.terminate()
             pytest.fail("Evaluator server did not start within 120 seconds")
+        ## Give the server a moment to fully initialise after the port opens.
+        time.sleep(2)
         self.input_file='gradient.in'
         self.logger.debug("\nSetting input file to '%s'\n" % self.input_file)
 
     def teardown_method(self):
         self.estimator_process.terminate()
+        self._server_log.close()
+        for fnm in ["server.log"]:
+            if os.path.exists(fnm):
+                os.remove(fnm)
         for dnm in ["working_directory", "stored_data"]:
             if os.path.exists(dnm):
                 shutil.rmtree(dnm)

--- a/src/tests/test_system.py
+++ b/src/tests/test_system.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 from builtins import str
 import os, shutil
+import sys
 import tarfile
 from .__init__ import ForceBalanceTestCase, check_for_openmm
 from forcebalance.parser import parse_inputs
@@ -11,6 +12,11 @@ from forcebalance.optimizer import Optimizer, Counter
 from numpy import array
 import numpy as np
 import pytest
+
+skip_openff_py39 = pytest.mark.skipif(
+    sys.version_info < (3, 10),
+    reason="openff packages require ambertools which requires Python >= 3.10",
+)
 
 # expected results (mvals) taken from previous runs. Update this if it changes and seems reasonable (updated 10/24/13)
 #EXPECTED_WATER_RESULTS = array([3.3192e-02, 4.3287e-02, 5.5072e-03, -4.5933e-02, 1.5499e-02, -3.7655e-01, 2.4720e-03, 1.1914e-02, 1.5066e-01])
@@ -181,6 +187,8 @@ class TestThermoBromineStudy(ForceBalanceSystemTest):
         """Check liquid bromine study (Thermo target) converges to expected results"""
         self.run_optimizer()
 
+
+@skip_openff_py39
 class TestEvaluatorBromineStudy(ForceBalanceSystemTest):
     def setup_method(self, method):
         pytest.importorskip("openff.evaluator")
@@ -290,6 +298,7 @@ class TestImplicitSolventHFEStudy(ForceBalanceSystemTest):
         """Check implicit hydration free energy study (Hydration target) converges to expected results"""
         self.run_optimizer(check_result=False, check_iter=False, use_pvals=True)
 
+@skip_openff_py39
 class TestOpenFFTorsionProfileStudy(ForceBalanceSystemTest):
     def setup_method(self, method):
         pytest.importorskip("openff.toolkit", minversion="0.4")
@@ -310,6 +319,7 @@ class TestOpenFFTorsionProfileStudy(ForceBalanceSystemTest):
         """Check OpenFF torsion profile optimization converges to expected results"""
         self.run_optimizer(check_iter=False)
 
+@skip_openff_py39
 class TestRechargeMethaneStudy(ForceBalanceSystemTest):
 
     def setup_method(self, method):

--- a/src/tests/test_system.py
+++ b/src/tests/test_system.py
@@ -244,7 +244,15 @@ class TestEvaluatorBromineStudy(ForceBalanceSystemTest):
     def test_bromine_study(self):
         """Check bromine study produces objective function and gradient in expected range """
         objective = self.get_objective()
-        data      = objective.Full(np.zeros(objective.FF.np),1,verbose=True)
+        try:
+            data = objective.Full(np.zeros(objective.FF.np),1,verbose=True)
+        except Exception as exc:
+            self._server_log.flush()
+            log_contents = open("server.log").read()
+            raise RuntimeError(
+                "objective.Full raised %s: %s\nServer log (last 2000 chars):\n%s"
+                % (type(exc).__name__, exc, log_contents[-2000:])
+            ) from exc
         X, G, H   = data['X'], data['G'], data['H']
         msgX="\nCalculated objective function is outside expected range.\n If this seems reasonable, update EXPECTED_EVALUATOR_BROMINE_OBJECTIVE in test_system.py with these values"
         np.testing.assert_allclose(EXPECTED_EVALUATOR_BROMINE_OBJECTIVE, X, atol=200, err_msg=msgX)

--- a/src/tests/test_system.py
+++ b/src/tests/test_system.py
@@ -196,7 +196,8 @@ class TestEvaluatorBromineStudy(ForceBalanceSystemTest):
         ##   that inherit the fd don't fill the pipe buffer and deadlock.
         ## - Use 'python -u' so each log line is flushed immediately to disk.
         import subprocess, time
-        self._server_log = open("server.log", "w")
+        self._server_log_path = os.path.abspath("server.log")
+        self._server_log = open(self._server_log_path, "w")
         self.estimator_process = subprocess.Popen(
             ["python", "-u", "run_server.py", "-ngpus=0", "-ncpus=1"],
             stdout=self._server_log, stderr=self._server_log,
@@ -211,18 +212,18 @@ class TestEvaluatorBromineStudy(ForceBalanceSystemTest):
         while time.time() < deadline:
             if self.estimator_process.poll() is not None:
                 self._server_log.flush()
-                log_contents = open("server.log").read()
+                log_contents = open(self._server_log_path).read()
                 pytest.fail(
                     "Evaluator server process exited prematurely (rc=%d). Log:\n%s"
                     % (self.estimator_process.returncode, log_contents[-2000:])
                 )
-            with open("server.log") as f:
+            with open(self._server_log_path) as f:
                 if ready_marker in f.read():
                     break
             time.sleep(0.5)
         else:
             self.estimator_process.terminate()
-            log_contents = open("server.log").read()
+            log_contents = open(self._server_log_path).read()
             pytest.fail(
                 "Evaluator server did not start within 120 seconds. Log:\n%s"
                 % log_contents[-2000:]
@@ -233,9 +234,8 @@ class TestEvaluatorBromineStudy(ForceBalanceSystemTest):
     def teardown_method(self):
         self.estimator_process.terminate()
         self._server_log.close()
-        for fnm in ["server.log"]:
-            if os.path.exists(fnm):
-                os.remove(fnm)
+        if os.path.exists(self._server_log_path):
+            os.remove(self._server_log_path)
         for dnm in ["working_directory", "stored_data"]:
             if os.path.exists(dnm):
                 shutil.rmtree(dnm)
@@ -248,7 +248,7 @@ class TestEvaluatorBromineStudy(ForceBalanceSystemTest):
             data = objective.Full(np.zeros(objective.FF.np),1,verbose=True)
         except Exception as exc:
             self._server_log.flush()
-            log_contents = open("server.log").read()
+            log_contents = open(self._server_log_path).read()
             raise RuntimeError(
                 "objective.Full raised %s: %s\nServer log (last 2000 chars):\n%s"
                 % (type(exc).__name__, exc, log_contents[-2000:])

--- a/src/tests/test_system.py
+++ b/src/tests/test_system.py
@@ -192,19 +192,30 @@ class TestEvaluatorBromineStudy(ForceBalanceSystemTest):
         targets.extractall()
         targets.close()
         ## Start the estimator server.
-        import subprocess, time
+        import subprocess, socket, time
         self.estimator_process = subprocess.Popen([
             "python", "run_server.py", "-ngpus=0", "-ncpus=1"
         ], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        ## Give the server time to start.
-        time.sleep(5)
+        ## Poll until the server is accepting connections (or timeout after 120s).
+        server_port = 8000
+        deadline = time.time() + 120
+        while time.time() < deadline:
+            try:
+                with socket.create_connection(('localhost', server_port), timeout=1):
+                    break
+            except (ConnectionRefusedError, OSError):
+                time.sleep(1)
+        else:
+            self.estimator_process.terminate()
+            pytest.fail("Evaluator server did not start within 120 seconds")
         self.input_file='gradient.in'
         self.logger.debug("\nSetting input file to '%s'\n" % self.input_file)
 
     def teardown_method(self):
         self.estimator_process.terminate()
-        shutil.rmtree("working_directory")
-        shutil.rmtree("stored_data")
+        for dnm in ["working_directory", "stored_data"]:
+            if os.path.exists(dnm):
+                shutil.rmtree(dnm)
         super(TestEvaluatorBromineStudy, self).teardown_method()
 
     def test_bromine_study(self):

--- a/src/tests/test_system.py
+++ b/src/tests/test_system.py
@@ -191,17 +191,22 @@ class TestEvaluatorBromineStudy(ForceBalanceSystemTest):
         targets = tarfile.open('targets.tar.gz','r')
         targets.extractall()
         targets.close()
-        ## Start the estimator server, redirecting output to a log file to
-        ## avoid filling the OS pipe buffer (which would deadlock the server
-        ## when Dask workers inherit and write to the same pipe fd).
-        import subprocess, socket, time
+        ## Start the estimator server.
+        ## - Redirect output to a log file (not PIPE) so Dask worker subprocesses
+        ##   that inherit the fd don't fill the pipe buffer and deadlock.
+        ## - Use 'python -u' so each log line is flushed immediately to disk.
+        import subprocess, time
         self._server_log = open("server.log", "w")
         self.estimator_process = subprocess.Popen(
-            ["python", "run_server.py", "-ngpus=0", "-ncpus=1"],
+            ["python", "-u", "run_server.py", "-ngpus=0", "-ncpus=1"],
             stdout=self._server_log, stderr=self._server_log,
         )
-        ## Poll until the server is accepting connections (or timeout after 120s).
+        ## Wait for the server to log that it is ready.  We intentionally avoid
+        ## making a raw TCP probe: a bare connect+disconnect causes recvall() in
+        ## _handle_stream to return None, which crashes struct.unpack and kills
+        ## the _handle_connections loop because the except is outside the while.
         server_port = 8000
+        ready_marker = "listening at port {}".format(server_port)
         deadline = time.time() + 120
         while time.time() < deadline:
             if self.estimator_process.poll() is not None:
@@ -211,16 +216,17 @@ class TestEvaluatorBromineStudy(ForceBalanceSystemTest):
                     "Evaluator server process exited prematurely (rc=%d). Log:\n%s"
                     % (self.estimator_process.returncode, log_contents[-2000:])
                 )
-            try:
-                with socket.create_connection(('localhost', server_port), timeout=1):
+            with open("server.log") as f:
+                if ready_marker in f.read():
                     break
-            except (ConnectionRefusedError, OSError):
-                time.sleep(1)
+            time.sleep(0.5)
         else:
             self.estimator_process.terminate()
-            pytest.fail("Evaluator server did not start within 120 seconds")
-        ## Give the server a moment to fully initialise after the port opens.
-        time.sleep(2)
+            log_contents = open("server.log").read()
+            pytest.fail(
+                "Evaluator server did not start within 120 seconds. Log:\n%s"
+                % log_contents[-2000:]
+            )
         self.input_file='gradient.in'
         self.logger.debug("\nSetting input file to '%s'\n" % self.input_file)
 

--- a/studies/003d_evaluator_liquid_bromine/run_server.py
+++ b/studies/003d_evaluator_liquid_bromine/run_server.py
@@ -1,4 +1,13 @@
 #!/usr/bin/env python3
+import multiprocessing
+
+# Use "spawn" instead of the Linux default "fork". When forking from the
+# multi-threaded Dask/Tornado process, child processes inherit locked mutexes
+# from sibling threads and deadlock immediately. "spawn" starts a fresh
+# interpreter with no inherited thread state, avoiding the deadlock entirely.
+# This is the primary fix for Python 3.9 / older openff-evaluator versions.
+multiprocessing.set_start_method("spawn", force=True)
+
 import shutil
 from os import path
 

--- a/studies/003d_evaluator_liquid_bromine/run_server.py
+++ b/studies/003d_evaluator_liquid_bromine/run_server.py
@@ -6,6 +6,7 @@ import multiprocessing
 # from sibling threads and deadlock immediately. "spawn" starts a fresh
 # interpreter with no inherited thread state, avoiding the deadlock entirely.
 # This is the primary fix for Python 3.9 / older openff-evaluator versions.
+# LW 2026-03-07: this fix was suggested by Claude.
 multiprocessing.set_start_method("spawn", force=True)
 
 import shutil
@@ -17,6 +18,7 @@ from os import path
 # deadlocks on Python 3.9/3.10 due to fork-safety issues (locked mutexes
 # inherited by the child process). With it, tasks run directly in the
 # Dask worker thread instead of being dispatched to a subprocess.
+# LW 2026-03-07: backend/dask.py is from OpenFF Evaluator
 import openff.evaluator
 openff.evaluator._called_from_test = True
 

--- a/studies/003d_evaluator_liquid_bromine/run_server.py
+++ b/studies/003d_evaluator_liquid_bromine/run_server.py
@@ -2,6 +2,15 @@
 import shutil
 from os import path
 
+# Setting this attribute bypasses multiprocessing.Manager() +
+# multiprocessing.Process() in _Multiprocessor.run() (backends/dask.py).
+# Without it, forking from the multi-threaded Dask/Tornado process
+# deadlocks on Python 3.9/3.10 due to fork-safety issues (locked mutexes
+# inherited by the child process). With it, tasks run directly in the
+# Dask worker thread instead of being dispatched to a subprocess.
+import openff.evaluator
+openff.evaluator._called_from_test = True
+
 from openff.evaluator.backends import ComputeResources
 from openff.evaluator.backends.dask import DaskLocalCluster
 from openff.evaluator.server import EvaluatorServer


### PR DESCRIPTION
This PR updates the test matrix to go back to Python 3.9. It was unexpected much harder than I thought would be required, hence the number of commits -- I'd recommend squash merging if this is merged!

**Changes made**
- I've added a new env file for Python 3.9. The main difficulty I ran into is that ambertools is not available on Python 3.9 which short-circuited a lot of OpenFF tests. I dealt with this by just not running OpenFF tests on Python 3.9
- I think I fixed the ultimate cause of the flaky Evaluator bug, fingers crossed. I had thought this was fixed in #311 but the green CI there may have just been a fluke. I've commented where the additional code is for Evaluator.