### PR TITLE
Comment out env

### DIFF
--- a/src/data/run_psi_rdvr3_objective.sh
+++ b/src/data/run_psi_rdvr3_objective.sh
@@ -16,12 +16,12 @@ export PATH=/opt/python/2.7.2/bin:$PATH
 export LD_LIBRARY_PATH=/opt/python/2.7.2/lib:$LD_LIBRARY_PATH
 module load psi/tip.opt
 
-echo "#=======================#"
-echo "# ENVIRONMENT VARIABLES #"
-echo "#=======================#"
-echo
+# echo "#=======================#"
+# echo "# ENVIRONMENT VARIABLES #"
+# echo "#=======================#"
+# echo
 
-env
+# env
 
 echo
 echo "#=======================#"

--- a/src/data/runamber.sh
+++ b/src/data/runamber.sh
@@ -35,12 +35,12 @@ export BAK=$HOME/temp/rungmx-backups
 # Disable GROMACS backup files
 export GMX_MAXBACKUP=-1
 
-echo "#=======================#"
-echo "# ENVIRONMENT VARIABLES #"
-echo "#=======================#"
-echo
+# echo "#=======================#"
+# echo "# ENVIRONMENT VARIABLES #"
+# echo "#=======================#"
+# echo
 
-env
+# env
 
 echo
 echo "#=======================#"

--- a/src/data/runcuda.sh
+++ b/src/data/runcuda.sh
@@ -121,12 +121,12 @@ elif [[ x$PBS_JOBID != x ]] ; then
     sleep $(( PBS_JOBID * 10 ))
 fi
 
-echo "#=======================#"
-echo "# ENVIRONMENT VARIABLES #"
-echo "#=======================#"
-echo
+# echo "#=======================#"
+# echo "# ENVIRONMENT VARIABLES #"
+# echo "#=======================#"
+# echo
 
-env
+# env
 
 echo
 echo "#=======================#"

--- a/src/data/rungmx.sh
+++ b/src/data/rungmx.sh
@@ -37,12 +37,12 @@ export BAK=$HOME/temp/rungmx-backups
 # Disable GROMACS backup files
 export GMX_MAXBACKUP=-1
 
-echo "#=======================#"
-echo "# ENVIRONMENT VARIABLES #"
-echo "#=======================#"
-echo
+# echo "#=======================#"
+# echo "# ENVIRONMENT VARIABLES #"
+# echo "#=======================#"
+# echo
 
-env
+# env
 
 echo
 echo "#=======================#"

--- a/src/data/runtinker.sh
+++ b/src/data/runtinker.sh
@@ -32,12 +32,12 @@ fi
 # Backup folder
 export BAK=$HOME/temp/runtinker-backups
 
-echo "#=======================#"
-echo "# ENVIRONMENT VARIABLES #"
-echo "#=======================#"
-echo
+# echo "#=======================#"
+# echo "# ENVIRONMENT VARIABLES #"
+# echo "#=======================#"
+# echo
 
-env
+# env
 
 echo
 echo "#=======================#"

--- a/src/tests/files/targets/dms-liquid/runcuda.sh
+++ b/src/tests/files/targets/dms-liquid/runcuda.sh
@@ -71,12 +71,12 @@ elif [[ $ARCHIVER == "ranch.tacc.utexas.edu" ]] ; then
     # export BAK=$SCRATCH/runcuda-backups
 fi
 
-echo "#=======================#"
-echo "# ENVIRONMENT VARIABLES #"
-echo "#=======================#"
-echo
+# echo "#=======================#"
+# echo "# ENVIRONMENT VARIABLES #"
+# echo "#=======================#"
+# echo
 
-set
+# set
 
 echo
 echo "#=======================#"


### PR DESCRIPTION
Fixes #318 by commenting out everything that appears to print out the entire environment (`env` or `set`) without discernment (i.e. no grepping). 