### PR TITLE
Fix warnings in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,8 @@ jobs:
     - name: Set up conda environment
       uses: mamba-org/setup-micromamba@v1
       with:
-        environment-file: devtools/conda-envs/test_env.yaml
+        # ambertools has no Python 3.9 builds; use a separate env file for 3.9
+        environment-file: ${{ matrix.python-version == '3.9' && 'devtools/conda-envs/test_env_py39.yaml' || 'devtools/conda-envs/test_env.yaml' }}
         create-args: >- # beware the >- instead of |, we don't split on newlines but on spaces
           python=${{ matrix.python-version }}
 
@@ -49,12 +50,6 @@ jobs:
       if: matrix.python-version == '3.9' || matrix.python-version == '3.10'
       shell: bash -l {0}
       run: pip install "setuptools<82"
-
-    - name: Install ambertools for Python > 3.9
-      # AmberTools is not available for Python 3.9, so we install it separately for Python 3.10 and above
-      if: matrix.python-version != '3.9'
-      shell: bash -l {0}
-      run: micromamba install -c conda-forge ambertools
           
     - name: Additional info about the build
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
           - macOS-latest
           - ubuntu-latest
         python-version:
+          - "3.9"
+          - "3.10"
           - "3.11"
           - "3.12"
           # pymbar 3 does not support Python 3.13

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       # AmberTools is not available for Python 3.9, so we install it separately for Python 3.10 and above
       if: matrix.python-version != '3.9'
       shell: bash -l {0}
-      run: mamba install -c conda-forge ambertools
+      run: micromamba install -c conda-forge ambertools
           
     - name: Additional info about the build
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,11 @@ jobs:
         environment-file: devtools/conda-envs/test_env.yaml
         create-args: >- # beware the >- instead of |, we don't split on newlines but on spaces
           python=${{ matrix.python-version }}
+
+    - name: Pin setuptools for Python < 3.10
+      if: matrix.python-version == '3.9' || matrix.python-version == '3.10'
+      shell: bash -l {0}
+      run: pip install "setuptools<82"
           
     - name: Additional info about the build
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,12 @@ jobs:
       if: matrix.python-version == '3.9' || matrix.python-version == '3.10'
       shell: bash -l {0}
       run: pip install "setuptools<82"
+
+    - name: Install ambertools for Python > 3.9
+      # AmberTools is not available for Python 3.9, so we install it separately for Python 3.10 and above
+      if: matrix.python-version != '3.9'
+      shell: bash -l {0}
+      run: mamba install -c conda-forge ambertools
           
     - name: Additional info about the build
       shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,12 @@ studies/*/targets/
 studies/*/*.tmp/
 studies/*/*.bak/
 sutdies/*/*.err
+
+# test files from running CI locally
+src/tests/files/XmlScript_out/TIP3G2w.xml
+src/tests/files/targets/dms-liquid/dms.xml
+src/tests/files/temp.bak/
+src/tests/files/test_liquid/targets/Liquid/TIP3G2w.xml
+src/tests/files/test_liquid/targets/Liquid/dms.xml
+src/tests/test.job
+studies/003d_evaluator_liquid_bromine/smirnoff_parameter_assignments.json

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -24,6 +24,6 @@ dependencies:
   - geometric
   # - gromacs =2019.1
   - openff-toolkit >=0.11.3
-  - openff-evaluator-base >= 0.4.1
+  - openff-evaluator-base >= 0.4.5
   # - openff-recharge
   # - openeye-toolkits (Don't have a license file to use with GH Actions.)

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -24,6 +24,6 @@ dependencies:
   - geometric
   # - gromacs =2019.1
   - openff-toolkit >=0.11.3
-  - openff-evaluator >= 0.4.1
+  - openff-evaluator-base >= 0.4.1
   # - openff-recharge
   # - openeye-toolkits (Don't have a license file to use with GH Actions.)

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -23,7 +23,7 @@ dependencies:
   - ndcctools
   - geometric
   # - gromacs =2019.1
-  - openff-toolkit >=0.11.3
+  - openff-toolkit-base >=0.11.3
   - openff-evaluator-base >= 0.4.5
   # - openff-recharge
   # - openeye-toolkits (Don't have a license file to use with GH Actions.)

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -19,7 +19,6 @@ dependencies:
   - future
   - pymbar =3
   - openmm >= 8
-  - ambertools
   - ndcctools
   - geometric
   # - gromacs =2019.1

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -21,7 +21,7 @@ dependencies:
   - openmm >= 8
   - ndcctools
   - geometric
-  - rdkit # needed for openff toolkit
+  - rdkit!=2024.03.6,<2025.09
   # - gromacs =2019.1
   - openff-toolkit-base >=0.11.3
   - openff-evaluator-base >= 0.4.5

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -21,6 +21,7 @@ dependencies:
   - openmm >= 8
   - ndcctools
   - geometric
+  - rdkit # needed for openff toolkit
   # - gromacs =2019.1
   - openff-toolkit-base >=0.11.3
   - openff-evaluator-base >= 0.4.5

--- a/devtools/conda-envs/test_env_py39.yaml
+++ b/devtools/conda-envs/test_env_py39.yaml
@@ -19,11 +19,12 @@ dependencies:
   - future
   - pymbar =3
   - openmm >= 8
-  - ambertools
+  # ambertools has no Python 3.9 builds on conda-forge
   - ndcctools
   - geometric
   # - gromacs =2019.1
-  - openff-toolkit >=0.11.3
-  - openff-evaluator-base >= 0.4.5
+  # openff packages require Python >= 3.10; tests are skipped on 3.9
+  # - openff-toolkit-base
+  # - openff-evaluator-base
   # - openff-recharge
   # - openeye-toolkits (Don't have a license file to use with GH Actions.)

--- a/src/abinitio.py
+++ b/src/abinitio.py
@@ -606,15 +606,15 @@ class AbInitio(Target):
 
         In equation form, the objective function is given by:
 
-        \[ = {W_E}\left[ {\frac{{{\sum\limits_{i \in {N_s}}
-        {{w_i}{{\left( {E_i^{MM} - E_i^{QM}}
-        - \left( {{{\bar E}^{MM}} - {{\bar E}^{QM}}} \right) \right)}^2}}}}}
-        {{\sum\limits_{i \in {N_s}} {{w_i}{{\left(
-        {E_i^{QM} - {{\bar E}^{QM}}} \right)}^2}} }}} \right] +
-        {W_F}\left[ {\frac{{\sum\limits_{i \in {N_s}} {{w_i}\sum\limits_{a \in {N_a}}
-        {{{\left| {{\bf{F}}_{i,a}^{MM} - {\bf{F}}_{i,a}^{QM}} \right|}^2}} } }}
-        {{\sum\limits_{i \in {N_s}} {{w_i}\sum\limits_{a \in {N_a}}
-        {{{\left| {{\bf{F}}_{i,a}^{QM}} \right|}^2}} } }}} \right]\]
+        \\[ = {W_E}\\left[ {\\frac{{{\\sum\\limits_{i \\in {N_s}}
+        {{w_i}{{\\left( {E_i^{MM} - E_i^{QM}}
+        - \\left( {{{\\bar E}^{MM}} - {{\\bar E}^{QM}}} \\right) \\right)}^2}}}}}
+        {{\\sum\\limits_{i \\in {N_s}} {{w_i}{{\\left(
+        {E_i^{QM} - {{\\bar E}^{QM}}} \\right)}^2}} }}} \\right] +
+        {W_F}\\left[ {\\frac{{\\sum\\limits_{i \\in {N_s}} {{w_i}\\sum\\limits_{a \\in {N_a}}
+        {{{\\left| {{\\bf{F}}_{i,a}^{MM} - {\\bf{F}}_{i,a}^{QM}} \\right|}^2}} } }}
+        {{\\sum\\limits_{i \\in {N_s}} {{w_i}\\sum\\limits_{a \\in {N_a}}
+        {{{\\left| {{\\bf{F}}_{i,a}^{QM}} \\right|}^2}} } }}} \\right]\\]
 
         In the previous code (ForTune, 2011 and previous)
         this subroutine used analytic first derivatives of the

--- a/src/amberio.py
+++ b/src/amberio.py
@@ -248,7 +248,7 @@ def parse_amber_namelist(fin):
         # Matches the following:
         # variable name (may include alphanumeric characters or underscore)
         # 
-        block_split = re.findall("[A-Za-z0-9_]+ *= *(?:\'[^']*\'|[+-]?[0-9]+\.?[0-9]*),", block_string)
+        block_split = re.findall(r"[A-Za-z0-9_]+ *= *(?:\'[^']*\'|[+-]?[0-9]+\.?[0-9]*),", block_string)
         #block_split = re.findall("[A-Za-z0-9_ ]+= *(?:(?:\'.*\')*[+-]?[0-9]+\.*[0-9]*,)+", block_string)
         #block_split = re.findall("[A-Za-z0-9_ ]+= *(?:(?:\'.*\')*[^ ]*,)+", block_string)
         # print(block_string)
@@ -655,7 +655,7 @@ class FrcMod_Reader(BaseReader):
 #=============================================================================================
 
 # A regex for extracting print format info from the FORMAT lines.
-FORMAT_RE_PATTERN=re.compile("([0-9]+)([a-zA-Z]+)([0-9]+)\.?([0-9]*)")
+FORMAT_RE_PATTERN=re.compile(r"([0-9]+)([a-zA-Z]+)([0-9]+)\.?([0-9]*)")
 
 # Pointer labels which map to pointer numbers at top of prmtop files
 POINTER_LABELS  = """

--- a/src/binding.py
+++ b/src/binding.py
@@ -50,8 +50,8 @@ def parse_interactions(input_file):
             continue
         key = s[0].lower()
         # If line starts with a $, this signifies that we're in a new section.
-        if re.match('^\$',line):
-            word = re.sub('^\$','',line).upper()
+        if re.match(r'^\$',line):
+            word = re.sub(r'^\$','',line).upper()
             if word == "END": # End of a section, time to reinitialize variables.
                 if section == "GLOBAL": pass
                 elif section == "SYSTEM":

--- a/src/counterpoise.py
+++ b/src/counterpoise.py
@@ -76,7 +76,7 @@ class Counterpoise(Target):
             if match('^[0-9]+$',strip):
                 ## Number of atoms
                 self.na = int(strip)
-            elif match('[A-Z][a-z]*( +[-+]?([0-9]*\.[0-9]+|[0-9]+)){3}$',strip):
+            elif match(r'[A-Z][a-z]*( +[-+]?([0-9]*\.[0-9]+|[0-9]+)){3}$',strip):
                 xyz.append([float(i) for i in sline[1:]])
                 if len(elem) < self.na:
                     elem.append(sline[0])

--- a/src/custom_io.py
+++ b/src/custom_io.py
@@ -59,9 +59,9 @@ class Gen_Reader(BaseReader):
         # No sense in doing anything for an empty line or a comment line.
         if len(s) == 0 or match('^;',line): return None, None
         # Now go through all the cases.
-        if match('^\[.*\]',line):
+        if match(r'^\[.*\]',line):
             # Makes a word like "atoms", "bonds" etc.
-            self.sec = sub('[\[\] \n]','',line)
+            self.sec = sub(r'[\[\] \n]','',line)
         elif self.sec == 'counterpoise':
             self.itype = cptypes[int(s[2])]
             atom = [s[0],s[1]]

--- a/src/forcefield.py
+++ b/src/forcefield.py
@@ -1497,9 +1497,9 @@ class FF(forcebalance.BaseClass):
             # Matches dictionary keys in a string like this: 
             # Given string: PRM['Bonds/Bond/k/[#6X3:1]-[#6X3:2]']*np.arccos(PRM["[*:1]~[#7X3$(*~[#6X3]):2](~[*:3])~[*:4]"])
             # Returns: (['Bonds/Bond/k/[#6X3:1]-[#6X3:2]'], ["[*:1]~[#7X3$(*~[#6X3]):2](~[*:3])~[*:4]"])
-            matches = re.findall("\[['\"][^'\"]*['\"]\]", cmd)
+            matches = re.findall(r"\[['\"][^'\"]*['\"]\]", cmd)
             for word in matches:
-                src_param_name = re.sub("\[['\"]|['\"]\]", "", word)
+                src_param_name = re.sub(r"\[['\"]|['\"]\]", "", word)
                 src_nodes = [x for x in self.pTree.nodes() if x==src_param_name]
                 if len(src_nodes) > 1:
                     raise RuntimeError('Detected multiple nodes in pTree with the same name; this should not happen')

--- a/src/gmxio.py
+++ b/src/gmxio.py
@@ -409,9 +409,9 @@ class ITP_Reader(BaseReader):
             delattr(self, 'overpfx')
             delattr(self, 'oversfx')
 
-        if re.match('^ *\[.*\]',line):
+        if re.match(r'^ *\[.*\]',line):
             # Makes a word like "atoms", "bonds" etc.
-            self.sec = re.sub('[\[\] \n]','',line.strip())
+            self.sec = re.sub(r'[\[\] \n]','',line.strip())
         elif self.sec == 'defaults':
             self.itype = 'DEF'
             self.nbtype = int(s[0])

--- a/src/nifty.py
+++ b/src/nifty.py
@@ -863,9 +863,12 @@ def lp_load(fnm):
 #|      Work Queue stuff      |#
 #==============================#
 try:
-    import work_queue
-except:
-    pass
+    import ndcctools.work_queue as work_queue
+except ImportError:
+    try:
+        import work_queue
+    except ImportError:
+        pass
     #logger.warning("Work Queue library import fail (You can't queue up jobs using Work Queue)\n")
 
 # Global variable corresponding to the Work Queue object

--- a/src/optimizer.py
+++ b/src/optimizer.py
@@ -237,7 +237,7 @@ class Optimizer(forcebalance.BaseClass):
                 if os.path.exists(os.path.join(T.absrd(), 'mvals.txt')):
                     tmvals = np.loadtxt(os.path.join(T.absrd(), 'mvals.txt'))
                     if len(tmvals) > 0 and np.max(np.abs(tmvals - self.mvals0) > 1e-4):
-                        warn_press_key("mvals.txt in %s does not match loaded parameters.\nSave file : %s\Parameters : %s\n" % (T.absrd(), tmvals, self.mvals0))
+                        warn_press_key("mvals.txt in %s does not match loaded parameters.\nSave file : %s\nParameters : %s\n" % (T.absrd(), tmvals, self.mvals0))
                 else:
                     warn_press_key("mvals.txt does not exist in %s." % (T.absrd()))
         self.iterinit = maxrd
@@ -807,13 +807,13 @@ class Optimizer(forcebalance.BaseClass):
                 t0 = time.time()
                 # Opt1 = optimize.fmin_bfgs(HYP.compute_val,dx0,fprime=HYP.compute_grad,gtol=1e-5*np.sqrt(len(dx0)),full_output=True,disp=1)
                 # Opt1 = optimize.fmin_l_bfgs_b(HYP.compute_val,dx0,fprime=HYP.compute_grad,m=30,factr=1e7,pgtol=1e-4,iprint=0,disp=1,maxfun=1e5,maxiter=1e5)
-                Opt1 = optimize.fmin_l_bfgs_b(HYP.compute_val,dx0,fprime=HYP.compute_grad,m=30,factr=1e7,pgtol=1e-4,iprint=-1,disp=0,maxfun=1e5,maxiter=1e5)
+                Opt1 = optimize.fmin_l_bfgs_b(HYP.compute_val,dx0,fprime=HYP.compute_grad,m=30,factr=1e7,pgtol=1e-4,maxfun=int(1e5),maxiter=int(1e5))
                 logger.info("%.3f s (L-BFGS 1) ", time.time() - t0)
 
                 t0 = time.time()
                 # Opt2 = optimize.fmin_bfgs(HYP.compute_val,-xkd,fprime=HYP.compute_grad,gtol=1e-5*np.sqrt(len(dx0)),full_output=True,disp=1)
                 # Opt2 = optimize.fmin_l_bfgs_b(HYP.compute_val,-xkd,fprime=HYP.compute_grad,m=30,factr=1e7,pgtol=1e-4,iprint=0,disp=1,maxfun=1e5,maxiter=1e5)
-                Opt2 = optimize.fmin_l_bfgs_b(HYP.compute_val,-xkd,fprime=HYP.compute_grad,m=30,factr=1e7,pgtol=1e-4,iprint=-1,disp=0,maxfun=1e5,maxiter=1e5)
+                Opt2 = optimize.fmin_l_bfgs_b(HYP.compute_val,-xkd,fprime=HYP.compute_grad,m=30,factr=1e7,pgtol=1e-4,maxfun=int(1e5),maxiter=int(1e5))
                 logger.info("%.3f s (L-BFGS 2) ", time.time() - t0)
 
                 dx1, sol1 = Opt1[0], Opt1[1]

--- a/src/output.py
+++ b/src/output.py
@@ -56,16 +56,16 @@ class CleanStreamHandler(StreamHandler):
     
     def emit(self, record):
         message = record.getMessage()
-        message = re.sub("\x1b\[[0-9][0-9]?;?[0-9]?[0-9]?m", "", message)
+        message = re.sub(r"\x1b\[[0-9][0-9]?;?[0-9]?[0-9]?m", "", message)
         self.stream.write(message)
         self.flush()
-        
+
 class CleanFileHandler(FileHandler):
     """File handler that does not write terminal escape codes and carriage returns
     to files. Use this when writing to a file that will probably not be viewed in a terminal"""
     def emit(self, record):
         message = record.getMessage()
-        message = re.sub("\x1b\[[0-9][0-9]?;?[0-9]?[0-9]?m", "", message)
+        message = re.sub(r"\x1b\[[0-9][0-9]?;?[0-9]?[0-9]?m", "", message)
         message = re.sub("\r", "\n", message)
         self.stream.write(message)
         self.flush()

--- a/src/parser.py
+++ b/src/parser.py
@@ -329,7 +329,7 @@ mainsections = ["SIMULATION","TARGET","OPTIONS","END","NONE"]
 def read_mvals(fobj):
     Answer = []
     for line in fobj:
-        if re.match("(/read_mvals)|(^\$end)",line):
+        if re.match(r"(/read_mvals)|(^\$end)",line):
             break
         Answer.append(float(line.split('[', maxsplit=1)[-1].split(']', maxsplit=1)[0].split()[-1]))
     return Answer
@@ -337,7 +337,7 @@ def read_mvals(fobj):
 def read_pvals(fobj):
     Answer = []
     for line in fobj:
-        if re.match("(/read_pvals)|(^\$end)",line):
+        if re.match(r"(/read_pvals)|(^\$end)",line):
             break
         Answer.append(float(line.split('[', maxsplit=1)[-1].split(']', maxsplit=1)[0].split()[-1]))
     return Answer
@@ -346,7 +346,7 @@ def read_priors(fobj):
     Answer = OrderedDict()
     for line in fobj:
         line = line.split("#")[0]
-        if re.match("(/priors)|(^\$end)",line):
+        if re.match(r"(/priors)|(^\$end)",line):
             break
         Answer[line.split()[0]] = float(line.split()[-1])
     return Answer
@@ -462,7 +462,7 @@ def parse_inputs(input_file=None):
     there is a 'section' variable type.
 
     There is only one set of general options, but multiple sets of target options.
-    Each target has its own section delimited by the \em $target keyword,
+    Each target has its own section delimited by the \\em $target keyword,
     and we build a list of target options.
 
     @param[in]  input_file The name of the input file.
@@ -498,8 +498,8 @@ def parse_inputs(input_file=None):
             if key in bkwd: # Do option replacement for backward compatibility.
                 key = bkwd[key]
             # If line starts with a $, this signifies that we're in a new section.
-            if re.match('^\$',line):
-                newsection = re.sub('^\$','',line).upper()
+            if re.match(r'^\$',line):
+                newsection = re.sub(r'^\$','',line).upper()
                 if section in ["SIMULATION","TARGET"] and newsection in mainsections:
                     tgt_opts.append(this_tgt_opt)
                     this_tgt_opt = deepcopy(tgt_opts_defaults)

--- a/src/qchemio.py
+++ b/src/qchemio.py
@@ -52,14 +52,14 @@ class QCIn_Reader(BaseReader):
         # No sense in doing anything for an empty line or a comment line.
         if len(s) == 0 or match('^!',line): return None, None
         # Now go through all the cases.
-        if match('^\$',line):
+        if match(r'^\$',line):
             # Makes a word like "atoms", "bonds" etc.
-            self.sec = sub('^\$','',line)
+            self.sec = sub(r'^\$','',line)
         elif self.sec == 'basis':
             if match('^[A-Za-z][a-z]* +0$',line):
                 self.atom = s[0]
                 self.snum = -1
-            elif match('^[SPDFGH]P? +[0-9]+ +1\.0+$',line):
+            elif match(r'^[SPDFGH]P? +[0-9]+ +1\.0+$',line):
                 self.snum += 1
                 self.cnum  = -1
                 self.shell = s[0]

--- a/src/readfrq.py
+++ b/src/readfrq.py
@@ -28,7 +28,7 @@ def read_frq_gau(gauout):
         line = line.strip().expandtabs()
         if XMode >= 1:
             # Perfectionist here; matches integer, element, and three floating points
-            if re.match("^[0-9]+ +[0-9]+ +[0-9]+( +[-+]?([0-9]*\.)?[0-9]+){3}$", line):
+            if re.match(r"^[0-9]+ +[0-9]+ +[0-9]+( +[-+]?([0-9]*\.)?[0-9]+){3}$", line):
                 XMode = 2
                 sline = line.split()
                 elemThis.append(Elements[int(sline[1])])
@@ -152,7 +152,7 @@ def read_frq_qc(qcout):
         line = line.strip().expandtabs()
         if XMode >= 1:
             # Perfectionist here; matches integer, element, and three floating points
-            if re.match("^[0-9]+ +[A-Z][A-Za-z]?( +[-+]?([0-9]*\.)?[0-9]+){3}$", line):
+            if re.match(r"^[0-9]+ +[A-Z][A-Za-z]?( +[-+]?([0-9]*\.)?[0-9]+){3}$", line):
                 XMode = 2
                 sline = line.split()
                 elemThis.append(sline[1])
@@ -228,19 +228,19 @@ def read_frq_psi_current(psiout):
                     else:
                         frqs.append(float(mode))
         if VMode == 1:
-            if re.match('^\s*[0-9]', line) and mode_num >= skip_modes:
+            if re.match(r'^\s*[0-9]', line) and mode_num >= skip_modes:
                 s = line.split()
                 line_modes = int(len(s[2:])/3)
                 for mode in range(line_modes):
                     if mode not in readmodes:
                         readmodes[mode] = []
                     readmodes[mode].append([float(m) for m in s[2+mode*3:2+mode*3+3]])
-            elif re.match('^\s*[0-9]', line):
+            elif re.match(r'^\s*[0-9]', line):
                 s = line.split()
                 mode_num += int(len(s[2:])/3)
                 VMode = 0
                 VModeNxt = None
-            elif re.match('^[ \t\r\n\s]*$', line):
+            elif re.match(r'^[ \t\r\n\s]*$', line):
                 VMode = 0
                 VModeNxt = None
                 for mode in readmodes.keys():

--- a/src/tests/__init__.py
+++ b/src/tests/__init__.py
@@ -6,7 +6,7 @@ forcebalance.output.getLogger("forcebalance.test").propagate=False
 
 os.chdir(os.path.dirname(__file__))
 __all__ = [module[:-3] for module in sorted(os.listdir('.'))
-           if re.match("^test_.*\.py$",module)]
+           if re.match(r"^test_.*\.py$",module)]
 
 
 class ForceBalanceTestCase(object):

--- a/src/tests/test_nifty.py
+++ b/src/tests/test_nifty.py
@@ -8,9 +8,12 @@ from forcebalance.nifty import *
 from forcebalance.nifty import _exec
 
 try:
-    import work_queue
+    import ndcctools.work_queue as work_queue
 except ImportError:
-    work_queue = None
+    try:
+        import work_queue
+    except ImportError:
+        work_queue = None
 
 class TestNifty(ForceBalanceTestCase):
     def setup_method(self, method):

--- a/src/tests/test_objective.py
+++ b/src/tests/test_objective.py
@@ -23,7 +23,7 @@ class TestImplemented(ForceBalanceTestCase):
         test case
         """
         forcebalance_modules=[module[:-3] for module in os.listdir(forcebalance.__path__[0])
-                    if re.compile(".*\.py$").match(module)
+                    if re.compile(r".*\.py$").match(module)
                     and module not in ["__init__.py"]]
         for module in forcebalance_modules:
             # LPW: I don't think dcdlib should be imported this way.

--- a/src/tests/test_smirnoff_hack.py
+++ b/src/tests/test_smirnoff_hack.py
@@ -1,3 +1,4 @@
+import sys
 import pytest
 
 has_openff_toolkit = True
@@ -6,7 +7,10 @@ try:
 except ModuleNotFoundError:
     has_openff_toolkit = False
 
+from .test_system import skip_openff_py39
 
+
+@skip_openff_py39
 @pytest.mark.skipif(
     not has_openff_toolkit, reason="openff.toolkit module not found"
 )

--- a/src/tests/test_system.py
+++ b/src/tests/test_system.py
@@ -191,15 +191,26 @@ class TestEvaluatorBromineStudy(ForceBalanceSystemTest):
         targets = tarfile.open('targets.tar.gz','r')
         targets.extractall()
         targets.close()
-        ## Start the estimator server.
+        ## Start the estimator server, redirecting output to a log file to
+        ## avoid filling the OS pipe buffer (which would deadlock the server
+        ## when Dask workers inherit and write to the same pipe fd).
         import subprocess, socket, time
-        self.estimator_process = subprocess.Popen([
-            "python", "run_server.py", "-ngpus=0", "-ncpus=1"
-        ], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        self._server_log = open("server.log", "w")
+        self.estimator_process = subprocess.Popen(
+            ["python", "run_server.py", "-ngpus=0", "-ncpus=1"],
+            stdout=self._server_log, stderr=self._server_log,
+        )
         ## Poll until the server is accepting connections (or timeout after 120s).
         server_port = 8000
         deadline = time.time() + 120
         while time.time() < deadline:
+            if self.estimator_process.poll() is not None:
+                self._server_log.flush()
+                log_contents = open("server.log").read()
+                pytest.fail(
+                    "Evaluator server process exited prematurely (rc=%d). Log:\n%s"
+                    % (self.estimator_process.returncode, log_contents[-2000:])
+                )
             try:
                 with socket.create_connection(('localhost', server_port), timeout=1):
                     break
@@ -208,11 +219,17 @@ class TestEvaluatorBromineStudy(ForceBalanceSystemTest):
         else:
             self.estimator_process.terminate()
             pytest.fail("Evaluator server did not start within 120 seconds")
+        ## Give the server a moment to fully initialise after the port opens.
+        time.sleep(2)
         self.input_file='gradient.in'
         self.logger.debug("\nSetting input file to '%s'\n" % self.input_file)
 
     def teardown_method(self):
         self.estimator_process.terminate()
+        self._server_log.close()
+        for fnm in ["server.log"]:
+            if os.path.exists(fnm):
+                os.remove(fnm)
         for dnm in ["working_directory", "stored_data"]:
             if os.path.exists(dnm):
                 shutil.rmtree(dnm)

--- a/src/tests/test_system.py
+++ b/src/tests/test_system.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 from builtins import str
 import os, shutil
+import sys
 import tarfile
 from .__init__ import ForceBalanceTestCase, check_for_openmm
 from forcebalance.parser import parse_inputs
@@ -11,6 +12,11 @@ from forcebalance.optimizer import Optimizer, Counter
 from numpy import array
 import numpy as np
 import pytest
+
+skip_openff_py39 = pytest.mark.skipif(
+    sys.version_info < (3, 10),
+    reason="openff packages require ambertools which requires Python >= 3.10",
+)
 
 # expected results (mvals) taken from previous runs. Update this if it changes and seems reasonable (updated 10/24/13)
 #EXPECTED_WATER_RESULTS = array([3.3192e-02, 4.3287e-02, 5.5072e-03, -4.5933e-02, 1.5499e-02, -3.7655e-01, 2.4720e-03, 1.1914e-02, 1.5066e-01])
@@ -181,6 +187,8 @@ class TestThermoBromineStudy(ForceBalanceSystemTest):
         """Check liquid bromine study (Thermo target) converges to expected results"""
         self.run_optimizer()
 
+
+@skip_openff_py39
 class TestEvaluatorBromineStudy(ForceBalanceSystemTest):
     def setup_method(self, method):
         pytest.importorskip("openff.evaluator")
@@ -290,6 +298,7 @@ class TestImplicitSolventHFEStudy(ForceBalanceSystemTest):
         """Check implicit hydration free energy study (Hydration target) converges to expected results"""
         self.run_optimizer(check_result=False, check_iter=False, use_pvals=True)
 
+@skip_openff_py39
 class TestOpenFFTorsionProfileStudy(ForceBalanceSystemTest):
     def setup_method(self, method):
         pytest.importorskip("openff.toolkit", minversion="0.4")
@@ -310,6 +319,7 @@ class TestOpenFFTorsionProfileStudy(ForceBalanceSystemTest):
         """Check OpenFF torsion profile optimization converges to expected results"""
         self.run_optimizer(check_iter=False)
 
+@skip_openff_py39
 class TestRechargeMethaneStudy(ForceBalanceSystemTest):
 
     def setup_method(self, method):

--- a/src/tests/test_system.py
+++ b/src/tests/test_system.py
@@ -244,7 +244,15 @@ class TestEvaluatorBromineStudy(ForceBalanceSystemTest):
     def test_bromine_study(self):
         """Check bromine study produces objective function and gradient in expected range """
         objective = self.get_objective()
-        data      = objective.Full(np.zeros(objective.FF.np),1,verbose=True)
+        try:
+            data = objective.Full(np.zeros(objective.FF.np),1,verbose=True)
+        except Exception as exc:
+            self._server_log.flush()
+            log_contents = open("server.log").read()
+            raise RuntimeError(
+                "objective.Full raised %s: %s\nServer log (last 2000 chars):\n%s"
+                % (type(exc).__name__, exc, log_contents[-2000:])
+            ) from exc
         X, G, H   = data['X'], data['G'], data['H']
         msgX="\nCalculated objective function is outside expected range.\n If this seems reasonable, update EXPECTED_EVALUATOR_BROMINE_OBJECTIVE in test_system.py with these values"
         np.testing.assert_allclose(EXPECTED_EVALUATOR_BROMINE_OBJECTIVE, X, atol=200, err_msg=msgX)

--- a/src/tests/test_system.py
+++ b/src/tests/test_system.py
@@ -196,7 +196,8 @@ class TestEvaluatorBromineStudy(ForceBalanceSystemTest):
         ##   that inherit the fd don't fill the pipe buffer and deadlock.
         ## - Use 'python -u' so each log line is flushed immediately to disk.
         import subprocess, time
-        self._server_log = open("server.log", "w")
+        self._server_log_path = os.path.abspath("server.log")
+        self._server_log = open(self._server_log_path, "w")
         self.estimator_process = subprocess.Popen(
             ["python", "-u", "run_server.py", "-ngpus=0", "-ncpus=1"],
             stdout=self._server_log, stderr=self._server_log,
@@ -211,18 +212,18 @@ class TestEvaluatorBromineStudy(ForceBalanceSystemTest):
         while time.time() < deadline:
             if self.estimator_process.poll() is not None:
                 self._server_log.flush()
-                log_contents = open("server.log").read()
+                log_contents = open(self._server_log_path).read()
                 pytest.fail(
                     "Evaluator server process exited prematurely (rc=%d). Log:\n%s"
                     % (self.estimator_process.returncode, log_contents[-2000:])
                 )
-            with open("server.log") as f:
+            with open(self._server_log_path) as f:
                 if ready_marker in f.read():
                     break
             time.sleep(0.5)
         else:
             self.estimator_process.terminate()
-            log_contents = open("server.log").read()
+            log_contents = open(self._server_log_path).read()
             pytest.fail(
                 "Evaluator server did not start within 120 seconds. Log:\n%s"
                 % log_contents[-2000:]
@@ -233,9 +234,8 @@ class TestEvaluatorBromineStudy(ForceBalanceSystemTest):
     def teardown_method(self):
         self.estimator_process.terminate()
         self._server_log.close()
-        for fnm in ["server.log"]:
-            if os.path.exists(fnm):
-                os.remove(fnm)
+        if os.path.exists(self._server_log_path):
+            os.remove(self._server_log_path)
         for dnm in ["working_directory", "stored_data"]:
             if os.path.exists(dnm):
                 shutil.rmtree(dnm)
@@ -248,7 +248,7 @@ class TestEvaluatorBromineStudy(ForceBalanceSystemTest):
             data = objective.Full(np.zeros(objective.FF.np),1,verbose=True)
         except Exception as exc:
             self._server_log.flush()
-            log_contents = open("server.log").read()
+            log_contents = open(self._server_log_path).read()
             raise RuntimeError(
                 "objective.Full raised %s: %s\nServer log (last 2000 chars):\n%s"
                 % (type(exc).__name__, exc, log_contents[-2000:])

--- a/src/tests/test_system.py
+++ b/src/tests/test_system.py
@@ -192,19 +192,30 @@ class TestEvaluatorBromineStudy(ForceBalanceSystemTest):
         targets.extractall()
         targets.close()
         ## Start the estimator server.
-        import subprocess, time
+        import subprocess, socket, time
         self.estimator_process = subprocess.Popen([
             "python", "run_server.py", "-ngpus=0", "-ncpus=1"
         ], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        ## Give the server time to start.
-        time.sleep(5)
+        ## Poll until the server is accepting connections (or timeout after 120s).
+        server_port = 8000
+        deadline = time.time() + 120
+        while time.time() < deadline:
+            try:
+                with socket.create_connection(('localhost', server_port), timeout=1):
+                    break
+            except (ConnectionRefusedError, OSError):
+                time.sleep(1)
+        else:
+            self.estimator_process.terminate()
+            pytest.fail("Evaluator server did not start within 120 seconds")
         self.input_file='gradient.in'
         self.logger.debug("\nSetting input file to '%s'\n" % self.input_file)
 
     def teardown_method(self):
         self.estimator_process.terminate()
-        shutil.rmtree("working_directory")
-        shutil.rmtree("stored_data")
+        for dnm in ["working_directory", "stored_data"]:
+            if os.path.exists(dnm):
+                shutil.rmtree(dnm)
         super(TestEvaluatorBromineStudy, self).teardown_method()
 
     def test_bromine_study(self):

--- a/src/tests/test_system.py
+++ b/src/tests/test_system.py
@@ -191,17 +191,22 @@ class TestEvaluatorBromineStudy(ForceBalanceSystemTest):
         targets = tarfile.open('targets.tar.gz','r')
         targets.extractall()
         targets.close()
-        ## Start the estimator server, redirecting output to a log file to
-        ## avoid filling the OS pipe buffer (which would deadlock the server
-        ## when Dask workers inherit and write to the same pipe fd).
-        import subprocess, socket, time
+        ## Start the estimator server.
+        ## - Redirect output to a log file (not PIPE) so Dask worker subprocesses
+        ##   that inherit the fd don't fill the pipe buffer and deadlock.
+        ## - Use 'python -u' so each log line is flushed immediately to disk.
+        import subprocess, time
         self._server_log = open("server.log", "w")
         self.estimator_process = subprocess.Popen(
-            ["python", "run_server.py", "-ngpus=0", "-ncpus=1"],
+            ["python", "-u", "run_server.py", "-ngpus=0", "-ncpus=1"],
             stdout=self._server_log, stderr=self._server_log,
         )
-        ## Poll until the server is accepting connections (or timeout after 120s).
+        ## Wait for the server to log that it is ready.  We intentionally avoid
+        ## making a raw TCP probe: a bare connect+disconnect causes recvall() in
+        ## _handle_stream to return None, which crashes struct.unpack and kills
+        ## the _handle_connections loop because the except is outside the while.
         server_port = 8000
+        ready_marker = "listening at port {}".format(server_port)
         deadline = time.time() + 120
         while time.time() < deadline:
             if self.estimator_process.poll() is not None:
@@ -211,16 +216,17 @@ class TestEvaluatorBromineStudy(ForceBalanceSystemTest):
                     "Evaluator server process exited prematurely (rc=%d). Log:\n%s"
                     % (self.estimator_process.returncode, log_contents[-2000:])
                 )
-            try:
-                with socket.create_connection(('localhost', server_port), timeout=1):
+            with open("server.log") as f:
+                if ready_marker in f.read():
                     break
-            except (ConnectionRefusedError, OSError):
-                time.sleep(1)
+            time.sleep(0.5)
         else:
             self.estimator_process.terminate()
-            pytest.fail("Evaluator server did not start within 120 seconds")
-        ## Give the server a moment to fully initialise after the port opens.
-        time.sleep(2)
+            log_contents = open("server.log").read()
+            pytest.fail(
+                "Evaluator server did not start within 120 seconds. Log:\n%s"
+                % log_contents[-2000:]
+            )
         self.input_file='gradient.in'
         self.logger.debug("\nSetting input file to '%s'\n" % self.input_file)
 

--- a/studies/003d_evaluator_liquid_bromine/run_server.py
+++ b/studies/003d_evaluator_liquid_bromine/run_server.py
@@ -1,4 +1,13 @@
 #!/usr/bin/env python3
+import multiprocessing
+
+# Use "spawn" instead of the Linux default "fork". When forking from the
+# multi-threaded Dask/Tornado process, child processes inherit locked mutexes
+# from sibling threads and deadlock immediately. "spawn" starts a fresh
+# interpreter with no inherited thread state, avoiding the deadlock entirely.
+# This is the primary fix for Python 3.9 / older openff-evaluator versions.
+multiprocessing.set_start_method("spawn", force=True)
+
 import shutil
 from os import path
 

--- a/studies/003d_evaluator_liquid_bromine/run_server.py
+++ b/studies/003d_evaluator_liquid_bromine/run_server.py
@@ -2,6 +2,15 @@
 import shutil
 from os import path
 
+# Setting this attribute bypasses multiprocessing.Manager() +
+# multiprocessing.Process() in _Multiprocessor.run() (backends/dask.py).
+# Without it, forking from the multi-threaded Dask/Tornado process
+# deadlocks on Python 3.9/3.10 due to fork-safety issues (locked mutexes
+# inherited by the child process). With it, tasks run directly in the
+# Dask worker thread instead of being dispatched to a subprocess.
+import openff.evaluator
+openff.evaluator._called_from_test = True
+
 from openff.evaluator.backends import ComputeResources
 from openff.evaluator.backends.dask import DaskLocalCluster
 from openff.evaluator.server import EvaluatorServer


### PR DESCRIPTION
Outdated strings and imports are causing a ton of warnings in CI -- this PR fixes them.

Most of the changes are changing strings to raw strings. This is rebased off of #312 -- only the most recent commit is relevant.

e.g. the below from a run in `master`:

```


<unknown>:573: DeprecationWarning: invalid escape sequence '\['
/Users/runner/micromamba/envs/forcebalance-test/lib/python3.11/site-packages/forcebalance/abinitio.py:573: DeprecationWarning: invalid escape sequence '\['
  """
<unknown>:251: DeprecationWarning: invalid escape sequence '\.'
<unknown>:658: DeprecationWarning: invalid escape sequence '\.'
/Users/runner/micromamba/envs/forcebalance-test/lib/python3.11/site-packages/forcebalance/amberio.py:251: DeprecationWarning: invalid escape sequence '\.'
  block_split = re.findall("[A-Za-z0-9_]+ *= *(?:\'[^']*\'|[+-]?[0-9]+\.?[0-9]*),", block_string)
/Users/runner/micromamba/envs/forcebalance-test/lib/python3.11/site-packages/forcebalance/amberio.py:658: DeprecationWarning: invalid escape sequence '\.'
  FORMAT_RE_PATTERN=re.compile("([0-9]+)([a-zA-Z]+)([0-9]+)\.?([0-9]*)")
<unknown>:53: DeprecationWarning: invalid escape sequence '\$'
<unknown>:54: DeprecationWarning: invalid escape sequence '\$'
/Users/runner/micromamba/envs/forcebalance-test/lib/python3.11/site-packages/forcebalance/binding.py:53: DeprecationWarning: invalid escape sequence '\$'
  if re.match('^\$',line):
/Users/runner/micromamba/envs/forcebalance-test/lib/python3.11/site-packages/forcebalance/binding.py:54: DeprecationWarning: invalid escape sequence '\$'
  word = re.sub('^\$','',line).upper()
<unknown>:79: DeprecationWarning: invalid escape sequence '\.'
/Users/runner/micromamba/envs/forcebalance-test/lib/python3.11/site-packages/forcebalance/counterpoise.py:79: DeprecationWarning: invalid escape sequence '\.'
  elif match('[A-Z][a-z]*( +[-+]?([0-9]*\.[0-9]+|[0-9]+)){3}$',strip):
<unknown>:62: DeprecationWarning: invalid escape sequence '\['
<unknown>:64: DeprecationWarning: invalid escape sequence '\['
/Users/runner/micromamba/envs/forcebalance-test/lib/python3.11/site-packages/forcebalance/custom_io.py:62: DeprecationWarning: invalid escape sequence '\['
  if match('^\[.*\]',line):
/Users/runner/micromamba/envs/forcebalance-test/lib/python3.11/site-packages/forcebalance/custom_io.py:64: DeprecationWarning: invalid escape sequence '\['
  self.sec = sub('[\[\] \n]','',line)
<unknown>:1500: DeprecationWarning: invalid escape sequence '\['
<unknown>:1502: DeprecationWarning: invalid escape sequence '\['
/Users/runner/micromamba/envs/forcebalance-test/lib/python3.11/site-packages/forcebalance/forcefield.py:1500: DeprecationWarning: invalid escape sequence '\['
  matches = re.findall("\[['\"][^'\"]*['\"]\]", cmd)
/Users/runner/micromamba/envs/forcebalance-test/lib/python3.11/site-packages/forcebalance/forcefield.py:1502: DeprecationWarning: invalid escape sequence '\['
  src_param_name = re.sub("\[['\"]|['\"]\]", "", word)
<unknown>:412: DeprecationWarning: invalid escape sequence '\['
<unknown>:414: DeprecationWarning: invalid escape sequence '\['
/Users/runner/micromamba/envs/forcebalance-test/lib/python3.11/site-packages/forcebalance/gmxio.py:412: DeprecationWarning: invalid escape sequence '\['
  if re.match('^ *\[.*\]',line):
/Users/runner/micromamba/envs/forcebalance-test/lib/python3.11/site-packages/forcebalance/gmxio.py:414: DeprecationWarning: invalid escape sequence '\['
  self.sec = re.sub('[\[\] \n]','',line.strip())
<unknown>:240: DeprecationWarning: invalid escape sequence '\P'
/Users/runner/micromamba/envs/forcebalance-test/lib/python3.11/site-packages/forcebalance/optimizer.py:240: DeprecationWarning: invalid escape sequence '\P'
  warn_press_key("mvals.txt in %s does not match loaded parameters.\nSave file : %s\Parameters : %s\n" % (T.absrd(), tmvals, self.mvals0))
<unknown>:59: DeprecationWarning: invalid escape sequence '\['
<unknown>:68: DeprecationWarning: invalid escape sequence '\['
/Users/runner/micromamba/envs/forcebalance-test/lib/python3.11/site-packages/forcebalance/output.py:59: DeprecationWarning: invalid escape sequence '\['
  message = re.sub("\x1b\[[0-9][0-9]?;?[0-9]?[0-9]?m", "", message)
/Users/runner/micromamba/envs/forcebalance-test/lib/python3.11/site-packages/forcebalance/output.py:68: DeprecationWarning: invalid escape sequence '\['
  message = re.sub("\x1b\[[0-9][0-9]?;?[0-9]?[0-9]?m", "", message)
<unknown>:332: DeprecationWarning: invalid escape sequence '\$'
<unknown>:340: DeprecationWarning: invalid escape sequence '\$'
<unknown>:349: DeprecationWarning: invalid escape sequence '\$'
<unknown>:454: DeprecationWarning: invalid escape sequence '\e'
<unknown>:501: DeprecationWarning: invalid escape sequence '\$'
<unknown>:502: DeprecationWarning: invalid escape sequence '\$'
/Users/runner/micromamba/envs/forcebalance-test/lib/python3.11/site-packages/forcebalance/parser.py:332: DeprecationWarning: invalid escape sequence '\$'
  if re.match("(/read_mvals)|(^\$end)",line):
/Users/runner/micromamba/envs/forcebalance-test/lib/python3.11/site-packages/forcebalance/parser.py:340: DeprecationWarning: invalid escape sequence '\$'
  if re.match("(/read_pvals)|(^\$end)",line):
/Users/runner/micromamba/envs/forcebalance-test/lib/python3.11/site-packages/forcebalance/parser.py:349: DeprecationWarning: invalid escape sequence '\$'
  if re.match("(/priors)|(^\$end)",line):
/Users/runner/micromamba/envs/forcebalance-test/lib/python3.11/site-packages/forcebalance/parser.py:454: DeprecationWarning: invalid escape sequence '\e'
  """ Parse through the input file and read all user-supplied options.
/Users/runner/micromamba/envs/forcebalance-test/lib/python3.11/site-packages/forcebalance/parser.py:501: DeprecationWarning: invalid escape sequence '\$'
  if re.match('^\$',line):
/Users/runner/micromamba/envs/forcebalance-test/lib/python3.11/site-packages/forcebalance/parser.py:502: DeprecationWarning: invalid escape sequence '\$'
  newsection = re.sub('^\$','',line).upper()
<unknown>:55: DeprecationWarning: invalid escape sequence '\$'
<unknown>:57: DeprecationWarning: invalid escape sequence '\$'
<unknown>:62: DeprecationWarning: invalid escape sequence '\.'
/Users/runner/micromamba/envs/forcebalance-test/lib/python3.11/site-packages/forcebalance/qchemio.py:55: DeprecationWarning: invalid escape sequence '\$'
  if match('^\$',line):
/Users/runner/micromamba/envs/forcebalance-test/lib/python3.11/site-packages/forcebalance/qchemio.py:57: DeprecationWarning: invalid escape sequence '\$'
  self.sec = sub('^\$','',line)
/Users/runner/micromamba/envs/forcebalance-test/lib/python3.11/site-packages/forcebalance/qchemio.py:62: DeprecationWarning: invalid escape sequence '\.'
  elif match('^[SPDFGH]P? +[0-9]+ +1\.0+$',line):
<unknown>:31: DeprecationWarning: invalid escape sequence '\.'
<unknown>:155: DeprecationWarning: invalid escape sequence '\.'
<unknown>:231: DeprecationWarning: invalid escape sequence '\s'
<unknown>:238: DeprecationWarning: invalid escape sequence '\s'
<unknown>:243: DeprecationWarning: invalid escape sequence '\s'
/Users/runner/micromamba/envs/forcebalance-test/lib/python3.11/site-packages/forcebalance/readfrq.py:31: DeprecationWarning: invalid escape sequence '\.'
  if re.match("^[0-9]+ +[0-9]+ +[0-9]+( +[-+]?([0-9]*\.)?[0-9]+){3}$", line):
/Users/runner/micromamba/envs/forcebalance-test/lib/python3.11/site-packages/forcebalance/readfrq.py:155: DeprecationWarning: invalid escape sequence '\.'
  if re.match("^[0-9]+ +[A-Z][A-Za-z]?( +[-+]?([0-9]*\.)?[0-9]+){3}$", line):
/Users/runner/micromamba/envs/forcebalance-test/lib/python3.11/site-packages/forcebalance/readfrq.py:231: DeprecationWarning: invalid escape sequence '\s'
  if re.match('^\s*[0-9]', line) and mode_num >= skip_modes:
/Users/runner/micromamba/envs/forcebalance-test/lib/python3.11/site-packages/forcebalance/readfrq.py:238: DeprecationWarning: invalid escape sequence '\s'
  elif re.match('^\s*[0-9]', line):
/Users/runner/micromamba/envs/forcebalance-test/lib/python3.11/site-packages/forcebalance/readfrq.py:243: DeprecationWarning: invalid escape sequence '\s'
  elif re.match('^[ \t\r\n\s]*$', line):
src/tests/test_tinkerio.py::TestInteraction_TINKER::test_get_agrad PASSED [100%]

=============================== warnings summary ===============================
src/parser.py:332
  /Users/runner/work/forcebalance/forcebalance/src/parser.py:332: DeprecationWarning: invalid escape sequence '\$'
    if re.match("(/read_mvals)|(^\$end)",line):

src/parser.py:340
  /Users/runner/work/forcebalance/forcebalance/src/parser.py:340: DeprecationWarning: invalid escape sequence '\$'
    if re.match("(/read_pvals)|(^\$end)",line):

src/parser.py:349
  /Users/runner/work/forcebalance/forcebalance/src/parser.py:349: DeprecationWarning: invalid escape sequence '\$'
    if re.match("(/priors)|(^\$end)",line):

src/parser.py:454
  /Users/runner/work/forcebalance/forcebalance/src/parser.py:454: DeprecationWarning: invalid escape sequence '\e'
    """ Parse through the input file and read all user-supplied options.

src/parser.py:501
  /Users/runner/work/forcebalance/forcebalance/src/parser.py:501: DeprecationWarning: invalid escape sequence '\$'
    if re.match('^\$',line):

src/parser.py:502
  /Users/runner/work/forcebalance/forcebalance/src/parser.py:502: DeprecationWarning: invalid escape sequence '\$'
    newsection = re.sub('^\$','',line).upper()

src/nifty.py:866
  /Users/runner/work/forcebalance/forcebalance/src/nifty.py:866: DeprecationWarning: 'import work_queue' is deprecated. Please instead use: 'import ndcctools.work_queue'
    import work_queue

src/forcefield.py:1500
  /Users/runner/work/forcebalance/forcebalance/src/forcefield.py:1500: DeprecationWarning: invalid escape sequence '\['
    matches = re.findall("\[['\"][^'\"]*['\"]\]", cmd)

src/forcefield.py:1502
  /Users/runner/work/forcebalance/forcebalance/src/forcefield.py:1502: DeprecationWarning: invalid escape sequence '\['
    src_param_name = re.sub("\[['\"]|['\"]\]", "", word)

src/optimizer.py:240
  /Users/runner/work/forcebalance/forcebalance/src/optimizer.py:240: DeprecationWarning: invalid escape sequence '\P'
    warn_press_key("mvals.txt in %s does not match loaded parameters.\nSave file : %s\Parameters : %s\n" % (T.absrd(), tmvals, self.mvals0))

src/output.py:59
  /Users/runner/work/forcebalance/forcebalance/src/output.py:59: DeprecationWarning: invalid escape sequence '\['
    message = re.sub("\x1b\[[0-9][0-9]?;?[0-9]?[0-9]?m", "", message)

src/output.py:68
  /Users/runner/work/forcebalance/forcebalance/src/output.py:68: DeprecationWarning: invalid escape sequence '\['
    message = re.sub("\x1b\[[0-9][0-9]?;?[0-9]?[0-9]?m", "", message)

src/tests/__init__.py:9
  /Users/runner/work/forcebalance/forcebalance/src/tests/__init__.py:9: DeprecationWarning: invalid escape sequence '\.'
    if re.match("^test_.*\.py$",module)]

src/tests/test_objective.py:26
  /Users/runner/work/forcebalance/forcebalance/src/tests/test_objective.py:26: DeprecationWarning: invalid escape sequence '\.'
    if re.compile(".*\.py$").match(module)

src/tests/test_smirnoff_hack.py::test_smirnoff_hack
  /Users/runner/micromamba/envs/forcebalance-test/lib/python3.11/site-packages/openff/interchange/smirnoff/_create.py:142: UserWarning: Automatically up-converting BondHandler from version 0.3 to 0.4. Consider manually upgrading this BondHandler (or <Bonds> section in an OFFXML file) to 0.4 or newer. For more details, see https://openforcefield.github.io/standards/standards/smirnoff/#bonds.
    _upconvert_bondhandler(force_field["Bonds"])

src/tests/test_system.py: 176 warnings
  /Users/runner/micromamba/envs/forcebalance-test/lib/python3.11/site-packages/forcebalance/optimizer.py:810: DeprecationWarning: scipy.optimize: The `disp` and `iprint` options of the L-BFGS-B solver are deprecated and will be removed in SciPy 1.18.0.
    Opt1 = optimize.fmin_l_bfgs_b(HYP.compute_val,dx0,fprime=HYP.compute_grad,m=30,factr=1e7,pgtol=1e-4,iprint=-1,disp=0,maxfun=1e5,maxiter=1e5)

src/tests/test_system.py: 176 warnings
  /Users/runner/micromamba/envs/forcebalance-test/lib/python3.11/site-packages/forcebalance/optimizer.py:816: DeprecationWarning: scipy.optimize: The `disp` and `iprint` options of the L-BFGS-B solver are deprecated and will be removed in SciPy 1.18.0.
    Opt2 = optimize.fmin_l_bfgs_b(HYP.compute_val,-xkd,fprime=HYP.compute_grad,m=30,factr=1e7,pgtol=1e-4,iprint=-1,disp=0,maxfun=1e5,maxiter=1e5)

```